### PR TITLE
fix(site): sidebar background should be correct in dark mode

### DIFF
--- a/.dumi/theme/slots/Sidebar/index.tsx
+++ b/.dumi/theme/slots/Sidebar/index.tsx
@@ -130,13 +130,20 @@ const Sidebar: React.FC = () => {
   const [menuItems, selectedKey] = useMenu();
   const isDark = theme.includes('dark');
   const {
-    token: { colorBgContainer, colorFillSecondary },
+    token: { colorBgContainer, colorBgTextHover },
   } = useSiteToken();
 
   const menuChild = (
     <ConfigProvider
       theme={{
-        components: { Menu: { itemBg: colorBgContainer, itemHoverBg: colorFillSecondary } },
+        components: {
+          Menu: {
+            itemBg: colorBgContainer,
+            itemHoverBg: colorBgTextHover,
+            darkItemBg: colorBgContainer,
+            darkItemHoverBg: colorBgTextHover,
+          },
+        },
       }}
     >
       <Menu


### PR DESCRIPTION
| Previous | After |
| --- | --- |
| ![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/f66bd222-da9f-4e8d-a6a2-1ae679cf760f)  |    ![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/428a508c-e08d-468d-8e1e-51645740b03a) |