### PR TITLE
fix(design): genSizeStyle should cover default style for Spin

### DIFF
--- a/packages/design/src/spin/style/index.ts
+++ b/packages/design/src/spin/style/index.ts
@@ -13,13 +13,16 @@ const genSizeStyle = (spinDotSize: number, token: SpinToken): CSSObject => {
   const spinDotWidth = spinDotSize;
   const spinDotHight = spinDotWidth * (295 / 397);
   return {
-    [`${componentCls}-dot`]: {
-      width: spinDotWidth,
-      height: spinDotHight,
-    },
-    [`${componentCls}-text`]: {
-      width: spinDotWidth,
-      color: colorText,
+    // only work for oceanbase indicator
+    [`&${componentCls}-oceanbase`]: {
+      [`${componentCls}-dot`]: {
+        width: spinDotWidth,
+        height: spinDotHight,
+      },
+      [`${componentCls}-text`]: {
+        width: spinDotWidth,
+        color: colorText,
+      },
     },
   };
 };
@@ -35,6 +38,7 @@ const genNestedSizeStyle = (spinDotSize: number, token: SpinToken): CSSObject =>
   const dotMarginTop = -spinDotHight / 2;
   const textPaddingTop = (spinDotHight - fontSize) / 2 + 2;
   return {
+    // only work for oceanbase indicator
     [`&${componentCls}-oceanbase`]: {
       [`${componentCls}-dot`]: {
         marginLeft: dotMarginLeft,
@@ -53,11 +57,10 @@ const genNestedSizeStyle = (spinDotSize: number, token: SpinToken): CSSObject =>
 export const genSpinStyle: GenerateStyle<SpinToken> = (token: SpinToken): CSSObject => {
   const { componentCls, spinDotSize, spinDotSizeSM, spinDotSizeLG } = token;
   return {
-    // only work for oceanbase indicator
     [`${componentCls}`]: {
-      [`&-oceanbase`]: genSizeStyle(spinDotSize, token),
-      [`&-sm&-oceanbase`]: genSizeStyle(spinDotSizeSM, token),
-      [`&-lg&-oceanbase`]: genSizeStyle(spinDotSizeLG, token),
+      [`&`]: genSizeStyle(spinDotSize, token),
+      [`&-sm`]: genSizeStyle(spinDotSizeSM, token),
+      [`&-lg`]: genSizeStyle(spinDotSizeLG, token),
     },
     [`${componentCls}-nested-loading`]: {
       [`> div > ${componentCls}`]: {


### PR DESCRIPTION
## Result

![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/b367529d-1b4f-4632-adc5-bd3b07b91eb0)

## Reason

![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/90f3f373-c7f4-4dd2-8cc2-5a9210e2b546)

