### PR TITLE
fix(design): seed token should filter colorBgBase, colorTextBase and colorLink to make dark theme work correctly

### DIFF
--- a/packages/design/src/config-provider/index.tsx
+++ b/packages/design/src/config-provider/index.tsx
@@ -65,6 +65,8 @@ const ConfigProvider = ({
   const parentContext = React.useContext<ConfigConsumerProps>(AntConfigProvider.ConfigContext);
   const parentExtendedContext =
     React.useContext<ExtendedConfigConsumerProps>(ExtendedConfigContext);
+  const mergedTheme = merge(parentContext.theme, theme);
+  const currentTheme = mergedTheme.isDark ? darkTheme : defaultTheme;
   return (
     <AntConfigProvider
       spin={merge(parentContext.spin, spin)}
@@ -77,19 +79,13 @@ const ConfigProvider = ({
       )}
       theme={merge(
         {
-          token: theme?.isDark
-            ? {
-                ...defaultSeed,
-                ...darkTheme.token,
-              }
-            : {
-                ...defaultSeed,
-                ...defaultTheme.token,
-              },
-          components: theme?.isDark ? darkTheme.components : defaultTheme.components,
+          token: {
+            ...defaultSeed,
+            ...currentTheme.token,
+          },
+          components: currentTheme.components,
         },
-        parentContext.theme,
-        theme
+        mergedTheme
       )}
       {...restProps}
     >

--- a/packages/design/src/theme/index.ts
+++ b/packages/design/src/theme/index.ts
@@ -7,7 +7,11 @@ import defaultTheme from './default';
 export * from 'antd/lib/theme/internal';
 export * from 'antd/lib/theme';
 
-const seedTokenKeys = Object.keys(theme.defaultSeed);
+const seedTokenKeys = Object.keys(theme.defaultSeed).filter(
+  // should filter special seed token
+  // ref: https://github.com/ant-design/ant-design/blob/master/components/theme/themes/seed.ts#L32
+  key => !['colorBgBase', 'colorTextBase', 'colorLink'].includes(key)
+);
 const seedToken = pick(defaultTheme.token, seedTokenKeys) as SeedToken;
 
 const defaultSeed = {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- Fix #272.

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

- ref: https://github.com/ant-design/ant-design/blob/master/components/theme/themes/seed.ts#L32

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Not needed         |
| 🇨🇳 Chinese |  Not needed         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
