### PR TITLE
fix(design): fontFamily in nested ConfigProvider should be correct when enable theme.customFont

### DIFF
--- a/packages/design/src/config-provider/__tests__/theme.test.tsx
+++ b/packages/design/src/config-provider/__tests__/theme.test.tsx
@@ -1,7 +1,9 @@
 import React, { useContext } from 'react';
 import { render } from '@testing-library/react';
-import { ConfigProvider, useToken } from '@oceanbase/design';
+import { ConfigProvider, useToken, theme } from '@oceanbase/design';
 import defaultTheme from '../../theme/default';
+
+const antToken = theme.getDesignToken();
 
 describe('ConfigProvider theme', () => {
   it('ConfigProvider theme token', () => {
@@ -28,6 +30,39 @@ describe('ConfigProvider theme', () => {
             token: {
               colorBgLayout: '#ff0000',
             },
+          }}
+        >
+          <Child2 />
+          <ConfigProvider>
+            <Child3 />
+          </ConfigProvider>
+        </ConfigProvider>
+      </ConfigProvider>
+    );
+  });
+
+  it('ConfigProvider theme.customFont', () => {
+    const Child1 = () => {
+      const { token } = useToken();
+      expect(token.fontFamily).toBe(antToken.fontFamily);
+      return <div />;
+    };
+    const Child2 = () => {
+      const { token } = useToken();
+      expect(token.fontFamily).toBe(`'Source Sans Pro', ${antToken.fontFamily}`);
+      return <div />;
+    };
+    const Child3 = () => {
+      const { token } = useToken();
+      expect(token.fontFamily).toBe(`'Source Sans Pro', ${antToken.fontFamily}`);
+      return <div />;
+    };
+    render(
+      <ConfigProvider>
+        <Child1 />
+        <ConfigProvider
+          theme={{
+            customFont: true,
           }}
         >
           <Child2 />

--- a/packages/design/src/config-provider/index.tsx
+++ b/packages/design/src/config-provider/index.tsx
@@ -134,9 +134,10 @@ const ConfigProvider: ConfigProviderType = ({
       )}
       theme={merge(currentTheme, mergedTheme, {
         token: {
-          fontFamily: mergedTheme.customFont
-            ? `'Source Sans Pro', ${token.fontFamily}`
-            : token.fontFamily,
+          fontFamily:
+            mergedTheme.customFont && !token.fontFamily.startsWith(`'Source Sans Pro'`)
+              ? `'Source Sans Pro', ${token.fontFamily}`
+              : token.fontFamily,
         },
       })}
       renderEmpty={


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

- None

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese | 🐞 修复 ConfigProvider 开启 `theme.customFont` 并且多次嵌套后 `fontFamily` 不正确的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
