### PR TITLE
fix(site): Add missing locale text

### DIFF
--- a/.dumi/theme/locales/en-US.json
+++ b/.dumi/theme/locales/en-US.json
@@ -14,5 +14,11 @@
   "app.docs.components.icon.outlined": "Outlined",
   "app.docs.components.icon.filled": "Filled",
   "app.docs.components.icon.two-tone": "Two Tone",
-  "app.components.overview.search": "Search in components"
+  "app.components.overview.search": "Search in components",
+  "app.docs.components.icon.category.direction": "Directional Icons",
+  "app.docs.components.icon.category.suggestion": "Suggested Icons",
+  "app.docs.components.icon.category.editor": "Editor Icons",
+  "app.docs.components.icon.category.data": "Data Icons",
+  "app.docs.components.icon.category.other": "Application Icons",
+  "app.docs.components.icon.category.logo": "Brand and Logos"
 }

--- a/.dumi/theme/locales/zh-CN.json
+++ b/.dumi/theme/locales/zh-CN.json
@@ -14,5 +14,11 @@
   "app.docs.components.icon.outlined": "线框风格",
   "app.docs.components.icon.filled": "实底风格",
   "app.docs.components.icon.two-tone": "双色风格",
-  "app.components.overview.search": "搜索组件"
+  "app.components.overview.search": "搜索组件",
+  "app.docs.components.icon.category.direction": "方向性图标",
+  "app.docs.components.icon.category.suggestion": "提示建议性图标",
+  "app.docs.components.icon.category.editor": "编辑类图标",
+  "app.docs.components.icon.category.data": "数据类图标",
+  "app.docs.components.icon.category.other": "网站通用图标",
+  "app.docs.components.icon.category.logo": "品牌和标识"
 }

--- a/scripts/remove-useless-locale.ts
+++ b/scripts/remove-useless-locale.ts
@@ -18,18 +18,30 @@ const localeList = [
   },
 ];
 
+// keys not to check
+const excludeKeys = [
+  'app.docs.components.icon.category.direction',
+  'app.docs.components.icon.category.suggestion',
+  'app.docs.components.icon.category.editor',
+  'app.docs.components.icon.category.data',
+  'app.docs.components.icon.category.other',
+  'app.docs.components.icon.category.logo',
+];
+
 async function execute() {
   for (const localeItem of localeList) {
     const localeData = JSON.parse(fs.readFileSync(localeItem.path));
     for (const key in localeData) {
       const text = localeData[key];
-      try {
-        await runScript(`grep -qr ${key} .dumi --exclude-dir=locales --exclude-dir=tmp`);
-      } catch (err) {
-        // If no result macthes, should throw `RunScriptError`
-        if (err.name === 'RunScriptError') {
-          delete localeData[key];
-          fs.appendFileSync(filePath, `${key}: ${text}\n`);
+      if (!excludeKeys.includes(key)) {
+        try {
+          await runScript(`grep -qr ${key} .dumi --exclude-dir=locales --exclude-dir=tmp`);
+        } catch (err) {
+          // If no result macthes, should throw `RunScriptError`
+          if (err.name === 'RunScriptError') {
+            delete localeData[key];
+            fs.appendFileSync(filePath, `${key}: ${text}\n`);
+          }
         }
       }
     }


### PR DESCRIPTION
- `scripts/remove-useless-locale.ts` excludes some keys as below:
    - app.docs.components.icon.category.direction
    - app.docs.components.icon.category.suggestion
    - app.docs.components.icon.category.editor
    - app.docs.components.icon.category.data
    - app.docs.components.icon.category.other
    - app.docs.components.icon.category.logo