### PR TITLE
refact(ui): Remove react-router-dom and inject navigate by ConfigProvider

### DIFF
--- a/.fatherrc.base.ts
+++ b/.fatherrc.base.ts
@@ -17,7 +17,6 @@ export default defineConfig({
     externals: {
       react: 'React',
       'react-dom': 'ReactDOM',
-      'react-router-dom': 'ReactRouterDOM',
     },
   },
 });

--- a/packages/design/src/config-provider/index.tsx
+++ b/packages/design/src/config-provider/index.tsx
@@ -7,9 +7,9 @@ import type {
 import StaticFunction from '../static-function';
 import defaultTheme from '../theme';
 import defaultThemeToken from '../theme/default';
+import type { NavigateFunction } from './navigate';
 
-const { defaultSeed, components } = defaultTheme;
-
+export * from './navigate';
 export * from 'antd/es/config-provider';
 
 export interface ThemeConfig extends AntThemeConfig {
@@ -18,11 +18,25 @@ export interface ThemeConfig extends AntThemeConfig {
 
 export interface ConfigProviderProps extends AntConfigProviderProps {
   theme?: ThemeConfig;
+  // set global route navigate function
+  // for react-router-dom v5: history.push
+  // for react-router-dom v6: navigate
+  navigate?: NavigateFunction;
 }
+
+export interface ExtendedConfigConsumerProps {
+  navigate?: NavigateFunction;
+}
+
+const ExtendedConfigContext = React.createContext<ExtendedConfigConsumerProps>({
+  navigate: undefined,
+});
+
+const { defaultSeed, components } = defaultTheme;
 
 // ConfigProvider 默认设置主题和内嵌 App，支持 message, notification 和 Modal 等静态方法消费 ConfigProvider 配置
 // ref: https://ant.design/components/app-cn
-const ConfigProvider = ({ children, theme, ...restProps }: ConfigProviderProps) => {
+const ConfigProvider = ({ children, theme, navigate, ...restProps }: ConfigProviderProps) => {
   return (
     <AntConfigProvider
       theme={{
@@ -50,15 +64,22 @@ const ConfigProvider = ({ children, theme, ...restProps }: ConfigProviderProps) 
       }}
       {...restProps}
     >
-      <App>
-        {children}
-        <StaticFunction />
-      </App>
+      <ExtendedConfigContext.Provider
+        value={{
+          navigate,
+        }}
+      >
+        <App>
+          {children}
+          <StaticFunction />
+        </App>
+      </ExtendedConfigContext.Provider>
     </AntConfigProvider>
   );
 };
 
 ConfigProvider.ConfigContext = AntConfigProvider.ConfigContext;
+ConfigProvider.ExtendedConfigContext = ExtendedConfigContext;
 ConfigProvider.SizeContext = AntConfigProvider.SizeContext;
 ConfigProvider.config = AntConfigProvider.config;
 ConfigProvider.useConfig = AntConfigProvider.useConfig;

--- a/packages/design/src/config-provider/navigate.ts
+++ b/packages/design/src/config-provider/navigate.ts
@@ -1,0 +1,37 @@
+export interface Path {
+  /**
+   * A URL pathname, beginning with a /.
+   */
+  pathname: string;
+
+  /**
+   * A URL search string, beginning with a ?.
+   */
+  search: string;
+
+  /**
+   * Compatibale with history.push param for react-router-dom v5
+   */
+  query: Record<string, string>;
+
+  /**
+   * A URL fragment identifier, beginning with a #.
+   */
+  hash: string;
+}
+
+export type To = string | Partial<Path>;
+
+export type RelativeRoutingType = 'route' | 'path';
+
+export interface NavigateOptions {
+  replace?: boolean;
+  state?: any;
+  preventScrollReset?: boolean;
+  relative?: RelativeRoutingType;
+}
+
+export interface NavigateFunction {
+  (to: To, options?: NavigateOptions): void;
+  (delta: number): void;
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -64,7 +64,6 @@
   "peerDependencies": {
     "@antv/g6": "3.4.10",
     "react": "^16.9.0",
-    "react-dom": "^16.9.0",
-    "react-router-dom": ">=5.2.0"
+    "react-dom": "^16.9.0"
   }
 }

--- a/packages/ui/src/BasicLayout/Header.tsx
+++ b/packages/ui/src/BasicLayout/Header.tsx
@@ -14,7 +14,7 @@ import type { Locale } from '../interface';
 import type { LocaleWrapperProps } from '../locale/LocaleWrapper';
 import LocaleWrapper from '../locale/LocaleWrapper';
 import { directTo, getPrefix } from '../_util';
-import useHistory from '../_util/useHistory';
+import useNavigate from '../_util/useNavigate';
 import zhCN from './locale/zh-CN';
 // @ts-ignore
 import logoImg from '../assets/logo/oceanbase_logo.svg';
@@ -100,7 +100,7 @@ const Header: React.FC<HeaderProps> = ({
   langs,
   ...restProps
 }) => {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [visible, setVisible] = useState(false);
   // 是否为欢迎页
   // 主要是为了处理与欢迎页搭配使用的场景
@@ -110,7 +110,7 @@ const Header: React.FC<HeaderProps> = ({
     <Menu
       onClick={({ key }) => {
         if (key === 'welcome') {
-          history.push(welcomePath);
+          navigate?.(welcomePath);
         } else if (key === 'viewDocs') {
           directTo(docsPath);
         } else if (key === 'downloadDocs') {
@@ -144,7 +144,7 @@ const Header: React.FC<HeaderProps> = ({
           src={simpleLogoUrl}
           alt=""
           onClick={() => {
-            history.push('/');
+            navigate?.('/');
           }}
           className={`${prefix}-logo`}
         />

--- a/packages/ui/src/BasicLayout/index.md
+++ b/packages/ui/src/BasicLayout/index.md
@@ -21,6 +21,49 @@ nav:
 
 <code src="./demo/welcome.tsx" title="和欢迎页搭配使用"></code>
 
+## 与路由搭配使用
+
+由于 BasicLayout 左侧和顶部导航的跳转依赖路由能力，需要通过 ConfigProvider 全局注入 `navigate` 函数才会生效。
+
+- 对于 `react-router-dom v6` 或 `umi3`:
+
+```tsx | pure
+import { ConfigProvider } from '@oceanbase/design';
+import { BasicLayout } from '@oceanbase/ui';
+// for react-router-dom v6
+import { useNavigate } from 'react-router-dom';
+// for umi v4
+// import { useNavigate } from 'umi';
+
+const App = () => {
+  return (
+    <ConfigProvider navigate={useNavigate()}>
+      <BasicLayout />
+    </ConfigProvider>
+  );
+};
+```
+
+- 对于 `react-router-dom v5` 或 `umi4`:
+
+```tsx | pure
+import { ConfigProvider } from '@oceanbase/design';
+import { BasicLayout } from '@oceanbase/ui';
+// for react-router-dom v5
+import { useHistory } from 'react-router-dom';
+// for umi v3
+// import { useHistory } from 'umi';
+
+const App = () => {
+  const history = useHistory();
+  return (
+    <ConfigProvider navigate={history.push}>
+      <BasicLayout />
+    </ConfigProvider>
+  );
+};
+```
+
 ## API
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |

--- a/packages/ui/src/BasicLayout/index.tsx
+++ b/packages/ui/src/BasicLayout/index.tsx
@@ -12,7 +12,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import type { LocaleWrapperProps } from '../locale/LocaleWrapper';
 import LocaleWrapper from '../locale/LocaleWrapper';
 import { getPrefix, isEnglish, urlToList } from '../_util';
-import useHistory from '../_util/useHistory';
+import useNavigate from '../_util/useNavigate';
 import type { HeaderProps } from './Header';
 import Header from './Header';
 import zhCN from './locale/zh-CN';
@@ -100,7 +100,7 @@ const BasicLayout: React.FC<BasicLayoutProps> = ({
   const { wrapSSR, hashId } = useStyle(prefixCls);
   const basicLayoutCls = classNames(className, hashId);
 
-  const history = useHistory();
+  const navigate = useNavigate();
   // 侧边栏导航是否收起
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
   const [selectedKeys, setSelectedKeys] = useState(defaultSelectedKeys);
@@ -206,7 +206,7 @@ const BasicLayout: React.FC<BasicLayoutProps> = ({
             key={item.link}
             onClick={() => {
               if (pathname !== item.link) {
-                history.push(item.link);
+                navigate?.(item.link);
               }
             }}
           >
@@ -271,7 +271,7 @@ const BasicLayout: React.FC<BasicLayoutProps> = ({
             key={item.link}
             onClick={() => {
               if (pathname !== item.link) {
-                history.push(item.link);
+                navigate?.(item.link);
               }
             }}
           >

--- a/packages/ui/src/DocDialog/index.tsx
+++ b/packages/ui/src/DocDialog/index.tsx
@@ -1,6 +1,5 @@
 import { debounce } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import type { IDialogProps } from '../Dialog';
 import Dialog from '../Dialog';
 import type { LocaleWrapperProps } from '../locale/LocaleWrapper';
@@ -52,7 +51,7 @@ const DocDialogComp = (props: IDocDialogProps) => {
   } = props;
   const [clientHeight, setClientHeight] = useState(document.body.clientHeight);
   const [clientWidth, setClientWidth] = useState(document.body.clientWidth);
-  const location = useLocation();
+  const location = window.location;
 
   const currentLink = useMemo(() => {
     const { pathname } = location;

--- a/packages/ui/src/NavMenu/index.tsx
+++ b/packages/ui/src/NavMenu/index.tsx
@@ -2,7 +2,6 @@ import { Menu } from '@oceanbase/design';
 import { isArray } from 'lodash';
 import { pathToRegexp } from 'path-to-regexp';
 import React, { useCallback, useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import { getPrefix } from '../_util';
 import useHistory from '../_util/useHistory';
 import './index.less';
@@ -30,7 +29,7 @@ export default (props: MenuProps) => {
   const { menuList, className, style } = props;
   const [selectedKeys, setSelectedKeys] = useState(['0']);
   const [menus, setMenus] = useState([]);
-  const location = useLocation();
+  const location = window.location;
 
   const history = useHistory();
 

--- a/packages/ui/src/NavMenu/index.tsx
+++ b/packages/ui/src/NavMenu/index.tsx
@@ -3,7 +3,7 @@ import { isArray } from 'lodash';
 import { pathToRegexp } from 'path-to-regexp';
 import React, { useCallback, useEffect, useState } from 'react';
 import { getPrefix } from '../_util';
-import useHistory from '../_util/useHistory';
+import useNavigate from '../_util/useNavigate';
 import './index.less';
 
 const prefix = getPrefix('menu');
@@ -31,7 +31,7 @@ export default (props: MenuProps) => {
   const [menus, setMenus] = useState([]);
   const location = window.location;
 
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const preProcess = useCallback(
     list => {
@@ -78,9 +78,9 @@ export default (props: MenuProps) => {
   const onMenuClick = useCallback(
     link => {
       const linkList = isArray(link) ? link : [link];
-      history.push(linkList[0]);
+      navigate?.(linkList[0]);
     },
-    [history]
+    [navigate]
   );
 
   return (

--- a/packages/ui/src/PageContainer/ItemRender.tsx
+++ b/packages/ui/src/PageContainer/ItemRender.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import useHistory from '../_util/useHistory';
+import useNavigate from '../_util/useNavigate';
 
 export default ({ route, params, routes, paths }) => {
   const routeIndex = routes.indexOf(route);
@@ -14,14 +14,14 @@ export default ({ route, params, routes, paths }) => {
       .map(item => item.path)
       .join('/');
 
-  const history = useHistory();
+  const navigate = useNavigate();
 
   return last ? (
     <span>{title}</span>
   ) : (
     <a
       onClick={() => {
-        history.push(path);
+        navigate?.(path);
       }}
     >
       {title}

--- a/packages/ui/src/PageContainer/index.md
+++ b/packages/ui/src/PageContainer/index.md
@@ -20,6 +20,49 @@ nav:
 
 <code src="./demo/empty.tsx" title="空页面"></code>
 
+## 与路由搭配使用
+
+由于 PageContainer 内置的面包屑导航跳转依赖路由能力，需要通过 ConfigProvider 全局注入 `navigate` 函数才会生效。
+
+- 对于 `react-router-dom v6` 或 `umi4`:
+
+```tsx | pure
+import { ConfigProvider } from '@oceanbase/design';
+import { PageContainer } from '@oceanbase/ui';
+// for react-router-dom v6
+import { useNavigate } from 'react-router-dom';
+// for umi v4
+// import { useNavigate } from 'umi';
+
+const App = () => {
+  return (
+    <ConfigProvider navigate={useNavigate()}>
+      <PageContainer />
+    </ConfigProvider>
+  );
+};
+```
+
+- 对于 `react-router-dom v5` 或 `umi3`:
+
+```tsx | pure
+import { ConfigProvider } from '@oceanbase/design';
+import { PageContainer } from '@oceanbase/ui';
+// for react-router-dom v5
+import { useHistory } from 'react-router-dom';
+// for umi v3
+// import { useHistory } from 'umi';
+
+const App = () => {
+  const history = useHistory();
+  return (
+    <ConfigProvider navigate={history.push}>
+      <PageContainer />
+    </ConfigProvider>
+  );
+};
+```
+
 ## API
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |

--- a/packages/ui/src/_util/useHistory.ts
+++ b/packages/ui/src/_util/useHistory.ts
@@ -1,21 +1,9 @@
-import {
-  // react-router-dom v5
-  // @ts-ignore
-  useHistory,
-  // react-router-dom v6
-  // @ts-ignore
-  useNavigate,
-} from 'react-router-dom';
 import { directTo } from '@oceanbase/util';
 
 export default () => {
   return {
-    push: useHistory
-      ? useHistory().push
-      : useNavigate
-      ? useNavigate()
-      : (path: string) => {
-          directTo(path, false);
-        },
+    push: (path: string) => {
+      directTo(path, false);
+    },
   };
 };

--- a/packages/ui/src/_util/useHistory.ts
+++ b/packages/ui/src/_util/useHistory.ts
@@ -1,9 +1,0 @@
-import { directTo } from '@oceanbase/util';
-
-export default () => {
-  return {
-    push: (path: string) => {
-      directTo(path, false);
-    },
-  };
-};

--- a/packages/ui/src/_util/useNavigate.ts
+++ b/packages/ui/src/_util/useNavigate.ts
@@ -1,0 +1,7 @@
+import React, { useContext } from 'react';
+import { ConfigProvider } from '@oceanbase/design';
+
+export default () => {
+  const { navigate } = useContext(ConfigProvider.ExtendedConfigContext);
+  return navigate;
+};

--- a/packages/util/src/hooks/useQuery.ts
+++ b/packages/util/src/hooks/useQuery.ts
@@ -59,6 +59,7 @@ const format2Search = (value: any, parameter: QueryParameter) => {
  * @returns
  */
 export const useQuery = <T extends SearchValues>(
+  // TODO: history 仅使用 react-router-dom v5，后续需要改造适配 react-router-dom v6
   history: any,
   queryParameters: (QueryParameter | string)[]
 ) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,9 +376,6 @@ importers:
       react-json-view:
         specifier: ^1.21.3
         version: 1.21.3(@types/react@18.2.17)(react-dom@16.14.0)(react@16.14.0)
-      react-router-dom:
-        specifier: '>=5.2.0'
-        version: 6.14.2(react-dom@16.14.0)(react@16.14.0)
       react-split-pane:
         specifier: ^0.1.92
         version: 0.1.92(react-dom@16.14.0)(react@16.14.0)
@@ -5173,11 +5170,6 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@remix-run/router@1.7.2:
-    resolution: {integrity: sha512-7Lcn7IqGMV+vizMPoEl5F0XDshcdDYtMI6uJLQdQz5CfZAwy3vvGKYSUk789qndt5dEC4HfSjviSYlSoHGL2+A==}
-    engines: {node: '>=14'}
-    dev: false
-
   /@rgrove/parse-xml@2.0.4:
     resolution: {integrity: sha512-344bRXnUMu1tWqq1GJO2nCSqJRGTzcNLErcG2HZbVhUo90R5xQ6YdsCqtuT0KaFyN/mlxWqt2SdHSRNzwDvT5g==}
     engines: {node: '>=6.0.0'}
@@ -8100,7 +8092,7 @@ packages:
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.22.9)
       lodash: 4.17.21
       picomatch: 2.3.1
-      styled-components: 5.3.11(@babel/core@7.22.9)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+      styled-components: 5.3.11(@babel/core@7.22.9)(react-dom@16.14.0)(react-is@18.2.0)(react@16.14.0)
     transitivePeerDependencies:
       - '@babel/core'
     dev: true
@@ -20221,19 +20213,6 @@ packages:
       react-dom: 16.14.0(react@16.14.0)
     dev: false
 
-  /react-router-dom@6.14.2(react-dom@16.14.0)(react@16.14.0):
-    resolution: {integrity: sha512-5pWX0jdKR48XFZBuJqHosX3AAHjRAzygouMTyimnBPOLdY3WjzUSKhus2FVMihUFWzeLebDgr4r8UeQFAct7Bg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.7.2
-      react: 16.14.0
-      react-dom: 16.14.0(react@16.14.0)
-      react-router: 6.14.2(react@16.14.0)
-    dev: false
-
   /react-router-dom@6.3.0(react-dom@18.1.0)(react@18.1.0):
     resolution: {integrity: sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==}
     peerDependencies:
@@ -20257,16 +20236,6 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       react-router: 6.3.0(react@18.2.0)
     dev: true
-
-  /react-router@6.14.2(react@16.14.0):
-    resolution: {integrity: sha512-09Zss2dE2z+T1D03IheqAFtK4UzQyX8nFPWx6jkwdYzGLXd5ie06A6ezS2fO6zJfEb/SpG6UocN2O1hfD+2urQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      react: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.7.2
-      react: 16.14.0
-    dev: false
 
   /react-router@6.3.0(react@18.1.0):
     resolution: {integrity: sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==}


### PR DESCRIPTION
## Background

`react-router-dom` should not be `deps` for component library. Use `navigate` in ConfigProvider as replace.

## Related Components
- [x] `BasicLayout`
- [x] `PageContainer`
- [x] `NavMenu`

## Usage

![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/ac75115b-9e85-4ff9-99ba-4ad01fa96ab0)
