### PR TITLE
feat(design): ConfigProvider add table.selectionColumnWidth prop

### DIFF
--- a/packages/design/src/config-provider/__tests__/spin.test.tsx
+++ b/packages/design/src/config-provider/__tests__/spin.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import ConfigProvider from '..';
-import Spin from '../../spin';
+import { ConfigProvider, Spin } from '@oceanbase/design';
 
 describe('ConfigProvider spin', () => {
   it('spin.indicator should work', () => {

--- a/packages/design/src/config-provider/__tests__/table.test.tsx
+++ b/packages/design/src/config-provider/__tests__/table.test.tsx
@@ -1,0 +1,35 @@
+import React, { useContext } from 'react';
+import { ConfigProvider } from '@oceanbase/design';
+
+describe('ConfigProvider table', () => {
+  it('table.selectionColumnWidth should work', () => {
+    const Child1 = () => {
+      const { table } = useContext(ConfigProvider.ConfigContext);
+      expect(table.selectionColumnWidth).toBe(undefined);
+      return <div />;
+    };
+    const Child2 = () => {
+      const { table } = useContext(ConfigProvider.ConfigContext);
+      expect(table.selectionColumnWidth).toBe(48);
+      return <div />;
+    };
+    const Child3 = () => {
+      const { table } = useContext(ConfigProvider.ConfigContext);
+      expect(table.selectionColumnWidth).toBe(48);
+      return <div />;
+    };
+    <ConfigProvider>
+      <Child1 />
+      <ConfigProvider
+        table={{
+          selectionColumnWidth: 48,
+        }}
+      >
+        <Child2 />
+        <ConfigProvider>
+          <Child3 />
+        </ConfigProvider>
+      </ConfigProvider>
+    </ConfigProvider>;
+  });
+});

--- a/packages/design/src/config-provider/index.tsx
+++ b/packages/design/src/config-provider/index.tsx
@@ -33,11 +33,16 @@ export type SpinConfig = ComponentStyleConfig & {
   indicator?: SpinIndicator;
 };
 
+export type TableConfig = ComponentStyleConfig & {
+  selectionColumnWidth?: number;
+};
+
 export interface ConfigConsumerProps extends AntConfigConsumerProps {
   theme?: ThemeConfig;
   navigate?: NavigateFunction;
   hideOnSinglePage?: boolean;
   spin?: SpinConfig;
+  table?: TableConfig;
   locale?: Locale;
 }
 
@@ -49,6 +54,7 @@ export interface ConfigProviderProps extends AntConfigProviderProps {
   navigate?: NavigateFunction;
   hideOnSinglePage?: boolean;
   spin?: SpinConfig;
+  table?: TableConfig;
   // StyleProvider props
   styleProviderProps?: StyleProviderProps;
 }
@@ -71,6 +77,7 @@ const ConfigProvider = ({
   navigate,
   hideOnSinglePage,
   spin,
+  table,
   tabs,
   styleProviderProps,
   ...restProps
@@ -89,6 +96,7 @@ const ConfigProvider = ({
   return (
     <AntConfigProvider
       spin={merge(parentContext.spin, spin)}
+      table={merge(parentContext.table, table)}
       tabs={merge(
         {
           indicatorSize: origin => (origin >= 24 ? origin - 16 : origin),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None.

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | 🆕 ConfigProvider 新增 `table.selectionColumnWidth` 属性，用于设置表格的展开列宽度。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
