### PR TITLE
chore(docs): Add changelog for @oceanbase/design@0.2.35, @oceanbase/ui@0.2.36 and @oceanbase/charts@0.2.22

### DIFF
--- a/docs/charts/charts-CHANGELOG.md
+++ b/docs/charts/charts-CHANGELOG.md
@@ -8,6 +8,13 @@ group: 可视化图表
 
 ---
 
+## 0.2.22
+
+`2024-01-18`
+
+- 🆕 Stat 新增 padding 属性，用于设置图表的内间距。[#412](https://github.com/oceanbase/oceanbase-design/pull/412)
+- 🐞 修复 Pie 环图统计组件标题和内容 `formatter` 不生效的问题。[#413](https://github.com/oceanbase/oceanbase-design/pull/413)
+
 ## 0.2.21
 
 `2024-01-12`

--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,17 @@ group: 基础组件
 
 ---
 
+## 0.2.35
+
+`2024-01-18`
+
+- 🆕 ConfigProvider 新增 table.selectionColumnWidth 属性，用于配置表格的展开列宽度。[#421](https://github.com/oceanbase/oceanbase-design/pull/421)
+- 🐞 修复 Table 可展开时底部出现重复边框的问题。[#420](https://github.com/oceanbase/oceanbase-design/pull/420)
+- Table
+  - 💄 优化 Table 在无间距卡片内的展示样式，包括第一列和卡片标题对齐、最后一列和卡片操作区对齐、分页器左右增加间距。[#422](https://github.com/oceanbase/oceanbase-design/pull/422)
+  - 💄 减小 Table 单元格的纵向内间距，以对齐设计规范。[#425](https://github.com/oceanbase/oceanbase-design/pull/425)
+- 💄 Modal 去掉最大高度限制，高度超出时内容滚动改由上层控制。[#411](https://github.com/oceanbase/oceanbase-design/pull/411)
+
 ## 0.2.34
 
 `2024-01-12`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,14 @@ group: 业务组件
 
 ---
 
+## 0.2.36
+
+`2024-01-18`
+
+- 🐞 修复 Password 组件快速输入时丢失字符和焦点跳跃的问题。[#424](https://github.com/oceanbase/oceanbase-design/pull/424) [@Vanleehao](https://github.com/Vanleehao)
+- 🐞 修复 Highlight 国际化不生效的问题。[#419](https://github.com/oceanbase/oceanbase-design/pull/419) [@linhf123](https://github.com/linhf123)
+- 💄 优化 PageContainer 右上角和页脚操作区中的 Input 样式，保证宽高和字体大小符合设计规范。[#426](https://github.com/oceanbase/oceanbase-design/pull/426)
+
 ## 0.2.35
 
 `2024-01-12`


### PR DESCRIPTION
## @oceanbase/design@0.2.35

`2024-01-18`

- 🆕 ConfigProvider 新增 table.selectionColumnWidth 属性，用于配置表格的展开列宽度。[#421](https://github.com/oceanbase/oceanbase-design/pull/421)
- 🐞 修复 Table 可展开时底部出现重复边框的问题。[#420](https://github.com/oceanbase/oceanbase-design/pull/420)
- Table
  - 💄 优化 Table 在无间距卡片内的展示样式，包括第一列和卡片标题对齐、最后一列和卡片操作区对齐、分页器左右增加间距。[#422](https://github.com/oceanbase/oceanbase-design/pull/422)
  - 💄 减小 Table 单元格的纵向内间距，以对齐设计规范。[#425](https://github.com/oceanbase/oceanbase-design/pull/425)
- 💄 Modal 去掉最大高度限制，高度超出时内容滚动改由上层控制。[#411](https://github.com/oceanbase/oceanbase-design/pull/411)

---

## @oceanbase/ui@0.2.36

`2024-01-18`

- 🐞 修复 Password 组件快速输入时丢失字符和焦点跳跃的问题。[#424](https://github.com/oceanbase/oceanbase-design/pull/424) [@Vanleehao](https://github.com/Vanleehao)
- 🐞 修复 Highlight 国际化不生效的问题。[#419](https://github.com/oceanbase/oceanbase-design/pull/419) [@linhf123](https://github.com/linhf123)
- 💄 优化 PageContainer 右上角和页脚操作区中的 Input 样式，保证宽高和字体大小符合设计规范。[#426](https://github.com/oceanbase/oceanbase-design/pull/426)

---

## @oceanbase/charts@0.2.22

`2024-01-18`

- 🆕 Stat 新增 padding 属性，用于设置图表的内间距。[#412](https://github.com/oceanbase/oceanbase-design/pull/412)
- 🐞 修复 Pie 环图统计组件标题和内容 `formatter` 不生效的问题。[#413](https://github.com/oceanbase/oceanbase-design/pull/413)
