### PR TITLE
fix(design): ConfigProvider hideOnSinglePage change to false by default

### DIFF
--- a/packages/design/src/config-provider/__tests__/hideOnSinglePage.test.tsx
+++ b/packages/design/src/config-provider/__tests__/hideOnSinglePage.test.tsx
@@ -3,26 +3,26 @@ import { render } from '@testing-library/react';
 import { ConfigProvider } from '@oceanbase/design';
 
 describe('ConfigProvider hideOnSinglePage', () => {
-  it('ConfigProvider hideOnSinglePage', () => {
+  it('hideOnSinglePage', () => {
     const Child1 = () => {
       const { hideOnSinglePage } = useContext(ConfigProvider.ExtendedConfigContext);
-      expect(hideOnSinglePage).toBe(true);
+      expect(hideOnSinglePage).toBe(false);
       return <div />;
     };
     const Child2 = () => {
       const { hideOnSinglePage } = useContext(ConfigProvider.ExtendedConfigContext);
-      expect(hideOnSinglePage).toBe(false);
+      expect(hideOnSinglePage).toBe(true);
       return <div />;
     };
     const Child3 = () => {
       const { hideOnSinglePage } = useContext(ConfigProvider.ExtendedConfigContext);
-      expect(hideOnSinglePage).toBe(false);
+      expect(hideOnSinglePage).toBe(true);
       return <div />;
     };
     render(
       <ConfigProvider>
         <Child1 />
-        <ConfigProvider hideOnSinglePage={false}>
+        <ConfigProvider hideOnSinglePage={true}>
           <Child2 />
           <ConfigProvider>
             <Child3 />

--- a/packages/design/src/config-provider/index.tsx
+++ b/packages/design/src/config-provider/index.tsx
@@ -60,7 +60,7 @@ export interface ExtendedConfigConsumerProps {
 
 const ExtendedConfigContext = React.createContext<ExtendedConfigConsumerProps>({
   navigate: undefined,
-  hideOnSinglePage: true,
+  hideOnSinglePage: false,
 });
 
 const { defaultSeed } = themeConfig;
@@ -111,10 +111,11 @@ const ConfigProvider = ({
       <ExtendedConfigContext.Provider
         value={{
           navigate: navigate === undefined ? parentExtendedContext.navigate : navigate,
-          hideOnSinglePage:
-            hideOnSinglePage === undefined
-              ? parentExtendedContext.hideOnSinglePage
-              : hideOnSinglePage,
+          hideOnSinglePage: parentContext.pagination?.showSizeChanger
+            ? false
+            : hideOnSinglePage !== undefined
+              ? hideOnSinglePage
+              : parentExtendedContext.hideOnSinglePage,
         }}
       >
         <StyleProvider {...mergedStyleProviderProps}>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- Ref: #330

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

- 统一去掉分页器会有以下问题
  - 批量操作场景，批量操作栏位于分页器左侧，此时只有一页数据但也不应该去掉分页器。
  - 切换 pageSize 如果达到一页数据，则 pageSize 切换器会被隐藏，无法再切换回去。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | 🐞 ConfigProvider `hideOnSinglePage` 默认值改为 `false`，交由业务侧按需设置，避免统一去掉分页器带来的问题。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
