### PR TITLE
feat(ui): custom useHistory support for react-router-dom v5

### DIFF
--- a/packages/ui/src/_util/useHistory.ts
+++ b/packages/ui/src/_util/useHistory.ts
@@ -6,10 +6,16 @@ import {
   // @ts-ignore
   useNavigate,
 } from 'react-router-dom';
+import { directTo } from '@oceanbase/util';
 
 export default () => {
   return {
-    // push: useHistory ? useHistory().push : useNavigate ? useNavigate() : null,
-    push: useNavigate ? useNavigate() : null,
+    push: useHistory
+      ? useHistory().push
+      : useNavigate
+      ? useNavigate()
+      : (path: string) => {
+          directTo(path, false);
+        },
   };
 };


### PR DESCRIPTION
- react-router-dom v5: `useHistory`
- react-router-dom v6: `useNavigate`
- by default without react-router-dom: `directTo`