### PR TITLE
fix(codemod): path => targetPath to avoid duplicate name when prettier

### DIFF
--- a/packages/codemod/bin/cli.js
+++ b/packages/codemod/bin/cli.js
@@ -291,9 +291,9 @@ async function bootstrap() {
     console.log('[Prettier] format files running...');
     try {
       const isDir = isDirectory.sync(dir);
-      const path = isDir ? path.join(dir, '**/*.{js,jsx,ts,tsx,d.ts}') : dir;
+      const targetPath = isDir ? path.join(dir, '**/*.{js,jsx,ts,tsx,d.ts}') : dir;
       const npxCommand = commandExistsSync('tnpx') ? 'tnpx' : 'npx';
-      await execa(npxCommand, ['prettier', '--write', path], { stdio: 'inherit' });
+      await execa(npxCommand, ['prettier', '--write', targetPath], { stdio: 'inherit' });
       console.log('\n[Prettier] format files completed!\n');
     } catch (err) {
       console.log('\n[Prettier] format files failed, please format it by yourself.\n', err);


### PR DESCRIPTION
![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/9641d9c6-ecf8-4c87-b0ac-6207cafe06a4)
