### PR TITLE
improve(ui): Customize FooterToolbar style to follow design guide

### DIFF
--- a/packages/ui/src/FooterToolbar/index.tsx
+++ b/packages/ui/src/FooterToolbar/index.tsx
@@ -1,15 +1,24 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { FooterToolbar as AntFooterToolbar } from '@ant-design/pro-components';
 import type { FooterToolbarProps as AntFooterToolbarProps } from '@ant-design/pro-layout/es/components/FooterToolbar';
+import { ConfigProvider } from '@oceanbase/design';
+import useStyle from './style';
 
 export type FooterToolbarProps = AntFooterToolbarProps;
 
 const FooterToolbar: React.FC<FooterToolbarProps> = ({
   // render footer under parent instead of body by default
   portalDom = false,
+  prefixCls: customizePrefixCls,
   ...restProps
 }) => {
-  return <AntFooterToolbar portalDom={portalDom} {...restProps} />;
+  const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
+  const prefixCls = getPrefixCls('pro-footer-bar', customizePrefixCls);
+  const { wrapSSR } = useStyle(prefixCls);
+
+  return wrapSSR(
+    <AntFooterToolbar portalDom={portalDom} prefixCls={customizePrefixCls} {...restProps} />
+  );
 };
 
 export default FooterToolbar;

--- a/packages/ui/src/FooterToolbar/style/index.ts
+++ b/packages/ui/src/FooterToolbar/style/index.ts
@@ -1,0 +1,39 @@
+import type { CSSObject } from '@ant-design/cssinjs';
+import type { FooterToolBarToken } from '@ant-design/pro-layout/es/components/FooterToolbar/style';
+import type { GenerateStyle } from '@oceanbase/design/es/theme';
+import { genComponentStyleHook } from '../../_util/genComponentStyleHook';
+
+export const genFooterToolbarStyle: GenerateStyle<FooterToolBarToken> = (
+  token: FooterToolBarToken
+): CSSObject => {
+  const { antCls, componentCls, colorBgBase, borderRadius, boxShadowSecondary, controlHeightLG } =
+    token;
+  const height = controlHeightLG;
+  const lineHeight = `${controlHeightLG}px`;
+
+  return {
+    [`${componentCls}`]: {
+      width: '100%',
+      backgroundColor: colorBgBase,
+      borderRadius: borderRadius,
+      boxShadow: boxShadowSecondary,
+      borderBlockStart: 'none',
+      // 设置底部操作栏的组件高度
+      [`${antCls}-btn:not(${antCls}-input-search-button)`]: {
+        minWidth: 68,
+        height,
+      },
+      [`${antCls}-radio-button-wrapper`]: {
+        height,
+        lineHeight,
+      },
+    },
+  };
+};
+
+export default (prefixCls: string) => {
+  const useStyle = genComponentStyleHook('FooterToolbar', token => {
+    return [genFooterToolbarStyle(token as FooterToolBarToken)];
+  });
+  return useStyle(prefixCls);
+};

--- a/packages/ui/src/PageContainer/style/index.ts
+++ b/packages/ui/src/PageContainer/style/index.ts
@@ -2,6 +2,7 @@ import type { CSSObject } from '@ant-design/cssinjs';
 import type { PageContainerToken } from '@ant-design/pro-layout/es/components/PageContainer/style';
 import type { GenerateStyle } from '@oceanbase/design/es/theme';
 import { genComponentStyleHook } from '../../_util/genComponentStyleHook';
+import { genFooterToolbarStyle } from '../../FooterToolbar/style';
 
 export const genPageContainerStyle: GenerateStyle<PageContainerToken> = (
   token: PageContainerToken
@@ -86,22 +87,10 @@ export const genPageContainerStyle: GenerateStyle<PageContainerToken> = (
     [`${componentCls}-with-footer `]: {
       paddingBottom: 64,
     },
-    [`${proComponentsCls}-footer-bar`]: {
-      width: '100%',
-      backgroundColor: colorBgBase,
-      borderRadius: borderRadius,
-      boxShadow: boxShadowSecondary,
-      borderBlockStart: 'none',
-      // 设置底部操作栏的组件高度
-      [`${antCls}-btn:not(${antCls}-input-search-button)`]: {
-        minWidth: 68,
-        height,
-      },
-      [`${antCls}-radio-button-wrapper`]: {
-        height,
-        lineHeight,
-      },
-    },
+    ...(genFooterToolbarStyle({
+      ...token,
+      componentCls: `${proComponentsCls}-footer-bar`,
+    }) as object),
   };
 };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/b71d3614-cd2b-49a6-b48f-70e8e8ff1041)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 💄 Customize FooterToolbar style to follow OceanBase Design guide.          |
| 🇨🇳 Chinese |  💄 定制 FooterToolbar 样式，以符合 OceanBase Design 设计规范。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
