### PR TITLE
fix(ui): should not use hooks in styleFn of genComponentStyleHook

### DIFF
--- a/packages/ui/src/_util/genComponentStyleHook.ts
+++ b/packages/ui/src/_util/genComponentStyleHook.ts
@@ -19,10 +19,11 @@ export interface OBToken extends ProAliasToken {
 
 export function genComponentStyleHook(componentName: string, styleFn: GenerateStyle<OBToken>) {
   return (prefixCls: string) => {
+    const { getPrefixCls, iconPrefixCls } = React.useContext(ConfigProvider.ConfigContext);
+    const rootPrefixCls = getPrefixCls();
+    const componentCls = `.${prefixCls}`;
+
     return useStyle(componentName, token => {
-      const { getPrefixCls, iconPrefixCls } = React.useContext(ConfigProvider.ConfigContext);
-      const rootPrefixCls = getPrefixCls();
-      const componentCls = `.${prefixCls}`;
       const mergedToken: OBToken = {
         ...token,
         componentCls,


### PR DESCRIPTION
![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/510ebbf0-f35f-4ed9-8c52-04bdedfd328d)
