### PR TITLE
🐞 fix(charts): Remove unreasonable xAxis.tickCount calculate logic for Line, Area, Column and DualAxes

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -264,12 +264,12 @@ export default defineConfig({
               link: '/charts/histogram',
             },
             {
-              title: 'Pie 饼图&环图',
-              link: '/charts/pie',
-            },
-            {
               title: 'DualAxes 双轴图',
               link: '/charts/dual-axes',
+            },
+            {
+              title: 'Pie 饼图&环图',
+              link: '/charts/pie',
             },
             {
               title: 'Gauge 仪表盘',

--- a/packages/charts/src/Area/demo/basic.tsx
+++ b/packages/charts/src/Area/demo/basic.tsx
@@ -18,6 +18,9 @@ export default () => {
     data,
     xField: 'timePeriod',
     yField: 'value',
+    xAxis: {
+      tickCount: 7,
+    },
   };
   return <Area {...config} />;
 };

--- a/packages/charts/src/Area/demo/stack.tsx
+++ b/packages/charts/src/Area/demo/stack.tsx
@@ -19,6 +19,9 @@ export default () => {
     xField: 'date',
     yField: 'value',
     seriesField: 'country',
+    xAxis: {
+      tickCount: 7,
+    },
   };
   return <Area {...config} />;
 };

--- a/packages/charts/src/Area/demo/tooltip-scrollable.tsx
+++ b/packages/charts/src/Area/demo/tooltip-scrollable.tsx
@@ -22,6 +22,9 @@ export default () => {
     xField: 'date',
     yField: 'value',
     seriesField: 'country',
+    xAxis: {
+      tickCount: 7,
+    },
     tooltip: {
       scrollable: true,
     },

--- a/packages/charts/src/Area/index.tsx
+++ b/packages/charts/src/Area/index.tsx
@@ -47,8 +47,6 @@ const Area = forwardRef<unknown, AreaConfig>(
         // type 为 time 时需要关闭自动美化，否则 X 轴两侧会留白
         // issue: https://github.com/antvis/G2Plot/issues/1951
         nice: xAxis?.type === 'time' ? false : undefined,
-        // 点数 >= 14 时，x 方向展示 7 个刻度线和网格
-        tickCount: data?.length >= 14 ? 7 : undefined,
         ...xAxis,
         // x 方向增加虚线网格
         grid:

--- a/packages/charts/src/Column/index.tsx
+++ b/packages/charts/src/Column/index.tsx
@@ -81,8 +81,6 @@ const Column = forwardRef<unknown, ColumnConfig>(
         // type 为 time 时需要关闭自动美化，否则 X 轴两侧会留白
         // issue: https://github.com/antvis/G2Plot/issues/1951
         nice: xAxis?.type === 'time' ? false : undefined,
-        // 点数 >= 14 时，x 方向展示 7 个刻度线和网格
-        tickCount: data?.length >= 14 ? 7 : undefined,
         ...xAxis,
         // x 方向增加虚线网格
         grid:

--- a/packages/charts/src/DualAxes/index.tsx
+++ b/packages/charts/src/DualAxes/index.tsx
@@ -55,8 +55,6 @@ const DualAxes = forwardRef<unknown, DualAxesConfig>(
         // type 为 time 时需要关闭自动美化，否则 X 轴两侧会留白
         // issue: https://github.com/antvis/G2Plot/issues/1951
         nice: xAxis?.type === 'time' ? false : undefined,
-        // 点数 >= 14，x 方向展示 7 个刻度线和网格
-        tickCount: data?.length >= 14 ? 7 : undefined,
         ...xAxis,
         // x 方向增加虚线网格
         grid:

--- a/packages/charts/src/Line/demo/basic.tsx
+++ b/packages/charts/src/Line/demo/basic.tsx
@@ -18,6 +18,9 @@ export default () => {
     data,
     xField: 'Date',
     yField: 'scales',
+    xAxis: {
+      type: 'timeCat',
+    },
   };
   return <Line {...config} />;
 };

--- a/packages/charts/src/Line/index.tsx
+++ b/packages/charts/src/Line/index.tsx
@@ -41,8 +41,6 @@ const Line = forwardRef<unknown, LineConfig>(
         // type 为 time 时需要关闭自动美化，否则 X 轴两侧会留白
         // issue: https://github.com/antvis/G2Plot/issues/1951
         nice: xAxis?.type === 'time' ? false : undefined,
-        // 非阶梯折线图，并且点数 >= 14，x 方向展示 7 个刻度线和网格
-        tickCount: !stepType && data?.length >= 14 ? 7 : undefined,
         ...xAxis,
         // x 方向增加虚线网格
         grid:


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [x] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

- None

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | 🐞 Line、Area、Column 和 DualAxes 去掉不合理的 `xAxis.tickCount` 计算逻辑，改由上层进行控制。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
