### PR TITLE
chore(docs): Add changelog for @oceanbase/design@0.2.28, @oceanbase/ui@0.2.29

### DIFF
--- a/.github/workflows/release-helper.yml
+++ b/.github/workflows/release-helper.yml
@@ -31,5 +31,5 @@ jobs:
           dingding-token: ${{ secrets.DINGDING_BOT_TOKEN }}
           dingding-message-title: '# 🎉 OceanBase Design 新版本发布 🎉'
           dingding-message-poster: 'https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*zx7LTI_ECSAAAAAAAAAAAABkARQnAQ'
-          dingding-message-footer: '🚀 前往 [**OceanBase Design 官网**](https://design.oceanbase.com) 查看示例和用法 \n\n 🚀 前往 [**OceanBase Design Releases**](https://github.com/oceanbase/oceanbase-design/releases) 查看更新日志 \n\n 🚀 使用 [**OceanBase Codemod**](https://github.com/oceanbase/oceanbase-design/tree/master/packages/codemod) 可一键迁移'
+          dingding-message-footer: '🚀 前往 [**OceanBase Design 官网**](https://design.oceanbase.com) 查看示例和用法 \n 🚀 前往 [**OceanBase Design Releases**](https://github.com/oceanbase/oceanbase-design/releases) 查看更新日志 \n 🚀 使用 [**OceanBase Codemod**](https://github.com/oceanbase/oceanbase-design/tree/master/packages/codemod) 进行一键迁移'
           dingding-message-prettier: true

--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,13 @@ group: 基础组件
 
 ---
 
+## 0.2.28
+
+`2023-11-14`
+
+- 🌈 新增主题预览和编辑器，便于主题调试和预览。[#287](https://github.com/oceanbase/oceanbase-design/pull/287)
+- 💄 优化 Drawer 的标题、内容区和页脚样式，以符合设计规范。[#283](https://github.com/oceanbase/oceanbase-design/pull/283) [@Vanleehao](https://github.com/Vanleehao)
+
 ## 0.2.27
 
 `2023-11-09`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,13 @@ group: 业务组件
 
 ---
 
+## 0.2.29
+
+`2023-11-14`
+
+- 🆕 Login 新增 `isMobile`` 属性，用于开启移动端样式。[#288](https://github.com/oceanbase/oceanbase-design/pull/288)
+- 🔨 ContentWithQuestion 样式方案从 less 改造为 CSS-in-JS，以支持动态主题。[#283](https://github.com/oceanbase/oceanbase-design/pull/283) [@Vanleehao](https://github.com/Vanleehao)
+
 ## 0.2.28
 
 `2023-11-09`


### PR DESCRIPTION
## @oceanbase/design@0.2.28

`2023-11-14`

- 🌈 新增主题预览和编辑器，便于主题调试和预览。[#287](https://github.com/oceanbase/oceanbase-design/pull/287)
- 💄 优化 Drawer 的标题、内容区和页脚样式，以符合设计规范。[#283](https://github.com/oceanbase/oceanbase-design/pull/283) [@Vanleehao](https://github.com/Vanleehao)

## @oceanbase/ui@0.2.29

`2023-11-14`

- 🆕 Login 新增 `isMobile`` 属性，用于开启移动端样式。[#288](https://github.com/oceanbase/oceanbase-design/pull/288)
- 🔨 ContentWithQuestion 样式方案从 less 改造为 CSS-in-JS，以支持动态主题。[#283](https://github.com/oceanbase/oceanbase-design/pull/283) [@Vanleehao](https://github.com/Vanleehao)
