### PR TITLE
fix(design): ConfigProvider form.requiredMark should be `optional` by default and work for ProForm

### DIFF
--- a/packages/design/src/config-provider/__tests__/__snapshots__/form.test.tsx.snap
+++ b/packages/design/src/config-provider/__tests__/__snapshots__/form.test.tsx.snap
@@ -1,0 +1,183 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ConfigProvider form > ConfigProvider form.requiredMark should be \`optional\` by default and work for ProForm 1`] = `
+<form
+  autocomplete="off"
+  class="ant-form ant-form-vertical ant-pro-form"
+>
+  <input
+    style="display: none;"
+    type="text"
+  />
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class="ant-form-item-required ant-form-item-required-mark-optional"
+          for="name"
+          title="Name"
+        >
+          Name
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <span
+              class="ant-input-affix-wrapper ant-input-affix-wrapper-focused ant-input-outlined"
+            >
+              <input
+                class="ant-input"
+                id="name"
+                placeholder="请输入"
+                type="text"
+                value=""
+              />
+              <span
+                class="ant-input-suffix"
+              >
+                <span
+                  class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                  role="button"
+                  tabindex="-1"
+                >
+                  <span
+                    aria-label="close-circle"
+                    class="anticon anticon-close-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="close-circle"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class="ant-form-item-required-mark-optional"
+          for="address"
+          title="Address"
+        >
+          Address
+          <span
+            class="ant-form-item-optional"
+            title=""
+          >
+            （可选）
+          </span>
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <span
+              class="ant-input-affix-wrapper ant-input-outlined"
+            >
+              <input
+                class="ant-input"
+                id="address"
+                placeholder="请输入"
+                type="text"
+                value=""
+              />
+              <span
+                class="ant-input-suffix"
+              >
+                <span
+                  class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                  role="button"
+                  tabindex="-1"
+                >
+                  <span
+                    aria-label="close-circle"
+                    class="anticon anticon-close-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="close-circle"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    style="display: flex; gap: 8px; align-items: center;"
+  >
+    <button
+      class="ant-btn ant-btn-default"
+      type="button"
+    >
+      <span>
+        重 置
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-primary"
+      type="button"
+    >
+      <span>
+        提 交
+      </span>
+    </button>
+  </div>
+</form>
+`;

--- a/packages/design/src/config-provider/__tests__/form.test.tsx
+++ b/packages/design/src/config-provider/__tests__/form.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ConfigProvider } from '@oceanbase/design';
+import { ProForm, ProFormText } from '@oceanbase/ui';
+import type { ProFormProps } from '@oceanbase/ui';
+
+const ProFormTest: React.FC<ProFormProps> = props => (
+  <ProForm {...props}>
+    <ProFormText
+      label="Name"
+      name="name"
+      rules={[
+        {
+          required: true,
+          message: 'Name is required',
+        },
+      ]}
+    />
+    <ProFormText label="Address" name="address" />
+  </ProForm>
+);
+
+describe('ConfigProvider form', () => {
+  it('ConfigProvider form.requiredMark should be `optional` by default and work for ProForm', () => {
+    const { container, asFragment } = render(
+      <ConfigProvider>
+        <ProFormTest />
+      </ConfigProvider>
+    );
+    expect(
+      container.querySelector('.ant-form-item-required.ant-form-item-required-mark-optional')
+    ).toBeTruthy();
+    expect(container.querySelector('.ant-form-item-optional')).toBeTruthy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+});

--- a/packages/design/src/config-provider/index.tsx
+++ b/packages/design/src/config-provider/index.tsx
@@ -89,6 +89,7 @@ const ConfigProvider: ConfigProviderType = ({
   theme,
   navigate,
   hideOnSinglePage,
+  form,
   spin,
   table,
   tabs,
@@ -109,6 +110,13 @@ const ConfigProvider: ConfigProviderType = ({
 
   return (
     <AntConfigProvider
+      form={merge(
+        {
+          requiredMark: 'optional',
+        },
+        parentContext.form,
+        form
+      )}
       spin={merge(parentContext.spin, spin)}
       table={merge(parentContext.table, table)}
       tabs={merge(

--- a/packages/design/src/form/demo/pro-form.tsx
+++ b/packages/design/src/form/demo/pro-form.tsx
@@ -1,0 +1,40 @@
+import { Button, Form, Input, message } from '@oceanbase/design';
+import React from 'react';
+
+const onFinish = (values: any) => {
+  message.success('Success');
+  console.log(values);
+};
+
+const onFinishFailed = (errorInfo: any) => {
+  message.error('Failed');
+  console.log(errorInfo);
+};
+
+const App: React.FC = () => (
+  <Form
+    name="basic"
+    labelCol={{ span: 6 }}
+    wrapperCol={{ span: 10 }}
+    onFinish={onFinish}
+    onFinishFailed={onFinishFailed}
+  >
+    <Form.Item
+      label="Username"
+      name="username"
+      rules={[{ required: true, message: 'Please input your username!' }]}
+    >
+      <Input />
+    </Form.Item>
+    <Form.Item label="Address" name="address">
+      <Input />
+    </Form.Item>
+    <Form.Item wrapperCol={{ offset: 6, span: 10 }}>
+      <Button type="primary" htmlType="submit">
+        Submit
+      </Button>
+    </Form.Item>
+  </Form>
+);
+
+export default App;

--- a/packages/design/src/form/index.md
+++ b/packages/design/src/form/index.md
@@ -19,6 +19,8 @@ nav:
 
 <code src="./demo/hideRequiredMark.tsx" title="hideRequiredMark" debug></code>
 
+<code src="./demo/pro-form.tsx" title="ProForm" debug></code>
+
 <code src="./demo/form-item-tooltip.tsx" title="配置提示信息"></code>
 
 ## API


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | 🐞 ConfigProvider `form.requiredMark` 属性的默认值改为 `optional`，保证 ProForm 等 Form 衍生组件也能生效。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
