### PR TITLE
fix(design): Tooltip closeIcon should consider visible prop

### DIFF
--- a/packages/design/src/tooltip/__tests__/index.test.tsx
+++ b/packages/design/src/tooltip/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { Tooltip } from '@oceanbase/design';
 import { waitFakeTimer } from '../../../../../tests/util';
@@ -65,6 +65,74 @@ describe('Tooltip', () => {
     fireEvent.click(document.querySelector('.ant-tooltip-close-icon'));
     expect(onClose).toHaveBeenCalled();
 
+    await waitFakeTimer();
+    expect(container.querySelector('.ant-tooltip-open')).toBeNull();
+  });
+
+  it('close icon should work correctly for open', async () => {
+    const Demo = () => {
+      const [open, setOpen] = useState(true);
+      return (
+        <Tooltip
+          title="This is prompt text"
+          open={open}
+          closeIcon={true}
+          onClose={() => {
+            setOpen(false);
+          }}
+        >
+          <button id="button">Button</button>
+        </Tooltip>
+      );
+    };
+    const { container } = render(<Demo />);
+
+    // tooltip is open by default
+    expect(container.querySelector('.ant-tooltip-open')).not.toBeNull();
+
+    // click close icon => tooltip close
+    const closeIconElement = document.querySelector('.ant-tooltip-close-icon');
+    fireEvent.click(closeIconElement!);
+    await waitFakeTimer();
+    expect(container.querySelector('.ant-tooltip-open')).toBeNull();
+
+    // mouse enter div => tooltip is still closed
+    const buttonElement = container.querySelector('#button');
+    fireEvent.mouseEnter(buttonElement!);
+    await waitFakeTimer();
+    expect(container.querySelector('.ant-tooltip-open')).toBeNull();
+  });
+
+  it('close icon should work correctly for visible', async () => {
+    const Demo = () => {
+      const [visible, setVisible] = useState(true);
+      return (
+        <Tooltip
+          title="This is prompt text"
+          visible={visible}
+          closeIcon={true}
+          onClose={() => {
+            setVisible(false);
+          }}
+        >
+          <button id="button">Button</button>
+        </Tooltip>
+      );
+    };
+    const { container } = render(<Demo />);
+
+    // tooltip is open by default
+    expect(container.querySelector('.ant-tooltip-open')).not.toBeNull();
+
+    // click close icon => tooltip close
+    const closeIconElement = document.querySelector('.ant-tooltip-close-icon');
+    fireEvent.click(closeIconElement!);
+    await waitFakeTimer();
+    expect(container.querySelector('.ant-tooltip-open')).toBeNull();
+
+    // mouse enter div => tooltip is still closed
+    const buttonElement = container.querySelector('#button');
+    fireEvent.mouseEnter(buttonElement!);
     await waitFakeTimer();
     expect(container.querySelector('.ant-tooltip-open')).toBeNull();
   });

--- a/packages/design/src/tooltip/demo/close-icon.tsx
+++ b/packages/design/src/tooltip/demo/close-icon.tsx
@@ -1,40 +1,46 @@
-import { Space, Tooltip, Button } from '@oceanbase/design';
-import { CloseCircleOutlined } from '@oceanbase/icons';
+import { Button, Space, Tooltip, message } from '@oceanbase/design';
+import { CloseCircleOutlined, ReloadOutlined, SyncOutlined } from '@oceanbase/icons';
 import React, { useState } from 'react';
 
 const App: React.FC = () => {
-  const [open, setOpen] = useState(true);
-  const log = (e: React.MouseEvent<HTMLElement>) => {
-    console.log(e);
-  };
+  const [open1, setOpen1] = useState(true);
+  const [open2, setOpen2] = useState(true);
 
   return (
-    <Space>
-      <Tooltip title="This is prompt text" closeIcon={true}>
-        <Button>Default Close Tooltip</Button>
-      </Tooltip>
-
+    <Space size={24}>
       <Tooltip
         title="This is prompt text"
-        open={open}
+        open={open1}
         closeIcon={true}
         onClose={() => {
-          setOpen(false);
-        }}
-        onOpenChange={v => {
-          setOpen(v);
+          setOpen1(false);
+          message.success('Default close icon is clicked');
         }}
       >
-        <Button>Set open</Button>
+        <Button>Default close icon</Button>
       </Tooltip>
       <Tooltip
-        title="This is prompt text This is prompt text This is prompt text This is prompt text"
+        title="This is prompt text"
+        open={open2}
         closeIcon={<CloseCircleOutlined />}
-        onClose={log}
+        onClose={() => {
+          setOpen2(false);
+          message.success('Custom close icon is clicked');
+        }}
       >
-        <Button>Customize closeIcon</Button>
+        <Button>Custom close icon</Button>
       </Tooltip>
+      <Button
+        icon={<ReloadOutlined />}
+        onClick={() => {
+          setOpen1(true);
+          setOpen2(true);
+        }}
+      >
+        Reset
+      </Button>
     </Space>
   );
 };
+
 export default App;


### PR DESCRIPTION
| Before | After |
| :--- | :--- |
| ![2023-10-29 17-00-24 2023-10-29 17_01_18](https://github.com/oceanbase/oceanbase-design/assets/14918822/a9bbb1b1-9d28-400e-a19f-818703ae903b)  |  ![2023-10-29 16-57-00 2023-10-29 16_58_10](https://github.com/oceanbase/oceanbase-design/assets/14918822/c8d854b7-ed42-4d8f-9684-a1dc3995f224) |

## Tests

- [x] close icon should work correctly for `open`
- [x] close icon should work correctly for `visible`