### PR TITLE
fix(codemod): should not transform when specific file is not .less

### DIFF
--- a/packages/codemod/transforms/less-to-token.js
+++ b/packages/codemod/transforms/less-to-token.js
@@ -18,7 +18,7 @@ const findAllLessFiles = dir => {
     files.forEach(file => {
       const filePath = path.join(dir, file);
       if (isDirectory.sync(filePath)) {
-        if (filePath.includes('.umi')) {
+        if (filePath.includes('.umi') || filePath.includes('.umi-production')) {
           return;
         }
         lessFiles.push(...findAllLessFiles(filePath));
@@ -26,7 +26,7 @@ const findAllLessFiles = dir => {
         lessFiles.push(filePath);
       }
     });
-  } else {
+  } else if (dir.endsWith('.less')) {
     lessFiles.push(dir);
   }
   return lessFiles;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [x] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  🐞 Fix `less-to-style` should not transform single non less file. [#242](https://github.com/oceanbase/oceanbase-design/pull/242)        |
| 🇨🇳 Chinese |  🐞 修复 `less-to-style` 不应该转换单个非 less 文件的问题。[#242](https://github.com/oceanbase/oceanbase-design/pull/242)         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
