### PR TITLE
fix(design): List pagination.hideOnSinglePage should be false when pagination.showSizeChanger exist

### DIFF
--- a/packages/design/src/list/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/design/src/list/__tests__/__snapshots__/index.test.tsx.snap
@@ -82,87 +82,7 @@ exports[`List hideOnSinglePage could be changed 1`] = `
   </div>
   <div
     class="ant-list-pagination ant-list-pagination-align-end"
-  >
-    <ul
-      class="ant-pagination"
-    >
-      <li
-        aria-disabled="true"
-        class="ant-pagination-prev ant-pagination-disabled"
-        title="Previous Page"
-      >
-        <button
-          class="ant-pagination-item-link"
-          disabled=""
-          tabindex="-1"
-          type="button"
-        >
-          <span
-            aria-label="left"
-            class="anticon anticon-left"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="left"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
-              />
-            </svg>
-          </span>
-        </button>
-      </li>
-      <li
-        class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
-        tabindex="0"
-        title="1"
-      >
-        <a
-          rel="nofollow"
-        >
-          1
-        </a>
-      </li>
-      <li
-        aria-disabled="true"
-        class="ant-pagination-next ant-pagination-disabled"
-        title="Next Page"
-      >
-        <button
-          class="ant-pagination-item-link"
-          disabled=""
-          tabindex="-1"
-          type="button"
-        >
-          <span
-            aria-label="right"
-            class="anticon anticon-right"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="right"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-              />
-            </svg>
-          </span>
-        </button>
-      </li>
-    </ul>
-  </div>
+  />
 </div>
 `;
 
@@ -248,7 +168,87 @@ exports[`List hideOnSinglePage should be true by default 1`] = `
   </div>
   <div
     class="ant-list-pagination ant-list-pagination-align-end"
-  />
+  >
+    <ul
+      class="ant-pagination"
+    >
+      <li
+        aria-disabled="true"
+        class="ant-pagination-prev ant-pagination-disabled"
+        title="Previous Page"
+      >
+        <button
+          class="ant-pagination-item-link"
+          disabled=""
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            aria-label="left"
+            class="anticon anticon-left"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="left"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+              />
+            </svg>
+          </span>
+        </button>
+      </li>
+      <li
+        class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+        tabindex="0"
+        title="1"
+      >
+        <a
+          rel="nofollow"
+        >
+          1
+        </a>
+      </li>
+      <li
+        aria-disabled="true"
+        class="ant-pagination-next ant-pagination-disabled"
+        title="Next Page"
+      >
+        <button
+          class="ant-pagination-item-link"
+          disabled=""
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            aria-label="right"
+            class="anticon anticon-right"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </button>
+      </li>
+    </ul>
+  </div>
 </div>
 `;
 

--- a/packages/design/src/list/__tests__/index.test.tsx
+++ b/packages/design/src/list/__tests__/index.test.tsx
@@ -33,7 +33,7 @@ describe('List', () => {
 
   it('hideOnSinglePage should be true by default', () => {
     const { container, asFragment } = render(<ListTest dataSource={dataSource.slice(0, 10)} />);
-    expect(container.querySelector('.ant-pagination')).toBeFalsy();
+    expect(container.querySelector('.ant-pagination')).toBeTruthy();
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
@@ -42,11 +42,11 @@ describe('List', () => {
       <ListTest
         dataSource={dataSource.slice(0, 10)}
         pagination={{
-          hideOnSinglePage: false,
+          hideOnSinglePage: true,
         }}
       />
     );
-    expect(container.querySelector('.ant-pagination')).toBeTruthy();
+    expect(container.querySelector('.ant-pagination')).toBeFalsy();
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 });

--- a/packages/design/src/list/index.md
+++ b/packages/design/src/list/index.md
@@ -7,7 +7,6 @@ nav:
 
 - 🔥 完全继承 antd [List](https://ant.design/components/list-cn) 的能力和 API，可无缝切换。
 - 💄 定制主题和样式，符合 OceanBase Design 设计规范。
-- 📢 默认开启 `pagination.hideOnSinglePage`，即只有一页数据时会隐藏分页器。
 
 ## 代码演示
 

--- a/packages/design/src/list/index.tsx
+++ b/packages/design/src/list/index.tsx
@@ -15,11 +15,12 @@ function List<T>({ pagination, ...restProps }: ListProps<T>) {
       pagination={
         typeof pagination === 'object'
           ? {
-              hideOnSinglePage:
-                extendedContext.hideOnSinglePage !== undefined
-                  ? extendedContext.hideOnSinglePage
-                  : true,
               ...pagination,
+              hideOnSinglePage: pagination?.showSizeChanger
+                ? false
+                : pagination?.hideOnSinglePage !== undefined
+                  ? pagination?.hideOnSinglePage
+                  : extendedContext.hideOnSinglePage,
             }
           : pagination
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- Ref: #330

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  -         |
| 🇨🇳 Chinese | 🐞 修复 List 只有一页数据且存在 `pageSize` 切换时分页器被隐藏的问题。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
