### PR TITLE
chore(docs): Add changelog for @oceanbase/design@0.2.33, @oceanbase/ui@0.2.34 and @oceanbase/charts@0.2.20

### DIFF
--- a/docs/charts/charts-CHANGELOG.md
+++ b/docs/charts/charts-CHANGELOG.md
@@ -8,6 +8,19 @@ group: 可视化图表
 
 ---
 
+## 0.2.20
+
+`2023-12-28`
+
+- Stat
+  - 🆕 新增 `chartConfig` 属性，用于配置图表。[#384](https://github.com/oceanbase/oceanbase-design/pull/384)
+  - 💄 优化样式，包括限制 `title` 字体最小为 12px、限制 `value` 字体最大为 40px 以及优化内容居中对齐样式。[#385](https://github.com/oceanbase/oceanbase-design/pull/385)
+  - 💄 容器高度小于 `72px` 时，图表的高度比例从 `0.5` 减小为 `0.25`。[#387](https://github.com/oceanbase/oceanbase-design/pull/387)
+- Liquid
+  - 🆕 新增 `containerStyle`、`percentStyle` 和 `titleStyle` 属性，分别用于设置容器样式、百分比样式和标题样式。[#374](https://github.com/oceanbase/oceanbase-design/pull/374)
+  - 🐞 修复未设置图表高度时水波无法渲染的问题。[#383](https://github.com/oceanbase/oceanbase-design/pull/383)
+- 💄 Column 适配 X 时序轴，自动对数据进行排序，并关闭自动美化避免两侧留白。[#382](https://github.com/oceanbase/oceanbase-design/pull/382)
+
 ## 0.2.19
 
 `2023-12-14`

--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,15 @@ group: 基础组件
 
 ---
 
+## 0.2.33
+
+`2023-12-28`
+
+- 🐞 ConfigProvider `hideOnSinglePage` 默认值改为 `false`，避免统一去掉分页器带来的问题。[#388](https://github.com/oceanbase/oceanbase-design/pull/388)
+- 🐞 修复 Table 只有一页数据且存在批量操作或 `pageSize` 切换时分页器被隐藏的问题。[#389](https://github.com/oceanbase/oceanbase-design/pull/389)
+- 🐞 修复 List 只有一页数据且存在 `pageSize` 切换时分页器被隐藏的问题。[#390](https://github.com/oceanbase/oceanbase-design/pull/390)
+- 💄 更新 Design Token，新增 `fontHeight`、`fontHeightLG` 和 `fontHeightSM` less 变量。[#381](https://github.com/oceanbase/oceanbase-design/pull/381)
+
 ## 0.2.32
 
 `2023-12-14`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,15 @@ group: 业务组件
 
 ---
 
+## 0.2.34
+
+`2023-12-28`
+
+- IconFont
+  - 🐞 修复 IconFont 会请求不必要 JS 资源的问题。[#375](https://github.com/oceanbase/oceanbase-design/pull/375)
+  - 📢 将 IconFont 组件标记为即将废弃，不推荐使用。[#375](https://github.com/oceanbase/oceanbase-design/pull/375)
+- 💄 优化 TagSelect 的 `disabled` 和 `hover` 样式，并将固定样式改造为 Design Token。[#373](https://github.com/oceanbase/oceanbase-design/pull/373)
+
 ## 0.2.33
 
 `2023-12-14`

--- a/packages/design/src/list/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/design/src/list/__tests__/__snapshots__/index.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`List hideOnSinglePage could be changed 1`] = `
 </div>
 `;
 
-exports[`List hideOnSinglePage should be true by default 1`] = `
+exports[`List hideOnSinglePage should be false by default 1`] = `
 <div
   class="ant-list ant-list-split ant-list-bordered ant-list-something-after-last-item"
 >

--- a/packages/design/src/list/__tests__/index.test.tsx
+++ b/packages/design/src/list/__tests__/index.test.tsx
@@ -31,7 +31,7 @@ describe('List', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
-  it('hideOnSinglePage should be true by default', () => {
+  it('hideOnSinglePage should be false by default', () => {
     const { container, asFragment } = render(<ListTest dataSource={dataSource.slice(0, 10)} />);
     expect(container.querySelector('.ant-pagination')).toBeTruthy();
     expect(asFragment().firstChild).toMatchSnapshot();


### PR DESCRIPTION
## @oceanbase/design@0.2.33

## 0.2.33

`2023-12-28`

- 🐞 ConfigProvider `hideOnSinglePage` 默认值改为 `false`，避免统一去掉分页器带来的问题。[#388](https://github.com/oceanbase/oceanbase-design/pull/388)
- 🐞 修复 Table 只有一页数据且存在批量操作或 `pageSize` 切换时分页器被隐藏的问题。[#389](https://github.com/oceanbase/oceanbase-design/pull/389)
- 🐞 修复 List 只有一页数据且存在 `pageSize` 切换时分页器被隐藏的问题。[#390](https://github.com/oceanbase/oceanbase-design/pull/390)
- 💄 更新 Design Token，新增 `fontHeight`、`fontHeightLG` 和 `fontHeightSM` less 变量。[#381](https://github.com/oceanbase/oceanbase-design/pull/381)

---

## @oceanbase/ui@0.2.34

## 0.2.34

`2023-12-28`

- IconFont
  - 🐞 修复 IconFont 会请求不必要 JS 资源的问题。[#375](https://github.com/oceanbase/oceanbase-design/pull/375)
  - 📢 将 IconFont 组件标记为即将废弃，不推荐使用。[#375](https://github.com/oceanbase/oceanbase-design/pull/375)
- 💄 优化 TagSelect 的 `disabled` 和 `hover` 样式，并将固定样式改造为 Design Token。[#373](https://github.com/oceanbase/oceanbase-design/pull/373)

---

## @oceanbase/charts@0.2.20

## 0.2.20

`2023-12-28`

- Stat
  - 🆕 新增 `chartConfig` 属性，用于配置图表。[#384](https://github.com/oceanbase/oceanbase-design/pull/384)
  - 💄 优化样式，包括限制 `title` 字体最小为 12px、限制 `value` 字体最大为 40px 以及优化内容居中对齐样式。[#385](https://github.com/oceanbase/oceanbase-design/pull/385)
  - 💄 容器高度小于 `72px` 时，图表的高度比例从 `0.5` 减小为 `0.25`。[#387](https://github.com/oceanbase/oceanbase-design/pull/387)
- Liquid
  - 🆕 新增 `containerStyle`、`percentStyle` 和 `titleStyle` 属性，分别用于设置容器样式、百分比样式和标题样式。[#374](https://github.com/oceanbase/oceanbase-design/pull/374)
  - 🐞 修复未设置图表高度时水波无法渲染的问题。[#383](https://github.com/oceanbase/oceanbase-design/pull/383)
- 💄 Column 适配 X 时序轴，自动对数据进行排序，并关闭自动美化避免两侧留白。[#382](https://github.com/oceanbase/oceanbase-design/pull/382)