### PR TITLE
feat(charts): customMemo support to compare function

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^29.5.4",
+    "@types/lodash": "^4.14.199",
     "@types/node": "^20.6.2",
     "@types/react": "^18.2.21",
     "@umijs/fabric": "^4.0.1",

--- a/packages/charts/src/Pie/demo/state-change.tsx
+++ b/packages/charts/src/Pie/demo/state-change.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import { Pie } from '@oceanbase/charts';
 
 const Demo: React.FC = () => {
@@ -30,16 +30,13 @@ const Demo: React.FC = () => {
     },
   ]);
 
-  // memo function to avoid re-render
-  const onReady = useCallback(plot => {
-    console.log(plot);
-  }, []);
-
   const config = {
     data,
     angleField: 'value',
     colorField: 'type',
-    onReady,
+    onReady: plot => {
+      console.log(plot);
+    },
   };
 
   return (
@@ -50,7 +47,7 @@ const Demo: React.FC = () => {
           setCount(count + 1);
         }}
         style={{
-          marginLeft: 16,
+          marginLeft: 8,
         }}
       >
         外部状态改变不会重新渲染
@@ -73,7 +70,7 @@ const Demo: React.FC = () => {
           ]);
         }}
         style={{
-          marginLeft: 16,
+          marginLeft: 8,
         }}
       >
         数据改变重新渲染

--- a/packages/charts/src/util/__tests__/custom-memo.test.ts
+++ b/packages/charts/src/util/__tests__/custom-memo.test.ts
@@ -1,0 +1,99 @@
+import { isEqualWithFunction } from '../custom-memo';
+
+describe('custom-memo', () => {
+  it('isEqualWithFunction', () => {
+    expect(
+      isEqualWithFunction(
+        {
+          a: 1,
+          b: 2,
+          data: [{ x: 1, y: 2 }],
+        },
+        {
+          a: 1,
+          b: 2,
+          data: [{ x: 1, y: 2 }],
+        }
+      )
+    ).toEqual(true);
+    expect(
+      isEqualWithFunction(
+        {
+          a: 1,
+          b: 2,
+          data: [{ x: 1, y: 2 }],
+          // arrow function
+          fn: (x, y) => x + y,
+        },
+        {
+          a: 1,
+          b: 2,
+          data: [{ x: 1, y: 2 }],
+          fn: (x, y) => x + y,
+        }
+      )
+    ).toEqual(true);
+    expect(
+      isEqualWithFunction(
+        {
+          a: 1,
+          b: 2,
+          data: [{ x: 1, y: 2 }],
+          // normal function
+          fn: function (x, y) {
+            return x + y;
+          },
+        },
+        {
+          a: 1,
+          b: 2,
+          data: [{ x: 1, y: 2 }],
+          fn: function (x, y) {
+            return x + y;
+          },
+        }
+      )
+    ).toEqual(true);
+    expect(
+      isEqualWithFunction(
+        {
+          a: 1,
+          b: 2,
+          data: [{ x: 1, y: 2 }],
+          // normal function abbreviation
+          fn(x, y) {
+            return x + y;
+          },
+        },
+        {
+          a: 1,
+          b: 2,
+          data: [{ x: 1, y: 2 }],
+          fn(x, y) {
+            return x + y;
+          },
+        }
+      )
+    ).toEqual(true);
+    expect(
+      isEqualWithFunction(
+        {
+          a: 1,
+          b: 2,
+          data: [{ x: 1, y: 2 }],
+          fn: function (x, y) {
+            return x + y;
+          },
+        },
+        {
+          a: 1,
+          b: 2,
+          data: [{ x: 1, y: 2 }],
+          fn(x, y) {
+            return x + y;
+          },
+        }
+      )
+    ).toEqual(false);
+  });
+});

--- a/packages/charts/src/util/custom-memo.ts
+++ b/packages/charts/src/util/custom-memo.ts
@@ -1,13 +1,28 @@
 import { memo } from 'react';
 import type { FunctionComponent } from 'react';
-import { isEqual } from 'lodash';
+import { isFunction, isEqualWith, isEqual, isPlainObject, maxBy } from 'lodash';
 import type { BaseConfig, AllBaseConfig } from '@ant-design/charts';
+
+export function isEqualWithFunction(v1: any, v2: any) {
+  return isEqualWith(v1, v2, (value1, value2) => {
+    // function equals
+    if (isFunction(value1) && isFunction(value2)) {
+      return value1.toString() === value2.toString();
+    } else if (isPlainObject(value1) && isPlainObject(value2)) {
+      const keys1 = Object.keys(value1);
+      const keys2 = Object.keys(value2);
+      const keys = maxBy([keys1, keys2], o => o.length);
+      return keys.every(key => isEqualWithFunction(value1[key], value2[key]));
+    }
+    return isEqual(value1, value2);
+  });
+}
 
 export function customMemo<P extends BaseConfig<AllBaseConfig>>(
   Component: FunctionComponent<P>,
   propsAreEqual?: (prevProps: Readonly<P>, nextProps: Readonly<P>) => boolean
 ) {
   return memo(Component, (prevProps, nextProps) =>
-    propsAreEqual ? propsAreEqual(prevProps, nextProps) : isEqual(prevProps, nextProps)
+    propsAreEqual ? propsAreEqual(prevProps, nextProps) : isEqualWithFunction(prevProps, nextProps)
   );
 }

--- a/packages/design/src/index.ts
+++ b/packages/design/src/index.ts
@@ -29,3 +29,5 @@ const { useToken } = theme;
 
 // 直接导出 useToken，方便上层使用
 export { useToken };
+
+export type { PresetStatusColorType } from 'antd/es/_util/colors';

--- a/packages/ui/src/SideTip/demo/content.tsx
+++ b/packages/ui/src/SideTip/demo/content.tsx
@@ -4,6 +4,7 @@
  */
 import React, { useState } from 'react';
 import { Badge, Card, Dropdown, Progress, Table } from '@oceanbase/design';
+import type { PresetStatusColorType } from '@oceanbase/design';
 import { SideTip } from '@oceanbase/ui';
 import { FileTextOutlined } from '@oceanbase/icons';
 import { findByValue } from '@oceanbase/util';
@@ -35,7 +36,7 @@ export default () => {
       width: 100,
       render: text => {
         const { label = '全部', badgeStatus = 'default' } = findByValue(STATUS_LIST, text) || {};
-        return <Badge status={badgeStatus} text={label} />;
+        return <Badge status={badgeStatus as PresetStatusColorType} text={label} />;
       },
     },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@types/jest':
         specifier: ^29.5.4
         version: 29.5.4
+      '@types/lodash':
+        specifier: ^4.14.199
+        version: 4.14.199
       '@types/node':
         specifier: ^20.6.2
         version: 20.6.2
@@ -6307,6 +6310,10 @@ packages:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
       '@types/node': 20.6.2
+    dev: true
+
+  /@types/lodash@4.14.199:
+    resolution: {integrity: sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==}
     dev: true
 
   /@types/mapbox-gl@1.13.6:


### PR DESCRIPTION
- Ref: #151.
- There is no need to add `useCallback` wrapper for `function` prop from now on.

![2023-10-07 16-24-50 2023-10-07 16_26_16](https://github.com/oceanbase/oceanbase-design/assets/14918822/41acfefe-e270-4af7-a6c8-d90452191fe2)
