### PR TITLE
feat(charts): Add Score component

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -227,6 +227,10 @@ export default defineConfig({
               title: 'Tiny 迷你图',
               link: '/charts/tiny',
             },
+            {
+              title: 'Score 得分图',
+              link: '/charts/score',
+            },
           ],
         },
       ],

--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -188,6 +188,10 @@ export default defineConfig({
               link: '/charts/stat',
             },
             {
+              title: 'Score 得分图',
+              link: '/charts/score',
+            },
+            {
               title: 'Line 折线图',
               link: '/charts/line',
             },
@@ -226,10 +230,6 @@ export default defineConfig({
             {
               title: 'Tiny 迷你图',
               link: '/charts/tiny',
-            },
-            {
-              title: 'Score 得分图',
-              link: '/charts/score',
             },
           ],
         },

--- a/packages/charts/src/Score/demo/basic.tsx
+++ b/packages/charts/src/Score/demo/basic.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { Score } from '@oceanbase/charts';
+import { Col, Row, Form, Radio } from '@oceanbase/design';
+
+export default () => {
+  const [size, setSize] = useState('large');
+
+  return (
+    <div>
+      <Form
+        layout="horizontal"
+        style={{ marginBottom: '30px' }}
+      >
+        <Row gutter={8}>
+          <Col span={12}>
+            <Form.Item label="Size">
+              <Radio.Group value={size} onChange={e => setSize(e.target.value)}>
+                <Radio.Button value='large'>Large</Radio.Button>
+                <Radio.Button value='middle'>Default</Radio.Button>
+                <Radio.Button value='small'>Small</Radio.Button>
+              </Radio.Group>
+            </Form.Item>
+          </Col>
+        </Row>
+      </Form>
+      <Row>
+        <Col span={6}>
+          <Score
+            size={size}
+            value={50}
+          />
+        </Col>
+        <Col span={6} >
+          <Score
+            size={size}
+            value={60}
+          />
+        </Col>
+        <Col span={6} >
+          <Score
+            size={size}
+            value={70}
+          />
+        </Col>
+        <Col span={6} >
+          <Score
+            size={size}
+            value={85}
+          />
+        </Col>
+      </Row>
+    </div>
+  );
+};

--- a/packages/charts/src/Score/demo/basic.tsx
+++ b/packages/charts/src/Score/demo/basic.tsx
@@ -3,25 +3,21 @@ import { Score } from '@oceanbase/charts';
 import { Col, Row, Form, Radio } from '@oceanbase/design';
 
 export default () => {
-  const [size, setSize] = useState('large');
+  const [size, setSize] = useState('middle');
 
   return (
     <div>
       <Form
-        layout="horizontal"
         style={{ marginBottom: '30px' }}
       >
-        <Row gutter={8}>
-          <Col span={12}>
-            <Form.Item label="Size">
-              <Radio.Group value={size} onChange={e => setSize(e.target.value)}>
-                <Radio.Button value='large'>Large</Radio.Button>
-                <Radio.Button value='middle'>Default</Radio.Button>
-                <Radio.Button value='small'>Small</Radio.Button>
-              </Radio.Group>
-            </Form.Item>
-          </Col>
-        </Row>
+        <Form.Item label="Size">
+          <Radio.Group value={size} onChange={e => setSize(e.target.value)}>
+            <Radio.Button value='large'>Large</Radio.Button>
+            <Radio.Button value='middle'>Default</Radio.Button>
+            <Radio.Button value='small'>Small</Radio.Button>
+            <Radio.Button value={300}>300px</Radio.Button>
+          </Radio.Group>
+        </Form.Item>
       </Form>
       <Row>
         <Col span={6}>

--- a/packages/charts/src/Score/demo/custom.tsx
+++ b/packages/charts/src/Score/demo/custom.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Score } from '@oceanbase/charts';
+
+export default () => {
+  return (
+    <Score
+      size={300}
+      value={100}
+      color="#A084E8"
+      unit={false}
+      valueStyle={{ color: '#D0BFFF' }}
+    />
+  );
+};

--- a/packages/charts/src/Score/demo/customColor.tsx
+++ b/packages/charts/src/Score/demo/customColor.tsx
@@ -4,10 +4,9 @@ import { Score } from '@oceanbase/charts';
 export default () => {
   return (
     <Score
-      size={300}
       value={100}
       color="#A084E8"
-      unit={false}
+      unit=""
       valueStyle={{ color: '#D0BFFF' }}
     />
   );

--- a/packages/charts/src/Score/demo/customThreshold.tsx
+++ b/packages/charts/src/Score/demo/customThreshold.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Score } from '@oceanbase/charts';
+import { Col, Row } from '@oceanbase/design';
+import { range } from 'lodash';
+
+export default () => {
+  const thresholds = {
+    0: 'rgb(242, 73, 92)',
+    20: 'rgb(250, 222, 42)',
+    40: 'rgb(255, 152, 48)',
+    60: 'rgb(184, 119, 217)',
+    80: 'rgb(87, 148, 242)',
+    100: 'rgb(115, 191, 105)',
+  };
+  return (
+    <Row gutter={[8, 8]}>
+      {range(0, 6).map(index => (
+        <Col span={8} key={index}>
+          <Score
+            value={index * 20}
+            thresholds={thresholds}
+          />
+        </Col>
+      ))}
+    </Row>
+  );
+};

--- a/packages/charts/src/Score/index.less
+++ b/packages/charts/src/Score/index.less
@@ -45,7 +45,7 @@
       position: absolute;
       top: 50%;
       left: 50%;
-      width: 110px;
+      width: 100%;
       text-align: center;
       transform: translate(-50%, -50%);
       .@{prefixCls}-number {

--- a/packages/charts/src/Score/index.less
+++ b/packages/charts/src/Score/index.less
@@ -1,0 +1,72 @@
+@prefixCls: ob-score;
+
+.@{prefixCls}-container {
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  width: 160px;
+  height: 160px;
+
+  .@{prefixCls}-background-first {
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: 56% 56% 52% 54%;
+    opacity: 0.8;
+    animation: wave 12s infinite linear;
+    content: '';
+  }
+
+  .@{prefixCls}-background-second {
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: 46% 46% 42% 44%;
+    opacity: 0.4;
+    animation: wave 8s infinite linear;
+    content: '';
+  }
+
+  .@{prefixCls}-circle {
+    position: absolute;
+    top: 5%;
+    left: 5%;
+    width: 88%;
+    height: 88%;
+    background: #fff;
+    border-radius: 70% 60% 60% 60%;
+    .@{prefixCls}-circle-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 110px;
+      text-align: center;
+      transform: translate(-50%, -50%);
+      .@{prefixCls}-number {
+        font-weight: bolder;
+      }
+      .@{prefixCls}-unit {
+        margin-left: 8px;
+        font-size: 12px;
+      }
+    }
+  }
+}
+
+@keyframes wave {
+  0% {
+    transform: rotate(0deg);
+  }
+  50% {
+    transform: rotate(180deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/charts/src/Score/index.md
+++ b/packages/charts/src/Score/index.md
@@ -11,15 +11,17 @@ nav:
 
 ## 代码演示
 
-<code src="./demo/basic.tsx" title="基础使用"></code> <code src="./demo/custom.tsx" title="自定义"></code>
+<code src="./demo/basic.tsx" title="基础使用"></code> <code src="./demo/customColor.tsx" title="自定义颜色和单位"></code> <code src="./demo/customThreshold.tsx" title="自定义阈值"></code>
 
 ## API
 
-| 参数       | 说明     | 类型              | 默认值 | 版本 |
-| :--------- | :------- | :---------------- | :----- | :--- |
-| size       | 图表大小 | string \| number  | middle | -    |
-| color      | 图表颜色 | string            | green  | -    |
-| value      | 数值     | string \| number  | -      | -    |
-| valueStyle | 数字样式 | CSSProperties     | -      | -    |
-| unit       | 单位     | string \| boolean | 分     | -    |
-| unitStyle  | 单位样式 | CSSProperties     | -      | -    |
+| 参数       | 说明                 | 类型            | 默认值 | 版本 |
+| :--------- | :------------------- | :-------------- | :----- | :--- |
+| size       | 图表大小             | string\| number | middle | -    |
+| color      | 图表颜色             | string          | green  | -    |
+| value      | 数值                 | number          | -      | -    |
+| valueStyle | 数字样式             | CSSProperties   | -      | -    |
+| unit       | 单位                 | string          | 分     | -    |
+| unitStyle  | 单位样式             | CSSProperties   | -      | -    |
+| thresholds | 阈值和颜色值映射对象 | object          | -      | -    |
+| className  | 类名                 | string          | -      | -    |

--- a/packages/charts/src/Score/index.md
+++ b/packages/charts/src/Score/index.md
@@ -1,0 +1,25 @@
+---
+title: Score 得分图
+nav:
+  title: 图表
+  path: /charts
+---
+
+## 默认规范
+
+- 默认 85 <= num 分为优（绿色），70 <= num < 85 为良（蓝色），60 <= num < 70 为中（橙色），NUM < 60 为差（红色）
+
+## 代码演示
+
+<code src="./demo/basic.tsx" title="基础使用"></code> <code src="./demo/custom.tsx" title="自定义"></code>
+
+## API
+
+| 参数       | 说明     | 类型              | 默认值 | 版本 |
+| :--------- | :------- | :---------------- | :----- | :--- |
+| size       | 图表大小 | string \| number  | middle | -    |
+| color      | 图表颜色 | string            | green  | -    |
+| value      | 数值     | string \| number  | -      | -    |
+| valueStyle | 数字样式 | CSSProperties     | -      | -    |
+| unit       | 单位     | string \| boolean | 分     | -    |
+| unitStyle  | 单位样式 | CSSProperties     | -      | -    |

--- a/packages/charts/src/Score/index.tsx
+++ b/packages/charts/src/Score/index.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { toString } from 'lodash';
+import { calculateFontSize } from '../util/measureText';
+import './index.less';
+
+export interface ScoreConfig {
+  size?: number | string;
+  color?: string;
+  value: number;
+  valueStyle?: React.CSSProperties;
+  unit?: string | boolean;
+  unitStyle?: React.CSSProperties;
+}
+
+const prefixCls = 'ob-score';
+const smallSize = 120;
+const middleSize = 160;
+const largeSize = 200;
+const LINE_HEIGHT = 1.2;
+const VALUE_FONT_WEIGHT = 500;
+
+const firstColor = '#6caf4b';
+const secondColor = '#3f82e0';
+const thirdColor = '#ff8303';
+const fourthlyColor = '#de5c51';
+
+const Score: React.FC<ScoreConfig> = ({
+  size,
+  color,
+  value,
+  valueStyle,
+  unit,
+  unitStyle,
+  ...restConfig
+}) => {
+  const showUnit = unit === false ? null : unit || '分';
+
+  let currentColor = '';
+  if (color) {
+    currentColor = color;
+  } else if (value >= 85) {
+    currentColor = firstColor;
+  } else if (value < 85 && value >= 70) {
+    currentColor = secondColor;
+  } else if (value < 70 && value >= 60) {
+    currentColor = thirdColor;
+  } else {
+    currentColor = fourthlyColor;
+  }
+
+  const bgColorStyle: React.CSSProperties = {
+    backgroundColor: currentColor
+  }
+
+  const fontColorStyle: React.CSSProperties = {
+    color: currentColor
+  }
+
+  let style: React.CSSProperties = {};
+  if (typeof size === 'string') {
+    switch (size) {
+      case 'small':
+        style = {
+          width: smallSize,
+          height: smallSize,
+        }
+        break;
+      case 'large':
+        style = {
+          width: largeSize,
+          height: largeSize,
+        }
+        break;
+      case 'large':
+        style = {
+          width: middleSize,
+          height: middleSize,
+        }
+        break;
+      default:
+        style = {
+          width: size,
+          height: size,
+        }
+        break
+    }
+  } else if (typeof size === 'number') {
+    style = {
+      width: size,
+      height: size,
+    }
+  } else {
+    style = {
+      width: middleSize,
+      height: middleSize,
+    }
+  }
+
+  const numberFontSize = calculateFontSize(
+    toString(value),
+    style.width * 0.33,
+    style.height * 0.33,
+    LINE_HEIGHT,
+    undefined,
+    VALUE_FONT_WEIGHT
+  );
+
+  const unitFontSize = calculateFontSize(
+    toString(unit),
+    style.width * 0.08,
+    style.height * 0.08,
+    LINE_HEIGHT,
+    undefined,
+    VALUE_FONT_WEIGHT
+  );
+
+  return (
+    <div
+      className={`${prefixCls}-container`}
+      style={{ ...style }}
+      {...restConfig}
+    >
+      <div className={`${prefixCls}-background-first`} style={{ ...bgColorStyle }} />
+      <div className={`${prefixCls}-background-second`} style={{ ...bgColorStyle }} />
+      <div className={`${prefixCls}-circle`}>
+        <div className={`${prefixCls}-circle-content`}>
+          <span className={`${prefixCls}-value`} style={{ fontSize: `${numberFontSize}px`, ...fontColorStyle, ...(valueStyle || {}) }} >{value || 0}</span>
+          {showUnit ? <span className={`${prefixCls}-unit`} style={{ fontSize: `${unitFontSize}px`, marginLeft: style.width * 0.04, ...fontColorStyle, ...(unitStyle || {}) }} >{showUnit}</span> : null}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Score;

--- a/packages/charts/src/Stat/demo/basic.tsx
+++ b/packages/charts/src/Stat/demo/basic.tsx
@@ -16,8 +16,8 @@ export default () => {
     height,
     ...(extra
       ? {
-          [extra]: extra === 'prefix' ? '$' : 'USD',
-        }
+        [extra]: extra === 'prefix' ? '$' : 'USD',
+      }
       : {}),
     layout,
     themeMode,

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -43,5 +43,7 @@ export type { TinyColumnConfig } from './Tiny/TinyColumn';
 
 export { default as Progress } from './Tiny/Progress';
 export type { ProgressConfig } from './Tiny/Progress';
+export { default as Score } from './Score';
+export type { ScoreConfig } from './Score';
 
 export { theme } from './theme';


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

新增 Score 得分图组件, 主要用于突出展示一个数值分数的动态效果。

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description

- 默认 85 <= num 分为优（绿色），70 <= num < 85 为良（蓝色），60 <= num < 70 为中（橙色），NUM < 60 为差（红色）
- 支持自定义单位、数值样式、单位样式、阈值配置等。

<!-- Please clearly and consice descipt the solution. -->

### Usage

![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/073eaa77-a4eb-42c0-8ad5-2403540db2d7)

#### API

| 参数       | 说明                 | 类型            | 默认值 | 版本 |
| :--------- | :------------------- | :-------------- | :----- | :--- |
| size       | 图表大小             | string\| number | middle | -    |
| color      | 图表颜色             | string          | green  | -    |
| value      | 数值                 | number          | -      | -    |
| valueStyle | 数字样式             | CSSProperties   | -      | -    |
| unit       | 单位                 | string          | 分     | -    |
| unitStyle  | 单位样式             | CSSProperties   | -      | -    |
| thresholds | 阈值和颜色值映射对象 | object          | -      | -    |
| className  | 类名                 | string          | -      | -    |

