### PR TITLE
improve(ui): Set footerToolBarProps.portalDom to false by default for…

### DIFF
--- a/packages/ui/src/BasicLayout/style/index.ts
+++ b/packages/ui/src/BasicLayout/style/index.ts
@@ -16,9 +16,9 @@ export const genBasicLayoutStyle: GenerateStyle<BasicLayoutToken> = (
         // 48px is the height of BasicLayout header
         minHeight: 'calc(100vh - 48px)',
       },
-    },
-    [`${proComponentsCls}-footer-bar`]: {
-      width: `calc(100% - 192px - 24px)`,
+      [`${proComponentsCls}-footer-bar`]: {
+        width: `calc(100% - 192px - 24px)`,
+      },
     },
   };
 };

--- a/packages/ui/src/PageContainer/index.tsx
+++ b/packages/ui/src/PageContainer/index.tsx
@@ -37,6 +37,7 @@ const PageContainer = ({
   extraContent,
   tabList,
   tabBarExtraContent,
+  footerToolBarProps,
   locale,
   ...restProps
 }: PageContainerProps) => {
@@ -80,7 +81,7 @@ const PageContainer = ({
     },
   };
   const noHasHeader =
-    ['title', 'subTitle', 'extra', 'tags', 'footer', 'avatar', 'backIcon', 'breadcrumb'].every(
+    ['title', 'subTitle', 'extra', 'tags', 'avatar', 'backIcon', 'breadcrumb'].every(
       item => !newHeader?.[item]
     ) &&
     !content &&
@@ -104,6 +105,11 @@ const PageContainer = ({
       extraContent={extraContent}
       tabList={tabList}
       tabBarExtraContent={tabBarExtraContent}
+      footerToolBarProps={{
+        ...footerToolBarProps,
+        // render footer as same level with PageContainer instead of under body
+        portalDom: false,
+      }}
       {...restProps}
     />
   );


### PR DESCRIPTION
- Set footerToolBarProps.portalDom to false by default for customize PageContainer style in BasicLayou
t:

| Before | After |
| :--- | :--- |
| ![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/3611a6b4-3233-48bb-98be-2604d788f60b) | ![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/7b34a3d9-2f35-4933-8ad9-ceb6d80058b6) |