### PR TITLE
improve(design): Icon and close icon should vertical align to flex-start

### DIFF
--- a/packages/design/src/alert/demo/action.tsx
+++ b/packages/design/src/alert/demo/action.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 
 const App: React.FC = () => (
   <Space direction="vertical" style={{ width: '100%' }}>
-    <Alert message="Success Tips" type="success" showIcon action={<a>查看详情</a>} />
-    <Alert message="Informational Notes" type="info" showIcon action={<a>查看详情</a>} />
-    <Alert message="Warning" type="warning" showIcon action={<a>查看详情</a>} />
-    <Alert message="Error" type="error" showIcon action={<a>查看详情</a>} />
+    <Alert message="Success Tips" type="success" showIcon action={<a>Detail</a>} />
+    <Alert message="Informational Notes" type="info" showIcon action={<a>Detail</a>} />
+    <Alert message="Warning" type="warning" showIcon action={<a>Detail</a>} />
+    <Alert message="Error" type="error" showIcon action={<a>Detail</a>} />
     <Alert
       message="Success Tips"
       description="Detailed description and advice about successful copywriting."

--- a/packages/design/src/alert/demo/over-length.tsx
+++ b/packages/design/src/alert/demo/over-length.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Alert, Button, Space } from '@oceanbase/design';
+
+const onClose = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  console.log(e, 'I was closed.');
+};
+
+const App: React.FC = () => (
+  <Space direction="vertical" style={{ width: '100%' }}>
+    <Alert
+      message="Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips."
+      type="success"
+      showIcon
+      closable
+      onClose={onClose}
+    />
+    <Alert
+      message="Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips."
+      type="success"
+      showIcon
+      closable
+      closeIcon={<span>Close</span>}
+    />
+    <Alert
+      message="Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips."
+      type="success"
+      showIcon
+      action={<a>Detail</a>}
+    />
+    <Alert
+      message="Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips."
+      description="Detailed description and advice about successful copywriting. Detailed description and advice about successful copywriting. Detailed description and advice about successful copywriting. Detailed description and advice about successful copywriting. Detailed description and advice about successful copywriting."
+      type="success"
+      showIcon
+      closable
+      onClose={onClose}
+    />
+    <Alert
+      message="Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips. Success Tips."
+      description="Detailed description and advice about successful copywriting. Detailed description and advice about successful copywriting. Detailed description and advice about successful copywriting. Detailed description and advice about successful copywriting. Detailed description and advice about successful copywriting."
+      type="success"
+      showIcon
+      action={
+        <Button type="primary" size="small">
+          Detail
+        </Button>
+      }
+    />
+  </Space>
+);
+
+export default App;

--- a/packages/design/src/alert/index.md
+++ b/packages/design/src/alert/index.md
@@ -12,18 +12,14 @@ nav:
 
 ## 代码演示
 
+<!-- prettier-ignore -->
 <code src="./demo/style.tsx" title="四种样式" description="共有四种样式 `success`、`info`、`warning`、`error`。"></code>
-
 <code src="./demo/closable.tsx" title="可关闭的警告提示" description="显示关闭按钮，点击可关闭警告提示。"></code>
-
 <code src="./demo/action.tsx" title="操作" description="可以在右上角自定义操作项。"></code>
-
+<code src="./demo/over-length.tsx" title="超长内容"></code>
 <code src="./demo/ghost-and-colored.tsx" title="透明背景和全局着色"></code>
-
 <code src="./demo/banner.tsx" iframe="250" title="顶部公告" description="页面顶部通告形式，默认有图标且 `type` 为 'warning'。"></code>
-
 <code src="./demo/loop-banner.tsx" title="轮播的公告" description="配合 [react-text-loop-next](https://npmjs.com/package/react-text-loop-next) 或 [react-fast-marquee](https://npmjs.com/package/react-fast-marquee) 实现消息轮播通知栏。"></code>
-
 <code src="./demo/error-boundary.tsx" title="React 错误处理" description="友好的 [React 错误处理](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html) 包裹组件。
 "></code>
 

--- a/packages/design/src/alert/style/index.ts
+++ b/packages/design/src/alert/style/index.ts
@@ -59,8 +59,28 @@ export const genAlertStyle: GenerateStyle<AlertToken> = (token: AlertToken): CSS
     colorWarningHover,
     colorError,
     colorErrorHover,
+    colorIcon,
+    colorIconHover,
+    motionDurationMid,
   } = token;
+  // height = fontSize * lineHeight
+  const height = token.fontSize * token.lineHeight;
   return {
+    [`${componentCls}`]: {
+      // vertical align to flex-start
+      alignItems: 'flex-start',
+      [`${componentCls}-icon`]: {
+        height,
+      },
+      [`${componentCls}-close-icon`]: {
+        height,
+        color: colorIcon,
+        transition: `color ${motionDurationMid}`,
+        '&:hover': {
+          color: colorIconHover,
+        },
+      },
+    },
     [`${componentCls}${componentCls}-with-description`]: {
       paddingBlock: token.padding,
       [`${componentCls}-message`]: {


### PR DESCRIPTION
## Alert without message

- when `message` is over length, icon and close icon should vertical align to `flex-start`:

| Previous | After |
| --- | --- |
|  ![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/82916d98-dd83-4977-b42d-92cff06cd991) |  ![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/93449a72-0533-40e8-8f34-9ae68261044a) |
|  ![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/79c49939-e6d6-409a-b1cd-d00a51601faa) |  ![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/f12a05d5-dca6-4f44-a0ed-2b3af0b5c61a)  |

