### PR TITLE
fix(ui): FooterToolbar children large size should work correctly

### DIFF
--- a/packages/ui/src/FooterToolbar/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/FooterToolbar/__tests__/__snapshots__/index.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`FooterToolbar portalDom is true 1`] = `
       class="ant-pro-footer-bar-right"
     >
       <button
-        class="ant-btn ant-btn-default ant-btn-lg"
+        class="ant-btn ant-btn-default"
         type="button"
       >
         <span>
@@ -22,7 +22,7 @@ exports[`FooterToolbar portalDom is true 1`] = `
         </span>
       </button>
       <button
-        class="ant-btn ant-btn-primary ant-btn-lg"
+        class="ant-btn ant-btn-primary"
         type="button"
       >
         <span>
@@ -48,7 +48,7 @@ exports[`FooterToolbar render 1`] = `
       class="ant-pro-footer-bar-right"
     >
       <button
-        class="ant-btn ant-btn-default ant-btn-lg"
+        class="ant-btn ant-btn-default"
         type="button"
       >
         <span>
@@ -56,7 +56,7 @@ exports[`FooterToolbar render 1`] = `
         </span>
       </button>
       <button
-        class="ant-btn ant-btn-primary ant-btn-lg"
+        class="ant-btn ant-btn-primary"
         type="button"
       >
         <span>

--- a/packages/ui/src/FooterToolbar/index.tsx
+++ b/packages/ui/src/FooterToolbar/index.tsx
@@ -10,30 +10,14 @@ const FooterToolbar: React.FC<FooterToolbarProps> = ({
   // render footer under parent instead of body by default
   portalDom = false,
   prefixCls: customizePrefixCls,
-  children,
   ...restProps
 }) => {
   const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
   const prefixCls = getPrefixCls('pro-footer-bar', customizePrefixCls);
   const { wrapSSR } = useStyle(prefixCls);
 
-  const { token } = theme.useToken();
-
   return wrapSSR(
-    <AntFooterToolbar portalDom={portalDom} prefixCls={customizePrefixCls} {...restProps}>
-      <ConfigProvider
-        // large size component
-        componentSize="large"
-        // middle font size
-        theme={{
-          token: {
-            fontSizeLG: token.fontSize,
-          },
-        }}
-      >
-        {children}
-      </ConfigProvider>
-    </AntFooterToolbar>
+    <AntFooterToolbar portalDom={portalDom} prefixCls={customizePrefixCls} {...restProps} />
   );
 };
 

--- a/packages/ui/src/PageContainer/index.tsx
+++ b/packages/ui/src/PageContainer/index.tsx
@@ -8,7 +8,7 @@ import { PageContainer as AntPageContainer } from '@ant-design/pro-components';
 import classNames from 'classnames';
 import { isObject } from 'lodash';
 import React, { useContext } from 'react';
-import { ConfigProvider, Space, Tooltip, theme } from '@oceanbase/design';
+import { ConfigProvider, Space, Tooltip } from '@oceanbase/design';
 import LocaleWrapper from '../locale/LocaleWrapper';
 import ItemRender from './ItemRender';
 import zhCN from './locale/zh-CN';
@@ -45,8 +45,6 @@ const PageContainer = ({
   const rootPrefixCls = getPrefixCls();
   const prefixCls = getPrefixCls('pro-page-container', customizePrefixCls);
   const { wrapSSR } = useStyle(prefixCls);
-
-  const { token } = theme.useToken();
 
   const { reload, subTitle, breadcrumb } = header || {};
   const reloadProps =


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- Fix #433.
- Ref: #443.

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

- 原先基于 ConfigProvider 修改组件尺寸的影响范围不可控，需要改为原来的样式定制方案，并优化样式以适配更多组件场景。

![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/d0b0a3d8-e39a-4820-b03c-269201d3f42b)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese | 🐞 修复 FooterToolbar 子元素外的组件尺寸也可能被改为 `large` 的问题。           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
