### PR TITLE
fix(design): Table pagination.hideOnSinglePage should be false when batch operation or pagination.showSizeChanger exist

### DIFF
--- a/packages/design/src/table/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/design/src/table/__tests__/__snapshots__/index.test.tsx.snap
@@ -255,96 +255,12 @@ exports[`Table hideOnSinglePage could be changed 1`] = `
           </div>
         </div>
       </div>
-      <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-right"
-      >
-        <li
-          class="ant-pagination-total-text"
-        >
-          <span />
-        </li>
-        <li
-          aria-disabled="true"
-          class="ant-pagination-prev ant-pagination-disabled"
-          title="Previous Page"
-        >
-          <button
-            class="ant-pagination-item-link"
-            disabled=""
-            tabindex="-1"
-            type="button"
-          >
-            <span
-              aria-label="left"
-              class="anticon anticon-left"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="left"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
-                />
-              </svg>
-            </span>
-          </button>
-        </li>
-        <li
-          class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
-          tabindex="0"
-          title="1"
-        >
-          <a
-            rel="nofollow"
-          >
-            1
-          </a>
-        </li>
-        <li
-          aria-disabled="true"
-          class="ant-pagination-next ant-pagination-disabled"
-          title="Next Page"
-        >
-          <button
-            class="ant-pagination-item-link"
-            disabled=""
-            tabindex="-1"
-            type="button"
-          >
-            <span
-              aria-label="right"
-              class="anticon anticon-right"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="right"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                />
-              </svg>
-            </span>
-          </button>
-        </li>
-      </ul>
     </div>
   </div>
 </div>
 `;
 
-exports[`Table hideOnSinglePage should be true by default 1`] = `
+exports[`Table hideOnSinglePage should be false by default 1`] = `
 <div
   class="ant-table-wrapper"
 >
@@ -599,6 +515,90 @@ exports[`Table hideOnSinglePage should be true by default 1`] = `
           </div>
         </div>
       </div>
+      <ul
+        class="ant-pagination ant-table-pagination ant-table-pagination-right"
+      >
+        <li
+          class="ant-pagination-total-text"
+        >
+          <span />
+        </li>
+        <li
+          aria-disabled="true"
+          class="ant-pagination-prev ant-pagination-disabled"
+          title="Previous Page"
+        >
+          <button
+            class="ant-pagination-item-link"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            <span
+              aria-label="left"
+              class="anticon anticon-left"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="left"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                />
+              </svg>
+            </span>
+          </button>
+        </li>
+        <li
+          class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+          tabindex="0"
+          title="1"
+        >
+          <a
+            rel="nofollow"
+          >
+            1
+          </a>
+        </li>
+        <li
+          aria-disabled="true"
+          class="ant-pagination-next ant-pagination-disabled"
+          title="Next Page"
+        >
+          <button
+            class="ant-pagination-item-link"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            <span
+              aria-label="right"
+              class="anticon anticon-right"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="right"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                />
+              </svg>
+            </span>
+          </button>
+        </li>
+      </ul>
     </div>
   </div>
 </div>

--- a/packages/design/src/table/__tests__/index.test.tsx
+++ b/packages/design/src/table/__tests__/index.test.tsx
@@ -39,9 +39,9 @@ describe('Table', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
-  it('hideOnSinglePage should be true by default', () => {
+  it('hideOnSinglePage should be false by default', () => {
     const { container, asFragment } = render(<TableTest dataSource={dataSource.slice(0, 10)} />);
-    expect(container.querySelector('.ant-pagination')).toBeFalsy();
+    expect(container.querySelector('.ant-pagination')).toBeTruthy();
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
@@ -50,11 +50,11 @@ describe('Table', () => {
       <TableTest
         dataSource={dataSource.slice(0, 10)}
         pagination={{
-          hideOnSinglePage: false,
+          hideOnSinglePage: true,
         }}
       />
     );
-    expect(container.querySelector('.ant-pagination')).toBeTruthy();
+    expect(container.querySelector('.ant-pagination')).toBeFalsy();
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 });

--- a/packages/design/src/table/index.md
+++ b/packages/design/src/table/index.md
@@ -7,7 +7,6 @@ nav:
 
 - 🔥 完全继承 antd [Alert](https://ant.design/components/alert-cn) 的能力和 API，可无缝切换。
 - 💄 定制主题和样式，符合 OceanBase Design 设计规范。
-- 📢 默认开启 `pagination.hideOnSinglePage`，即只有一页数据时会隐藏分页器。
 - 🆕 设置 `column.ellipsis`，开启自动省略，并使用 Tooltip 展示全部内容。
 - 🆕 新增 `批量操作栏`，可配置选中对象、批量操作项等，详见 [API](#api)。
 

--- a/packages/design/src/table/index.tsx
+++ b/packages/design/src/table/index.tsx
@@ -211,11 +211,16 @@ function Table<T>(props: TableProps<T>, ref: React.Ref<Reference>) {
         pagination === false
           ? false
           : {
-              hideOnSinglePage:
-                extendedContext.hideOnSinglePage !== undefined
-                  ? extendedContext.hideOnSinglePage
-                  : true,
               ...pagination,
+              hideOnSinglePage:
+                toolAlertRender ||
+                toolOptionsRender ||
+                toolSelectedContent ||
+                pagination?.showSizeChanger
+                  ? false
+                  : pagination?.hideOnSinglePage !== undefined
+                    ? pagination?.hideOnSinglePage
+                    : extendedContext.hideOnSinglePage,
               showTotal: renderOptionsBar,
             }
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- Ref: #330

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |  🐞 修复 Table 只有一页数据且存在批量操作或 `pageSize` 切换时分页器被隐藏的问题。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
