### PR TITLE
fix(design): boxShadowSecondary for static token and less token should be correct

### DIFF
--- a/packages/design/src/config-provider/__tests__/static-function.test.tsx
+++ b/packages/design/src/config-provider/__tests__/static-function.test.tsx
@@ -4,7 +4,12 @@ import { ConfigProvider, token } from '@oceanbase/design';
 import defaultTheme from '../../theme/default';
 
 describe('ConfigProvider static function', () => {
-  it('token', () => {
+  it('static token', () => {
+    expect(token.boxShadow).toBe(defaultTheme.token.boxShadow);
+    expect(token.boxShadowSecondary).toBe(defaultTheme.token.boxShadowSecondary);
+  });
+
+  it('static token in ConfigProvider', () => {
     render(
       <ConfigProvider>
         <div />

--- a/packages/design/src/static-function/index.tsx
+++ b/packages/design/src/static-function/index.tsx
@@ -21,7 +21,7 @@ const mapToken = {
   // 需要覆盖部分 Alias Token 的值
   override: {
     boxShadow: defaultTheme.token.boxShadow,
-    boxShadowSecondary: defaultTheme.token.boxShadow,
+    boxShadowSecondary: defaultTheme.token.boxShadowSecondary,
   },
 };
 let token = formatToken(mapToken);

--- a/packages/design/src/theme/style/compact.less
+++ b/packages/design/src/theme/style/compact.less
@@ -409,7 +409,7 @@
 @borderRadiusSM: 4;
 @borderRadiusLG: 8;
 @borderRadiusOuter: 4;
-@boxShadowSecondary: 0 1px 2px 0 rgba(54, 69, 99, 0.03), 0 1px 6px -1px rgba(54, 69, 99, 0.02), 0 2px 4px 0 rgba(54, 69, 99, 0.02);
+@boxShadowSecondary: 0 6px 16px 0 rgba(54, 69, 99, 0.08), 0 3px 6px -4px rgba(54, 69, 99, 0.12), 0 9px 28px 8px rgba(54, 69, 99, 0.05);
 @boxShadow: 0 1px 2px 0 rgba(54, 69, 99, 0.03), 0 1px 6px -1px rgba(54, 69, 99, 0.02), 0 2px 4px 0 rgba(54, 69, 99, 0.02);
 @colorFillContent: #e2e8f3;
 @colorFillContentHover: #cdd5e4;

--- a/packages/design/src/theme/style/default.less
+++ b/packages/design/src/theme/style/default.less
@@ -409,7 +409,7 @@
 @borderRadiusSM: 4;
 @borderRadiusLG: 8;
 @borderRadiusOuter: 4;
-@boxShadowSecondary: 0 1px 2px 0 rgba(54, 69, 99, 0.03), 0 1px 6px -1px rgba(54, 69, 99, 0.02), 0 2px 4px 0 rgba(54, 69, 99, 0.02);
+@boxShadowSecondary: 0 6px 16px 0 rgba(54, 69, 99, 0.08), 0 3px 6px -4px rgba(54, 69, 99, 0.12), 0 9px 28px 8px rgba(54, 69, 99, 0.05);
 @boxShadow: 0 1px 2px 0 rgba(54, 69, 99, 0.03), 0 1px 6px -1px rgba(54, 69, 99, 0.02), 0 2px 4px 0 rgba(54, 69, 99, 0.02);
 @colorFillContent: #e2e8f3;
 @colorFillContentHover: #cdd5e4;

--- a/plugin-theme-less.ts
+++ b/plugin-theme-less.ts
@@ -59,7 +59,7 @@ export default (api: IApi) => {
             : // 对于非暗色主题，需要覆盖部分 Alias Token 的值
               {
                 boxShadow: item.token.boxShadow,
-                boxShadowSecondary: item.token.boxShadow,
+                boxShadowSecondary: item.token.boxShadowSecondary,
               },
       };
       const aliasToken = formatToken(mapToken);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- Fix #552

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

- None

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | 🐞 修复主题 Token `boxShadowSecondary` 通过静态 token 对象和 less 变量访问时值不正确的问题         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
