### PR TITLE
improve(design): Set Form requiredMark to optional by default

### DIFF
--- a/packages/design/src/config-provider/index.tsx
+++ b/packages/design/src/config-provider/index.tsx
@@ -110,8 +110,7 @@ const ConfigProvider = ({
 ConfigProvider.ConfigContext =
   AntConfigProvider.ConfigContext as React.Context<ConfigConsumerProps>;
 ConfigProvider.ExtendedConfigContext = ExtendedConfigContext;
-// SizeContext is deprecated
-// ConfigProvider.SizeContext = AntConfigProvider.SizeContext;
+ConfigProvider.SizeContext = AntConfigProvider.SizeContext;
 ConfigProvider.config = AntConfigProvider.config;
 ConfigProvider.useConfig = AntConfigProvider.useConfig;
 

--- a/packages/design/src/form/demo/form-item-tooltip.tsx
+++ b/packages/design/src/form/demo/form-item-tooltip.tsx
@@ -1,4 +1,4 @@
-import { Button, Form, Input, message } from '@oceanbase/design';
+import { Button, Checkbox, Form, Input, message } from '@oceanbase/design';
 import React from 'react';
 
 const onFinish = (values: any) => {
@@ -21,11 +21,25 @@ const App: React.FC = () => (
       label="Username"
       name="username"
       rules={[{ required: true, message: 'Please input your username!' }]}
+      tooltip={{
+        title: 'This is username',
+      }}
     >
       <Input />
     </Form.Item>
-    <Form.Item label="Address" name="address">
-      <Input />
+    <Form.Item
+      label="Password"
+      name="password"
+      rules={[{ required: true, message: 'Please input your password!' }]}
+      tooltip={{
+        type: 'light',
+        title: 'This is password',
+      }}
+    >
+      <Input.Password autoComplete="new-password" />
+    </Form.Item>
+    <Form.Item name="remember" valuePropName="checked" wrapperCol={{ offset: 8, span: 16 }}>
+      <Checkbox>Remember me</Checkbox>
     </Form.Item>
     <Form.Item wrapperCol={{ offset: 6, span: 10 }}>
       <Button type="primary" htmlType="submit">

--- a/packages/design/src/form/index.md
+++ b/packages/design/src/form/index.md
@@ -7,12 +7,19 @@ nav:
 
 - 🔥 完全兼容 antd [Form](https://ant.design/components/form-cn) 的能力和 API，可无缝切换。
 - 💄 定制主题和样式，符合 OceanBase Design 设计规范。
+- 📢 Form `requiredMark` 默认为 `optional` 可选样式。
 - 🆕 Form.Item `tooltip` 新增 `type` 属性，支持不同类型的 Tooltip 提示，详见 [Tooltip 文档](/components/Tooltip)。
 
 ## 代码演示
 
-<code src="./demo/basic.tsx" title="基本"></code>
+<code src="./demo/basic.tsx" title="基本" description="默认为可选样式"></code>
+
+<code src="./demo/form-item-tooltip.tsx" title="配置提示信息"></code>
 
 ## API
 
-- 详见 antd Form 文档: https://ant.design/components/form-cn
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| :-- | :-- | :-- | :-- | :-- |
+| requiredMark | 设置必选或可选样式。此为 Form 配置，Form.Item 无法单独配置 | boolean \| `optional` \| ((label: ReactNode, info: { required: boolean }) => ReactNode) | `optional` | - |
+
+- 更多 API 详见 antd Form 文档: https://ant.design/components/form-cn

--- a/packages/design/src/form/index.ts
+++ b/packages/design/src/form/index.ts
@@ -1,9 +1,0 @@
-import { Form } from 'antd';
-import Item from './FormItem';
-
-export * from 'antd/es/form';
-export type { FormItemProps } from './FormItem';
-
-Form.Item = Item;
-
-export default Form;

--- a/packages/design/src/form/index.tsx
+++ b/packages/design/src/form/index.tsx
@@ -1,0 +1,35 @@
+import { Form as AntForm } from 'antd';
+import type { FormProps as AntFormProps } from 'antd/es/form';
+import Item from './FormItem';
+
+export * from 'antd/es/form';
+export type { FormItemProps } from './FormItem';
+
+export type FormProps = AntFormProps;
+
+type CompoundedComponent = React.FC<FormProps> & {
+  Item: typeof Item;
+  List: typeof AntForm.List;
+  ErrorList: typeof AntForm.ErrorList;
+  useForm: typeof AntForm.useForm;
+  useFormInstance: typeof AntForm.useFormInstance;
+  useWatch: typeof AntForm.useWatch;
+  Provider: typeof AntForm.Provider;
+  create: typeof AntForm.create;
+};
+
+const Form: CompoundedComponent = props => {
+  // @ts-ignore
+  return <AntForm requiredMark="optional" {...props} />;
+};
+
+Form.Item = Item;
+Form.List = AntForm.List;
+Form.ErrorList = AntForm.ErrorList;
+Form.useForm = AntForm.useForm;
+Form.useFormInstance = AntForm.useFormInstance;
+Form.useWatch = AntForm.useWatch;
+Form.Provider = AntForm.Provider;
+Form.create = AntForm.create;
+
+export default Form;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [x] Other (Component behavior adjustment)

### 🔗 Related issue link

- Fix #309

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/2d403172-a73c-4cd9-9d7f-14f51896fe8a)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  📢 Set Form `requiredMark` to `optional` by default.         |
| 🇨🇳 Chinese |  📢 Form `requiredMark` 默认为 `optional` 可选样式。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
