### PR TITLE
feat(codemod): Support fuzzy matching for style-to-token and less-to-token transform

### DIFF
--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -153,11 +153,11 @@ transform fixed style to antd v5 design token.
 +   const { token } = theme.useToken();
     return (
 -     <div>
--       <Alert style={{ color: 'rgba(0, 0, 0, 0.85)', background: 'rgba(0, 0, 0,0.65)', backgroundColor: 'rgba(0,0,0,0.45)', borderColor: '#fafafa' }} />
+-       <Alert style={{ color: 'rgba(0, 0, 0, 0.85)', background: 'rgba(0, 0, 0,0.65)', backgroundColor: 'rgba(0,0,0,0.45)', border: '1px solid #d9d9d9' }} />
 -       <Button style={{ color: '#1890ff', background: '#52c41a', backgroundColor: '#faad14', borderColor: '#ff4D4F' }}></Button>
 -     </div>
 +     (<div>
-+       <Alert style={{ color: token.colorText, background: token.colorTextSecondary, backgroundColor: token.colorTextTertiary, borderColor: token.colorBgLayout }} />
++       <Alert style={{ color: token.colorText, background: token.colorTextSecondary, backgroundColor: token.colorTextTertiary, border: `1px solid ${token.colorBorder}` }} />
 +       <Button style={{ color: token.colorInfo, background: token.colorSuccess, backgroundColor: token.colorWarning, borderColor: token.colorError }}></Button>
 +     </div>)
     );
@@ -182,11 +182,11 @@ export default Demo;
     render() {
       return (
 -       <div>
--         <Alert style={{ color: 'rgba(0, 0, 0, 0.85)', background: 'rgba(0, 0, 0,0.65)', backgroundColor: 'rgba(0,0,0,0.45)', borderColor: '#fafafa' }} />
+-         <Alert style={{ color: 'rgba(0, 0, 0, 0.85)', background: 'rgba(0, 0, 0,0.65)', backgroundColor: 'rgba(0,0,0,0.45)', border: '#d9d9d9' }} />
 -         <Button style={{ color: '#1890ff', background: '#52c41a', backgroundColor: '#faad14', borderColor: '#ff4D4F' }}></Button>
 -       </div>
 +       (<div>
-+         <Alert style={{ color: token.colorText, background: token.colorTextSecondary, backgroundColor: token.colorTextTertiary, borderColor: token.colorBgLayout }} />
++         <Alert style={{ color: token.colorText, background: token.colorTextSecondary, backgroundColor: token.colorTextTertiary, border: `1px solid ${token.colorBgLayout}` }} />
 +         <Button style={{ color: token.colorInfo, background: token.colorSuccess, backgroundColor: token.colorWarning, borderColor: token.colorError }}></Button>
 +       </div>)
       );
@@ -205,10 +205,12 @@ export default Demo;
 -   success: '#52c41a',
 -   warning: '#faad14',
 -   error: '#ff4D4F',
+-   border: '1px solid #d9d9d9',
 +   info: token.colorInfo,
 +   success: token.colorSuccess,
 +   warning: token.colorWarning,
 +   error: token.colorError,
++   border: `1px solid ${token.colorBorder}`,
   };
 
   function getColorList() {
@@ -232,14 +234,19 @@ export default Demo;
         type: 'error',
 -       color: '#ff4D4F',
 +       color: token.colorError,
-      }
+      },
+      {
+        type: 'border',
+-       color: '1px solid #d9d9d9',
++       color: `1px solid ${token.colorBorder}`,
+      },
     ];
   }
 ```
 
 ### `less-to-token`
 
-transform less style to antd v5 design token.
+transform fixed less style to antd v5 design token.
 
 ```diff
 + @import '~@oceanbase/design/es/theme/index.less';
@@ -262,5 +269,5 @@ transform less style to antd v5 design token.
 -     border: 1px solid #d9d9d9;
 +     border: 1px solid @colorBorder;
     }
-}
+  }
 ```

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -4,6 +4,10 @@ A collection of codemod scripts that help migrate to OceanBase Design using [jsc
 
 [![NPM version](https://img.shields.io/npm/v/@oceanbase/codemod.svg?style=flat)](https://npmjs.org/package/@oceanbase/codemod) [![NPM downloads](http://img.shields.io/npm/dm/@oceanbase/codemod.svg?style=flat)](https://npmjs.org/package/@oceanbase/codemod) [![Github Action](https://github.com/oceanbase/oceanbase-design/actions/workflows/ci.yml/badge.svg)](https://github.com/oceanbase/oceanbase-design/actions/workflows/ci.yml)
 
+## Prerequisite
+
+- antd v5 is the prerequisite. If you are using antd v4, please refer to [Upgrade Guideline](https://ant-design.antgroup.com/docs/react/migration-v5).
+
 ## Usage
 
 Before run codemod scripts, you'd better make sure to commit your local git changes firstly.
@@ -136,7 +140,7 @@ import utils and hooks from `@alipay/ob-util` to `@oceanbase/util`. Additionally
 
 ### `style-to-token`
 
-transform fixed css style to antd v5 design token.
+transform fixed style to antd v5 design token.
 
 - React function components:
 
@@ -231,4 +235,32 @@ export default Demo;
       }
     ];
   }
+```
+
+### `less-to-token`
+
+transform less style to antd v5 design token.
+
+```diff
++ @import '~@oceanbase/design/es/theme/index.less';
+  .container {
+-   color: #1890ff;
++   color: @colorInfo;
+-   background: #52c41a;
++   background: @colorSuccess;
+-   background-color: #faad14;
++   background-color: @colorWarning;
+-   border-color: #ff4D4F;
++   border-color: @colorError;
+    .content {
+-     color: rgba(0, 0, 0, 0.85);
++     color: @colorText;
+-     background: rgba(0, 0, 0,0.65);
++     background: @colorTextSecondary;
+-     background-color: rgba(0,0,0,0.45);
++     background-color: @colorTextTertiary;
+-     border: 1px solid #d9d9d9;
++     border: 1px solid @colorBorder;
+    }
+}
 ```

--- a/packages/codemod/transforms/__testfixtures__/less-to-token/antd-v4-less-to-token.input.less
+++ b/packages/codemod/transforms/__testfixtures__/less-to-token/antd-v4-less-to-token.input.less
@@ -7,6 +7,6 @@
     color: rgba(0, 0, 0, 0.85);
     background: rgba(0, 0, 0,0.65);
     background-color: rgba(0,0,0,0.45);
-    border: 1px solid #fafafa;
+    border: 1px solid #d9d9d9;
   }
 }

--- a/packages/codemod/transforms/__testfixtures__/less-to-token/antd-v4-less-to-token.output.less
+++ b/packages/codemod/transforms/__testfixtures__/less-to-token/antd-v4-less-to-token.output.less
@@ -8,6 +8,6 @@
     color: @colorText;
     background: @colorTextSecondary;
     background-color: @colorTextTertiary;
-    border: 1px solid @colorBgLayout;
+    border: 1px solid @colorBorder;
   }
 }

--- a/packages/codemod/transforms/__testfixtures__/less-to-token/obui-less-to-token.input.less
+++ b/packages/codemod/transforms/__testfixtures__/less-to-token/obui-less-to-token.input.less
@@ -9,6 +9,6 @@
     color: rgba(0, 0, 0, 0.85);
     background: rgba(0, 0, 0,0.65);
     background-color: rgba(0,0,0,0.45);
-    border: 1px solid #fafafa;
+    border: 1px solid #d9d9d9;
   }
 }

--- a/packages/codemod/transforms/__testfixtures__/less-to-token/obui-less-to-token.output.less
+++ b/packages/codemod/transforms/__testfixtures__/less-to-token/obui-less-to-token.output.less
@@ -8,6 +8,6 @@
     color: @colorText;
     background: @colorTextSecondary;
     background-color: @colorTextTertiary;
-    border: 1px solid @colorBgLayout;
+    border: 1px solid @colorBorder;
   }
 }

--- a/packages/codemod/transforms/__testfixtures__/style-to-token/class-component.input.js
+++ b/packages/codemod/transforms/__testfixtures__/style-to-token/class-component.input.js
@@ -10,7 +10,7 @@ class Demo extends React.PureComponent {
   render() {
     return (
       <div>
-        <Alert style={{ color: 'rgba(0, 0, 0, 0.85)', background: 'rgba(0, 0, 0,0.65)', backgroundColor: 'rgba(0,0,0,0.45)', borderColor: '#fafafa' }} />
+        <Alert style={{ color: 'rgba(0, 0, 0, 0.85)', background: 'rgba(0, 0, 0,0.65)', backgroundColor: 'rgba(0,0,0,0.45)', border: '1px solid #d9d9d9' }} />
         <Button style={{ color: '#1890ff', background: '#52c41a', backgroundColor: '#faad14', borderColor: '#ff4D4F' }}></Button>
       </div>
     );

--- a/packages/codemod/transforms/__testfixtures__/style-to-token/class-component.output.js
+++ b/packages/codemod/transforms/__testfixtures__/style-to-token/class-component.output.js
@@ -10,7 +10,7 @@ class Demo extends React.PureComponent {
   render() {
     return (
       (<div>
-        <Alert style={{ color: token.colorText, background: token.colorTextSecondary, backgroundColor: token.colorTextTertiary, borderColor: token.colorBgLayout }} />
+        <Alert style={{ color: token.colorText, background: token.colorTextSecondary, backgroundColor: token.colorTextTertiary, border: `1px solid ${token.colorBorder}` }} />
         <Button style={{ color: token.colorInfo, background: token.colorSuccess, backgroundColor: token.colorWarning, borderColor: token.colorError }}></Button>
       </div>)
     );

--- a/packages/codemod/transforms/__testfixtures__/style-to-token/function-component.input.js
+++ b/packages/codemod/transforms/__testfixtures__/style-to-token/function-component.input.js
@@ -4,7 +4,7 @@ import { Alert, Button } from '@oceanbase/design';
 const Demo = () => {
   return (
     <div>
-      <Alert style={{ color: 'rgba(0, 0, 0, 0.85)', background: 'rgba(0, 0, 0,0.65)', backgroundColor: 'rgba(0,0,0,0.45)', borderColor: '#fafafa' }} />
+      <Alert style={{ color: 'rgba(0, 0, 0, 0.85)', background: 'rgba(0, 0, 0,0.65)', backgroundColor: 'rgba(0,0,0,0.45)', border: '1px solid #d9d9d9' }} />
       <Button style={{ color: '#1890ff', background: '#52c41a', backgroundColor: '#faad14', borderColor: '#ff4D4F' }}></Button>
     </div>
   );

--- a/packages/codemod/transforms/__testfixtures__/style-to-token/function-component.output.js
+++ b/packages/codemod/transforms/__testfixtures__/style-to-token/function-component.output.js
@@ -5,7 +5,7 @@ const Demo = () => {
   const { token } = theme.useToken();
   return (
     (<div>
-      <Alert style={{ color: token.colorText, background: token.colorTextSecondary, backgroundColor: token.colorTextTertiary, borderColor: token.colorBgLayout }} />
+      <Alert style={{ color: token.colorText, background: token.colorTextSecondary, backgroundColor: token.colorTextTertiary, border: `1px solid ${token.colorBorder}` }} />
       <Button style={{ color: token.colorInfo, background: token.colorSuccess, backgroundColor: token.colorWarning, borderColor: token.colorError }}></Button>
     </div>)
   );

--- a/packages/codemod/transforms/__testfixtures__/style-to-token/static.input.js
+++ b/packages/codemod/transforms/__testfixtures__/style-to-token/static.input.js
@@ -3,6 +3,7 @@ const colorMap = {
   success: '#52c41a',
   warning: '#faad14',
   error: '#ff4D4F',
+  border: '1px solid #d9d9d9',
 };
 
 function getColorList() {
@@ -22,6 +23,10 @@ function getColorList() {
     {
       type: 'error',
       color: '#ff4D4F',
-    }
+    },
+    {
+      type: 'border',
+      color: '1px solid #d9d9d9',
+    },
   ];
 }

--- a/packages/codemod/transforms/__testfixtures__/style-to-token/static.output.js
+++ b/packages/codemod/transforms/__testfixtures__/style-to-token/static.output.js
@@ -4,6 +4,7 @@ const colorMap = {
   success: token.colorSuccess,
   warning: token.colorWarning,
   error: token.colorError,
+  border: `1px solid ${token.colorBorder}`,
 };
 
 function getColorList() {
@@ -23,6 +24,10 @@ function getColorList() {
     {
       type: 'error',
       color: token.colorError,
-    }
+    },
+    {
+      type: 'border',
+      color: `1px solid ${token.colorBorder}`,
+    },
   ];
 }

--- a/packages/codemod/transforms/less-to-token.js
+++ b/packages/codemod/transforms/less-to-token.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const postcss = require('postcss');
 const postcssLess = require('postcss-less');
 const isDirectory = require('is-directory');
-const { TOKEN_MAP, formatValue } = require('./utils/token');
+const { TOKEN_MAP, TOKEN_MAP_KEYS, formatValue } = require('./utils/token');
 
 /**
  * 搜索目录下所有的less文件
@@ -51,8 +51,11 @@ async function transform(file) {
   let tokenLessImported = false;
   // 遍历 AST
   ast.walk(node => {
-    if (node.type === 'decl' && TOKEN_MAP[formatValue(node.value)]) {
-      node.value = `@${TOKEN_MAP[formatValue(node.value)]}`;
+    const formattedValue = formatValue(node.value);
+    const key = TOKEN_MAP_KEYS.find(key => formattedValue.includes(key));
+    const token = TOKEN_MAP[key];
+    if (node.type === 'decl' && token) {
+      node.value = formattedValue.replace(key, `@${token}`);
       modified = true;
     } else if (node.type === 'atrule' && node.name === 'import') {
       if (node.params === "'~@oceanbase/design/es/theme/index.less'") {

--- a/packages/codemod/transforms/less-to-token.js
+++ b/packages/codemod/transforms/less-to-token.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const postcss = require('postcss');
 const postcssLess = require('postcss-less');
 const isDirectory = require('is-directory');
-const { TOKEN_MAP, TOKEN_MAP_KEYS, formatValue } = require('./utils/token');
+const { tokenParse } = require('./utils/token');
 
 /**
  * 搜索目录下所有的less文件
@@ -51,9 +51,7 @@ async function transform(file) {
   let tokenLessImported = false;
   // 遍历 AST
   ast.walk(node => {
-    const formattedValue = formatValue(node.value);
-    const key = TOKEN_MAP_KEYS.find(key => formattedValue.includes(key));
-    const token = TOKEN_MAP[key];
+    const { key, token, formattedValue } = tokenParse(node.value);
     if (node.type === 'decl' && token) {
       node.value = formattedValue.replace(key, `@${token}`);
       modified = true;

--- a/packages/codemod/transforms/utils/token.js
+++ b/packages/codemod/transforms/utils/token.js
@@ -45,9 +45,18 @@ function formatValue(value) {
   return customTrim(toLower(value));
 }
 
+function tokenParse(value) {
+  const formattedValue = formatValue(value);
+  const key = TOKEN_MAP_KEYS.find(item => formattedValue.includes(item));
+  return {
+    key,
+    token: TOKEN_MAP[key],
+    formattedValue,
+  };
+}
+
 module.exports = {
   TOKEN_MAP,
   TOKEN_MAP_KEYS,
-  customTrim,
-  formatValue,
+  tokenParse,
 };

--- a/packages/codemod/transforms/utils/token.js
+++ b/packages/codemod/transforms/utils/token.js
@@ -35,16 +35,19 @@ const TOKEN_MAP = {
   '#F8FAFE': 'colorFillQuaternary',
 };
 
-function trimAll(str) {
-  return str?.replace(/(\s)*/g, '');
+const TOKEN_MAP_KEYS = Object.keys(TOKEN_MAP);
+
+function customTrim(str) {
+  return str?.replace(/(\s)*([,\(\)])(\s)*/g, '$2');
 }
 
 function formatValue(value) {
-  return trimAll(toLower(value));
+  return customTrim(toLower(value));
 }
 
 module.exports = {
   TOKEN_MAP,
-  trimAll,
+  TOKEN_MAP_KEYS,
+  customTrim,
   formatValue,
 };


### PR DESCRIPTION
- Ref: #60
- `style-to-token` transform:

```diff
  import React from 'react';
- import { Alert, Button } from '@oceanbase/design';
+ import { Alert, Button, theme } from '@oceanbase/design';

  const Demo = () => {
+   const { token } = theme.useToken();
    return (
-     <div>
-       <Alert style={{ border: '1px solid #d9d9d9' }} />
-     </div>
+     (<div>
+       <Alert style={{ border: `1px solid ${token.colorBorder}` }} />
+     </div>)
    );
  };

export default Demo;
```

- `less-to-token` transform:

```diff
+ @import '~@oceanbase/design/es/theme/index.less';
  .container {
    .content {
-     border: 1px solid #d9d9d9;
+     border: 1px solid @colorBorder;
    }
  }
```