### PR TITLE
fix(codemod): includes => more match conditions for tokenParse

### DIFF
--- a/packages/codemod/transforms/__testfixtures__/style-to-token/function-component.input.js
+++ b/packages/codemod/transforms/__testfixtures__/style-to-token/function-component.input.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Alert, Button } from '@oceanbase/design';
+import { Alert, Button, Tooltip } from '@oceanbase/design';
 
 const Demo = () => {
   return (
     <div>
       <Alert style={{ color: 'rgba(0, 0, 0, 0.85)', background: 'rgba(0, 0, 0,0.65)', backgroundColor: 'rgba(0,0,0,0.45)', border: '1px solid #d9d9d9' }} />
-      <Button style={{ color: '#1890ff', background: '#52c41a', backgroundColor: '#faad14', borderColor: '#ff4D4F', scrollbarColor: '#ffffff' }}></Button>
-      <div color="#fafafa" border="1px solid #fafafa" />
+      <Button style={{ color: '#1890ff', background: '#52c41a', backgroundColor: '#faad14', borderColor: '#ff4D4F' }}></Button>
+      <Tooltip color="#ffffff" backgroundColor="#fff1f0" borderColor="#fafafa" border="1px solid #fafafa" />
     </div>
   );
 };

--- a/packages/codemod/transforms/__testfixtures__/style-to-token/function-component.output.js
+++ b/packages/codemod/transforms/__testfixtures__/style-to-token/function-component.output.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import { Alert, Button, theme } from '@oceanbase/design';
+import { Alert, Button, theme, Tooltip } from '@oceanbase/design';
 
 const Demo = () => {
   const { token } = theme.useToken();
   return (
     (<div>
       <Alert style={{ color: token.colorText, background: token.colorTextSecondary, backgroundColor: token.colorTextTertiary, border: `1px solid ${token.colorBorder}` }} />
-      <Button style={{ color: token.colorInfo, background: token.colorSuccess, backgroundColor: token.colorWarning, borderColor: token.colorError, scrollbarColor: token.colorBgContainer }}></Button>
-      <div color={token.colorBgLayout} border={`1px solid ${token.colorBgLayout}`} />
+      <Button style={{ color: token.colorInfo, background: token.colorSuccess, backgroundColor: token.colorWarning, borderColor: token.colorError }}></Button>
+      <Tooltip color={token.colorBgContainer} backgroundColor="#fff1f0" borderColor={token.colorBgLayout} border={`1px solid ${token.colorBgLayout}`} />
     </div>)
   );
 };

--- a/packages/codemod/transforms/utils/token.js
+++ b/packages/codemod/transforms/utils/token.js
@@ -14,7 +14,6 @@ const TOKEN_MAP = {
   '#bfbfbf': 'colorBorder',
   '#f0f2f5': 'colorBgLayout',
   '#fafafa': 'colorBgLayout',
-  // priority should be #ffffff > #fff to avoid bad case: '#ffffff' => `${token.colorBgContainer}fff`
   '#ffffff': 'colorBgContainer',
   '#fff': 'colorBgContainer',
   'rgba(0,0,0,0.85)': 'colorText',
@@ -36,7 +35,7 @@ const TOKEN_MAP = {
   '#F8FAFE': 'colorFillQuaternary',
 };
 
-const TOKEN_MAP_KEYS = Object.keys(TOKEN_MAP);
+const TOKEN_MAP_KEYS = Object.keys(TOKEN_MAP).map(item => formatValue(item));
 
 function customTrim(str) {
   return str?.replace(/(\s)*([,\(\)])(\s)*/g, '$2');
@@ -48,7 +47,13 @@ function formatValue(value) {
 
 function tokenParse(value) {
   const formattedValue = formatValue(value);
-  const key = TOKEN_MAP_KEYS.find(item => formattedValue.includes(item));
+  const key = TOKEN_MAP_KEYS.find(
+    item =>
+      formattedValue.endsWith(item) ||
+      formattedValue.includes(`${item} `) ||
+      formattedValue.includes(`${item}, `) ||
+      formattedValue.includes(`${item},`)
+  );
   return {
     key,
     token: TOKEN_MAP[key],


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [x] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/670bb7a0-9a3c-4878-9840-db1c6edd7e04)

- includes => more match conditions for `tokenParse`:

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  🐞 Fix incorrect rewritten token resulted by loose style match condition. [#238](https://github.com/oceanbase/oceanbase-design/pull/238)       |
| 🇨🇳 Chinese | 🐞 修复样式匹配规则不严谨导致 token 改写错误的问题。[#238](https://github.com/oceanbase/oceanbase-design/pull/238)          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
