### PR TITLE
improve(workflow): dependabot ignore @antv/g6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "@antv/g6"


### PR DESCRIPTION
- `@antv/g6` should fix version to `3.4.10` for now.