### PR TITLE
fix(design): Tag font-size not correct

### DIFF
--- a/packages/design/src/tag/style/index.ts
+++ b/packages/design/src/tag/style/index.ts
@@ -41,7 +41,9 @@ export const genTagStyle: GenerateStyle<TagToken> = (token: TagToken): CSSObject
   const { componentCls } = token;
   return {
     [`${componentCls}`]: {
+      paddingInline: token.paddingXS,
       borderColor: getTagBorderColor(token.colorBorder),
+      fontSize: token.fontSizeSM,
       ['&-ellipsis']: {
         maxWidth: '100%',
         textOverflow: 'ellipsis',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None.

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

| Before (font-size: 14px) | After (font-size: 12px) |
| :--- | :--- |
| ![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/729afaaf-4396-4800-8695-d1113d83da9f) | ![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/91854149-f4e9-418b-8775-25a27996a5a8) |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   🐞 Fix Tag `font-size` not correct.         |
| 🇨🇳 Chinese |  🐞 修复 Tag 的字体大小不正确的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
