### PR TITLE
fix(charts): tooltip cannot be closed for Line, Area and DualAxes

### DIFF
--- a/packages/charts/src/hooks/useTooltipScrollable.ts
+++ b/packages/charts/src/hooks/useTooltipScrollable.ts
@@ -6,26 +6,30 @@ export interface Tooltip extends AntTooltip {
 }
 
 export default (tooltip?: false | Tooltip, height?: number) => {
-  if (!tooltip) {
-    return false;
-  }
-  const { scrollable, domStyles, ...restTooltip } = tooltip;
-  return scrollable
-    ? {
-        follow: true,
-        shared: true,
-        enterable: true,
-        // 允许鼠标滑入 tooltip 会导致框选很难选中区间，因此加大鼠标和 tooltip 之间的间距，以缓解该问题
-        offset: 20,
-        ...restTooltip,
-        domStyles: {
-          ...domStyles,
-          'g2-tooltip': {
-            maxHeight: `${height}px`,
-            overflow: 'auto',
-            ...domStyles?.['g2-tooltip'],
+  if (typeof tooltip === 'object') {
+    const { scrollable, domStyles, ...restTooltip } = tooltip || {};
+    return scrollable
+      ? {
+          follow: true,
+          shared: true,
+          enterable: true,
+          // 允许鼠标滑入 tooltip 会导致框选很难选中区间，因此加大鼠标和 tooltip 之间的间距，以缓解该问题
+          offset: 20,
+          ...restTooltip,
+          domStyles: {
+            ...domStyles,
+            'g2-tooltip': {
+              maxHeight: `${height}px`,
+              overflow: 'auto',
+              ...domStyles?.['g2-tooltip'],
+            },
           },
-        },
-      }
-    : tooltip;
+        }
+      : tooltip;
+  }
+  // when tooltip is undefined, should return {} to ensure that crosshairs could display normally
+  if (tooltip === undefined) {
+    return {};
+  }
+  return tooltip;
 };

--- a/packages/charts/src/hooks/useTooltipScrollable.ts
+++ b/packages/charts/src/hooks/useTooltipScrollable.ts
@@ -7,7 +7,7 @@ export interface Tooltip extends AntTooltip {
 
 export default (tooltip?: false | Tooltip, height?: number) => {
   if (!tooltip) {
-    return {};
+    return false;
   }
   const { scrollable, domStyles, ...restTooltip } = tooltip;
   return scrollable


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [x] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)


### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

图表的 tooltip 配置如果返回一个空对象，仍然会展示tooltip，需要改成 false 才会关闭对应配置

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     🐞 Fix `tooltip` cannot be closed for Line, Area and DualAxes      |
| 🇨🇳 Chinese |  🐞 修复折线图、面积图和双轴图的 `tooltip` 无法关闭的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
