### PR TITLE
feat(design): Select add default placeholder and ConfigProvider support to config it global

### DIFF
--- a/packages/design/src/input/__tests__/__snapshots__/placeholder.test.tsx.snap
+++ b/packages/design/src/input/__tests__/__snapshots__/placeholder.test.tsx.snap
@@ -1,0 +1,37 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Input placeholder > ConfigProvider locale.Input.placeholder should work 1`] = `
+<input
+  class="ant-input ant-input-outlined"
+  placeholder="global placeholder"
+  type="text"
+  value=""
+/>
+`;
+
+exports[`Input placeholder > Input placeholder should be priority to ConfigProvider locale.Input.placeholder 1`] = `
+<input
+  class="ant-input ant-input-outlined"
+  placeholder="custom placeholder"
+  type="text"
+  value=""
+/>
+`;
+
+exports[`Input placeholder > custom placeholder should work 1`] = `
+<input
+  class="ant-input ant-input-outlined"
+  placeholder="custom placeholder"
+  type="text"
+  value=""
+/>
+`;
+
+exports[`Input placeholder > default placeholder should be correct 1`] = `
+<input
+  class="ant-input ant-input-outlined"
+  placeholder="Please enter"
+  type="text"
+  value=""
+/>
+`;

--- a/packages/design/src/input/__tests__/placeholder.test.tsx
+++ b/packages/design/src/input/__tests__/placeholder.test.tsx
@@ -26,7 +26,7 @@ const placeholderExpect = (container: HTMLElement, placeholder?: string) => {
   );
 };
 
-describe('Form', () => {
+describe('Input placeholder', () => {
   it('default placeholder should be correct', () => {
     const { container, asFragment } = render(<InputTest />);
     placeholderExpect(container, 'Please enter');

--- a/packages/design/src/locale/index.ts
+++ b/packages/design/src/locale/index.ts
@@ -1,6 +1,7 @@
 import type { Locale as AntLocale } from 'antd/es/locale';
 import type { DrawerLocale } from '../drawer';
 import type { InputLocale } from '../input';
+import type { SelectLocale } from '../select';
 import type { TableLocale } from '../table';
 
 export * from 'antd/es/locale';
@@ -8,6 +9,7 @@ export * from 'antd/es/locale';
 export interface Locale extends AntLocale {
   Drawer?: DrawerLocale;
   Input?: InputLocale;
+  Select?: SelectLocale;
   Table?: TableLocale;
 }
 

--- a/packages/design/src/select/__tests__/__snapshots__/placeholder.test.tsx.snap
+++ b/packages/design/src/select/__tests__/__snapshots__/placeholder.test.tsx.snap
@@ -1,0 +1,435 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Select placeholder > ConfigProvider locale.Select.placeholder should be priority to ConfigProvider locale.global.placeholder 1`] = `
+<div
+  class="ant-select ant-select-outlined ant-select-single ant-select-show-arrow"
+>
+  <div
+    class="ant-select-selector"
+  >
+    <span
+      class="ant-select-selection-search"
+    >
+      <input
+        aria-autocomplete="list"
+        aria-controls="rc_select_TEST_OR_SSR_list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="rc_select_TEST_OR_SSR_list"
+        autocomplete="off"
+        class="ant-select-selection-search-input"
+        id="rc_select_TEST_OR_SSR"
+        readonly=""
+        role="combobox"
+        style="opacity: 0;"
+        type="search"
+        unselectable="on"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-select-selection-placeholder"
+    >
+      Select global placeholder
+    </span>
+  </div>
+  <span
+    aria-hidden="true"
+    class="ant-select-arrow"
+    style="user-select: none;"
+    unselectable="on"
+  >
+    <span
+      aria-label="down"
+      class="anticon anticon-down ant-select-suffix"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="down"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+        />
+      </svg>
+    </span>
+  </span>
+</div>
+`;
+
+exports[`Select placeholder > ConfigProvider locale.Select.placeholder should work 1`] = `
+<div
+  class="ant-select ant-select-outlined ant-select-single ant-select-show-arrow"
+>
+  <div
+    class="ant-select-selector"
+  >
+    <span
+      class="ant-select-selection-search"
+    >
+      <input
+        aria-autocomplete="list"
+        aria-controls="rc_select_TEST_OR_SSR_list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="rc_select_TEST_OR_SSR_list"
+        autocomplete="off"
+        class="ant-select-selection-search-input"
+        id="rc_select_TEST_OR_SSR"
+        readonly=""
+        role="combobox"
+        style="opacity: 0;"
+        type="search"
+        unselectable="on"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-select-selection-placeholder"
+    >
+      global placeholder
+    </span>
+  </div>
+  <span
+    aria-hidden="true"
+    class="ant-select-arrow"
+    style="user-select: none;"
+    unselectable="on"
+  >
+    <span
+      aria-label="down"
+      class="anticon anticon-down ant-select-suffix"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="down"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+        />
+      </svg>
+    </span>
+  </span>
+</div>
+`;
+
+exports[`Select placeholder > ConfigProvider locale.global.placeholder should work 1`] = `
+<div
+  class="ant-select ant-select-outlined ant-select-single ant-select-show-arrow"
+>
+  <div
+    class="ant-select-selector"
+  >
+    <span
+      class="ant-select-selection-search"
+    >
+      <input
+        aria-autocomplete="list"
+        aria-controls="rc_select_TEST_OR_SSR_list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="rc_select_TEST_OR_SSR_list"
+        autocomplete="off"
+        class="ant-select-selection-search-input"
+        id="rc_select_TEST_OR_SSR"
+        readonly=""
+        role="combobox"
+        style="opacity: 0;"
+        type="search"
+        unselectable="on"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-select-selection-placeholder"
+    >
+      global placeholder
+    </span>
+  </div>
+  <span
+    aria-hidden="true"
+    class="ant-select-arrow"
+    style="user-select: none;"
+    unselectable="on"
+  >
+    <span
+      aria-label="down"
+      class="anticon anticon-down ant-select-suffix"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="down"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+        />
+      </svg>
+    </span>
+  </span>
+</div>
+`;
+
+exports[`Select placeholder > Select placeholder should be priority to ConfigProvider locale.Select.placeholder 1`] = `
+<div
+  class="ant-select ant-select-outlined ant-select-single ant-select-show-arrow"
+>
+  <div
+    class="ant-select-selector"
+  >
+    <span
+      class="ant-select-selection-search"
+    >
+      <input
+        aria-autocomplete="list"
+        aria-controls="rc_select_TEST_OR_SSR_list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="rc_select_TEST_OR_SSR_list"
+        autocomplete="off"
+        class="ant-select-selection-search-input"
+        id="rc_select_TEST_OR_SSR"
+        readonly=""
+        role="combobox"
+        style="opacity: 0;"
+        type="search"
+        unselectable="on"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-select-selection-placeholder"
+    >
+      custom placeholder
+    </span>
+  </div>
+  <span
+    aria-hidden="true"
+    class="ant-select-arrow"
+    style="user-select: none;"
+    unselectable="on"
+  >
+    <span
+      aria-label="down"
+      class="anticon anticon-down ant-select-suffix"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="down"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+        />
+      </svg>
+    </span>
+  </span>
+</div>
+`;
+
+exports[`Select placeholder > Select placeholder should be priority to ConfigProvider locale.global.placeholder 1`] = `
+<div
+  class="ant-select ant-select-outlined ant-select-single ant-select-show-arrow"
+>
+  <div
+    class="ant-select-selector"
+  >
+    <span
+      class="ant-select-selection-search"
+    >
+      <input
+        aria-autocomplete="list"
+        aria-controls="rc_select_TEST_OR_SSR_list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="rc_select_TEST_OR_SSR_list"
+        autocomplete="off"
+        class="ant-select-selection-search-input"
+        id="rc_select_TEST_OR_SSR"
+        readonly=""
+        role="combobox"
+        style="opacity: 0;"
+        type="search"
+        unselectable="on"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-select-selection-placeholder"
+    >
+      custom placeholder
+    </span>
+  </div>
+  <span
+    aria-hidden="true"
+    class="ant-select-arrow"
+    style="user-select: none;"
+    unselectable="on"
+  >
+    <span
+      aria-label="down"
+      class="anticon anticon-down ant-select-suffix"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="down"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+        />
+      </svg>
+    </span>
+  </span>
+</div>
+`;
+
+exports[`Select placeholder > custom placeholder should work 1`] = `
+<div
+  class="ant-select ant-select-outlined ant-select-single ant-select-show-arrow"
+>
+  <div
+    class="ant-select-selector"
+  >
+    <span
+      class="ant-select-selection-search"
+    >
+      <input
+        aria-autocomplete="list"
+        aria-controls="rc_select_TEST_OR_SSR_list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="rc_select_TEST_OR_SSR_list"
+        autocomplete="off"
+        class="ant-select-selection-search-input"
+        id="rc_select_TEST_OR_SSR"
+        readonly=""
+        role="combobox"
+        style="opacity: 0;"
+        type="search"
+        unselectable="on"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-select-selection-placeholder"
+    >
+      custom placeholder
+    </span>
+  </div>
+  <span
+    aria-hidden="true"
+    class="ant-select-arrow"
+    style="user-select: none;"
+    unselectable="on"
+  >
+    <span
+      aria-label="down"
+      class="anticon anticon-down ant-select-suffix"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="down"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+        />
+      </svg>
+    </span>
+  </span>
+</div>
+`;
+
+exports[`Select placeholder > default placeholder should be correct 1`] = `
+<div
+  class="ant-select ant-select-outlined ant-select-single ant-select-show-arrow"
+>
+  <div
+    class="ant-select-selector"
+  >
+    <span
+      class="ant-select-selection-search"
+    >
+      <input
+        aria-autocomplete="list"
+        aria-controls="rc_select_TEST_OR_SSR_list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="rc_select_TEST_OR_SSR_list"
+        autocomplete="off"
+        class="ant-select-selection-search-input"
+        id="rc_select_TEST_OR_SSR"
+        readonly=""
+        role="combobox"
+        style="opacity: 0;"
+        type="search"
+        unselectable="on"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-select-selection-placeholder"
+    >
+      Please select
+    </span>
+  </div>
+  <span
+    aria-hidden="true"
+    class="ant-select-arrow"
+    style="user-select: none;"
+    unselectable="on"
+  >
+    <span
+      aria-label="down"
+      class="anticon anticon-down ant-select-suffix"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="down"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+        />
+      </svg>
+    </span>
+  </span>
+</div>
+`;

--- a/packages/design/src/select/__tests__/placeholder.test.tsx
+++ b/packages/design/src/select/__tests__/placeholder.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ConfigProvider, Select } from '@oceanbase/design';
+import type { SelectProps } from '@oceanbase/design';
+
+const SelectTest: React.FC<SelectProps> = props => (
+  <Select options={[{ value: 'lucy', label: 'Lucy' }]} {...props} />
+);
+
+describe('Select placeholder', () => {
+  it('default placeholder should be correct', () => {
+    const { container, asFragment } = render(<SelectTest />);
+    expect(container.querySelector('.ant-select-selection-placeholder').textContent).toBe(
+      'Please select'
+    );
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('custom placeholder should work', () => {
+    const { container, asFragment } = render(<SelectTest placeholder="custom placeholder" />);
+    expect(container.querySelector('.ant-select-selection-placeholder').textContent).toBe(
+      'custom placeholder'
+    );
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('ConfigProvider locale.global.placeholder should work', () => {
+    const { container, asFragment } = render(
+      <ConfigProvider
+        locale={{
+          locale: 'en',
+          global: {
+            placeholder: 'global placeholder',
+          },
+        }}
+      >
+        <SelectTest />
+      </ConfigProvider>
+    );
+    expect(container.querySelector('.ant-select-selection-placeholder').textContent).toBe(
+      'global placeholder'
+    );
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('Select placeholder should be priority to ConfigProvider locale.global.placeholder', () => {
+    const { container, asFragment } = render(
+      <ConfigProvider
+        locale={{
+          locale: 'en',
+          global: {
+            placeholder: 'global placeholder',
+          },
+        }}
+      >
+        <SelectTest placeholder="custom placeholder" />
+      </ConfigProvider>
+    );
+    expect(container.querySelector('.ant-select-selection-placeholder').textContent).toBe(
+      'custom placeholder'
+    );
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('ConfigProvider locale.Select.placeholder should work', () => {
+    const { container, asFragment } = render(
+      <ConfigProvider
+        locale={{
+          locale: 'en',
+          Select: {
+            placeholder: 'global placeholder',
+          },
+        }}
+      >
+        <SelectTest />
+      </ConfigProvider>
+    );
+    expect(container.querySelector('.ant-select-selection-placeholder').textContent).toBe(
+      'global placeholder'
+    );
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('Select placeholder should be priority to ConfigProvider locale.Select.placeholder', () => {
+    const { container, asFragment } = render(
+      <ConfigProvider
+        locale={{
+          locale: 'en',
+          Select: {
+            placeholder: 'global placeholder',
+          },
+        }}
+      >
+        <SelectTest placeholder="custom placeholder" />
+      </ConfigProvider>
+    );
+    expect(container.querySelector('.ant-select-selection-placeholder').textContent).toBe(
+      'custom placeholder'
+    );
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('ConfigProvider locale.Select.placeholder should be priority to ConfigProvider locale.global.placeholder', () => {
+    const { container, asFragment } = render(
+      <ConfigProvider
+        locale={{
+          locale: 'en',
+          global: {
+            placeholder: 'global placeholder',
+          },
+          Select: {
+            placeholder: 'Select global placeholder',
+          },
+        }}
+      >
+        <SelectTest />
+      </ConfigProvider>
+    );
+    expect(container.querySelector('.ant-select-selection-placeholder').textContent).toBe(
+      'Select global placeholder'
+    );
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+});

--- a/packages/design/src/select/demo/basic.tsx
+++ b/packages/design/src/select/demo/basic.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Select, Space } from '@oceanbase/design';
+
+const handleChange = (value: string) => {
+  console.log(`selected ${value}`);
+};
+
+const App: React.FC = () => (
+  <Space wrap>
+    <Select
+      style={{ width: 120 }}
+      onChange={handleChange}
+      options={[
+        { value: 'jack', label: 'Jack' },
+        { value: 'lucy', label: 'Lucy' },
+      ]}
+    />
+    <Select
+      defaultValue="lucy"
+      style={{ width: 120 }}
+      onChange={handleChange}
+      options={[
+        { value: 'jack', label: 'Jack' },
+        { value: 'lucy', label: 'Lucy' },
+        { value: 'disabled', label: 'Disabled', disabled: true },
+      ]}
+    />
+    <Select
+      defaultValue="lucy"
+      style={{ width: 120 }}
+      disabled
+      options={[{ value: 'lucy', label: 'Lucy' }]}
+    />
+    <Select
+      defaultValue="lucy"
+      style={{ width: 120 }}
+      loading
+      options={[{ value: 'lucy', label: 'Lucy' }]}
+    />
+    <Select
+      defaultValue="lucy"
+      style={{ width: 120 }}
+      allowClear
+      options={[{ value: 'lucy', label: 'Lucy' }]}
+    />
+  </Space>
+);
+
+export default App;

--- a/packages/design/src/select/index.md
+++ b/packages/design/src/select/index.md
@@ -3,13 +3,19 @@ title: Select 选择器
 nav:
   title: 基础组件
   path: /components
+demo:
+  cols: 2
 ---
 
 - 🔥 完全继承 antd [Select](https://ant.design/components/select-cn/) 的能力和 API，可无缝切换。
 - 💄 定制主题和样式，符合 OceanBase Design 设计规范。
+- 📢 默认填充 `placeholder`，并支持通过 ConfigProvider `locale.global.placeholder` 或 `locale.Select.placeholder` 进行全局配置。
 
 ## 代码演示
 
-<code src="./demo/custom-tag-render.tsx" title="自定义选择标签" description="允许自定义选择标签的样式"></code> <code src="./demo/tags.tsx" title="标签" description="tags select，随意输入的内容（scroll the menu）。"></code>
+<!-- prettier-ignore -->
+<code src="./demo/basic.tsx" title="基本使用"></code>
+<code src="./demo/custom-tag-render.tsx" title="自定义标签样式" description="允许自定义选择标签的样式"></code>
+<code src="./demo/tags.tsx" title="标签" description="标签式选择，支持输入任意内容"></code>
 
 - 详见 antd Select 文档: https://ant.design/components/select-cn/

--- a/packages/design/src/select/index.tsx
+++ b/packages/design/src/select/index.tsx
@@ -1,14 +1,23 @@
 import { Select as AntSelect } from 'antd';
 import type { SelectProps as AntSelectProps, RefSelectProps } from 'antd/es/select';
+import type { Locale as AntLocale } from 'antd/es/locale';
 import type { OptGroup, Option } from 'rc-select';
 import classNames from 'classnames';
 import React, { useContext } from 'react';
 import ConfigProvider from '../config-provider';
+import type { ConfigConsumerProps } from '../config-provider';
+import defaultLocale from '../locale/en-US';
 import useStyle from './style';
 
 export * from 'antd/es/select';
 
-export type SelectProps = AntSelectProps;
+export type SelectLocale = AntLocale['Select'] & {
+  placeholder?: string;
+};
+
+export interface SelectProps extends AntSelectProps {
+  locale?: SelectLocale;
+}
 
 type CompoundedComponent = React.ForwardRefExoticComponent<
   SelectProps & React.RefAttributes<RefSelectProps>
@@ -20,14 +29,30 @@ type CompoundedComponent = React.ForwardRefExoticComponent<
 };
 
 const InternalSelect = React.forwardRef<RefSelectProps, SelectProps>(
-  ({ prefixCls: customizePrefixCls, className, ...restProps }, ref) => {
-    const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
+  ({ locale: customLocale, prefixCls: customizePrefixCls, className, ...restProps }, ref) => {
+    const { locale: contextLocale, getPrefixCls } = useContext<ConfigConsumerProps>(
+      ConfigProvider.ConfigContext
+    );
+    const selectLocale: SelectLocale = {
+      ...defaultLocale.global,
+      ...contextLocale?.global,
+      ...defaultLocale.Select,
+      ...contextLocale?.Select,
+      ...customLocale,
+    };
+
     const prefixCls = getPrefixCls('select', customizePrefixCls);
     const { wrapSSR } = useStyle(prefixCls);
-
     const selectCls = classNames(className);
+
     return wrapSSR(
-      <AntSelect ref={ref} prefixCls={customizePrefixCls} className={selectCls} {...restProps} />
+      <AntSelect
+        ref={ref}
+        placeholder={selectLocale.placeholder}
+        prefixCls={customizePrefixCls}
+        className={selectCls}
+        {...restProps}
+      />
     );
   }
 );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/312f2a98-95f5-4eb2-97e9-6048aab55aa4)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese | - 📢 Select 默认填充 `placeholder`，并支持通过 ConfigProvider `locale.global.placeholder` 或 `locale.Select.placeholder` 进行全局配置。- 🆕 ConfigProvider 新增 `locale.Select.placeholder` 属性，用于配置 Select 的默认 `placeholder`。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed

