### PR TITLE
chore(docs): Add changelog for @oceanbase/design@0.2.24, @oceanbase/ui@0.2.25 and @oceanbase/codemod@0.2.7

### DIFF
--- a/docs/codemod/codemod-CHANGELOG.md
+++ b/docs/codemod/codemod-CHANGELOG.md
@@ -1,0 +1,17 @@
+---
+title: 更新日志
+order: 12
+group: 自动化迁移工具
+---
+
+`@oceanbase/codemod` 严格遵循 [Semantic Versioning 2.0.0](http://semver.org/lang/zh-CN/) 语义化版本规范。
+
+---
+
+## 0.2.7
+
+`2023-10-26`
+
+- 🔥 新增 `style-to-token` 迁移能力，支持将 JS、TS、JSX、TSX 中固定的颜色值样式自动改写为 Design Token。[#215](https://github.com/oceanbase/oceanbase-design/pull/215)
+- 🔥 新增 `less-to-token` 迁移能力，支持将 less 中固定的颜色值样式自动改写为 Design Token。[#217](https://github.com/oceanbase/oceanbase-design/pull/217)
+- 🐞 修复 `dir` 目录参数没有限制迁移范围的问题。[#205](https://github.com/oceanbase/oceanbase-design/pull/205)

--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -7,3 +7,11 @@ group: 基础组件
 `@oceanbase/design` 严格遵循 [Semantic Versioning 2.0.0](http://semver.org/lang/zh-CN/) 语义化版本规范。
 
 ---
+
+## 0.2.24
+
+`2023-10-26`
+
+- Table
+  - 🐞 修复 `columns` 为空时，Table 执行报错、导致页面白屏的问题。[#206](https://github.com/oceanbase/oceanbase-design/pull/206)
+  - 💄 优化带边框的 Table 样式，去掉其底部多余的 border。[#207](https://github.com/oceanbase/oceanbase-design/pull/207)

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -7,3 +7,14 @@ group: 业务组件
 `@oceanbase/ui` 严格遵循 [Semantic Versioning 2.0.0](http://semver.org/lang/zh-CN/) 语义化版本规范。
 
 ---
+
+## 0.2.25
+
+`2023-10-26`
+
+- BasicLayout
+  - 🔥 样式方案从 less 改造为 CSS-in-JS，以支持动态主题。[#201](https://github.com/oceanbase/oceanbase-design/pull/201) [@Vanleehao](https://github.com/Vanleehao)
+  - 🆕 菜单项超长支持自动省略，并展示 tooltip 提示。[#208](https://github.com/oceanbase/oceanbase-design/pull/208)
+  - 💄 适配暗色主题。[#208](https://github.com/oceanbase/oceanbase-design/pull/208)
+  - 💄 优化和 Welcome 组合使用的样式效果。[#208](https://github.com/oceanbase/oceanbase-design/pull/208)
+- 💄 PageContainer 适配 pro-components 的最新版本，优化页头和面包屑导航的样式。[#209](https://github.com/oceanbase/oceanbase-design/pull/209)


### PR DESCRIPTION
## @oceanbase/design 0.2.24

`2023-10-26`

- Table
  - 🐞 修复 `columns` 为空时，Table 执行报错、导致页面白屏的问题。[#206](https://github.com/oceanbase/oceanbase-design/pull/206)
  - 💄 优化带边框的 Table 样式，去掉其底部多余的 border。[#207](https://github.com/oceanbase/oceanbase-design/pull/207)

## @oceanbase/ui 0.2.25

`2023-10-26`

- BasicLayout
  - 🔥 样式方案从 less 改造为 CSS-in-JS，以支持动态主题。[#201](https://github.com/oceanbase/oceanbase-design/pull/201) [@Vanleehao](https://github.com/Vanleehao)
  - 🆕 菜单项超长支持自动省略，并展示 tooltip 提示。[#208](https://github.com/oceanbase/oceanbase-design/pull/208)
  - 💄 适配暗色主题。[#208](https://github.com/oceanbase/oceanbase-design/pull/208)
  - 💄 优化和 Welcome 组合使用的样式效果。[#208](https://github.com/oceanbase/oceanbase-design/pull/208)
- 💄 PageContainer 适配 pro-components 的最新版本，优化页头和面包屑导航的样式。[#209](https://github.com/oceanbase/oceanbase-design/pull/209)

## @oceanbase/codemod 0.2.7

`2023-10-26`

- 🔥 新增 `style-to-token` 迁移能力，支持将 JS、TS、JSX、TSX 中固定的颜色值样式自动改写为 Design Token。[#215](https://github.com/oceanbase/oceanbase-design/pull/215)
- 🔥 新增 `less-to-token` 迁移能力，支持将 less 中固定的颜色值样式自动改写为 Design Token。[#217](https://github.com/oceanbase/oceanbase-design/pull/217)
- 🐞 修复 `dir` 目录参数没有限制迁移范围的问题。[#205](https://github.com/oceanbase/oceanbase-design/pull/205)