### PR TITLE
fix(design): Table locale & BatchOperationBar keys should related rowSelection 

### DIFF
--- a/packages/design/src/table/__tests__/index.test.tsx
+++ b/packages/design/src/table/__tests__/index.test.tsx
@@ -60,6 +60,20 @@ describe('Table', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
+  it('row selection should work', () => {
+    const { container, asFragment } = render(
+      <TableTest
+        rowSelection={{
+          selectedRowKeys: ['1', '2'],
+        }}
+      />
+    );
+    // selection column
+    expect(container.querySelector('.ant-table-selection-column')).toBeTruthy();
+    // batch operation bar
+    expect(container.querySelector('.ant-table-batch-operation-bar')).toBeTruthy();
+  });
+
   it('default pagination should work', () => {
     const { container, asFragment } = render(<TableTest />);
     // pagination.showTotal

--- a/packages/design/src/table/demo/row-selection.tsx
+++ b/packages/design/src/table/demo/row-selection.tsx
@@ -2,7 +2,7 @@ import { Button, Table } from '@oceanbase/design';
 import React, { useState } from 'react';
 
 const App: React.FC = () => {
-  const [selectedRowKeys, setSelectedRowKeys] = useState<any[]>([]);
+  const [selectedRowKeys, setSelectedRowKeys] = useState<any[]>(['4', '5']);
   const dataSource = [
     {
       key: '1',

--- a/packages/design/src/table/index.tsx
+++ b/packages/design/src/table/index.tsx
@@ -10,10 +10,10 @@ import type { ReactElement, ReactNode } from 'react';
 import React, { useContext, useEffect, useState } from 'react';
 import ConfigProvider from '../config-provider';
 import Typography from '../typography';
-import enUS from '../locale/en-US';
 import useStyle from './style';
 import type { AnyObject } from '../_util/type';
 import useDefaultPagination from './hooks/useDefaultPagination';
+import useMergedState from 'rc-util/lib/hooks/useMergedState';
 
 export * from 'antd/es/table';
 
@@ -29,6 +29,9 @@ export interface TableLocale extends AntTableLocale {
 
 export interface TableProps<T> extends AntTableProps<T> {
   columns?: ColumnsType<T>;
+  cancelText?: string;
+  collapseText?: string;
+  openText?: string;
   hiddenCancelBtn?: boolean;
   toolOptionsRender?: (selectedRowKeys, selectedRows) => ReactNode[];
   toolAlertRender?: false | ((selectedRowKeys, selectedRows) => ReactNode);
@@ -45,6 +48,9 @@ function Table<T>(props: TableProps<T>, ref: React.Ref<Reference>) {
     toolAlertRender,
     toolOptionsRender,
     toolSelectedContent,
+    cancelText,
+    collapseText,
+    openText,
     expandable,
     hiddenCancelBtn = false,
     prefixCls: customizePrefixCls,
@@ -73,7 +79,11 @@ function Table<T>(props: TableProps<T>, ref: React.Ref<Reference>) {
   );
 
   const [openPopover, setOpenPopover] = useState<boolean>(false);
-  const [currentSelectedRowKeys, setCurrentSelectedRowKeys] = useState<any[]>();
+  const [currentSelectedRowKeys, setCurrentSelectedRowKeys] = useMergedState([], {
+    value: rowSelection?.selectedRowKeys,
+    defaultValue: rowSelection?.defaultSelectedRowKeys,
+  });
+
   const [currentSelectedRows, setCurrentSelectedRows] = useState<any[]>([]);
   const [currentSelectedInfo, setCurrentSelectedInfo] = useState<any>({});
 
@@ -158,7 +168,9 @@ function Table<T>(props: TableProps<T>, ref: React.Ref<Reference>) {
                 <span>{batchOperationBar?.object}</span>
               </span>
             )}
-            {!hiddenCancelBtn && <a onClick={handleOptionsCancel}>{batchOperationBar?.cancel}</a>}
+            {!hiddenCancelBtn && (
+              <a onClick={handleOptionsCancel}>{cancelText ?? batchOperationBar?.cancel}</a>
+            )}
             {toolSelectedContent && (
               <Popover
                 placement="top"
@@ -168,7 +180,9 @@ function Table<T>(props: TableProps<T>, ref: React.Ref<Reference>) {
                 open={openPopover}
               >
                 <a onClick={() => setOpenPopover(!openPopover)}>
-                  {openPopover ? batchOperationBar?.collapse : batchOperationBar?.open}
+                  {openPopover
+                    ? collapseText ?? batchOperationBar?.collapse
+                    : openText ?? batchOperationBar?.open}
                 </a>
               </Popover>
             )}

--- a/packages/design/src/table/index.tsx
+++ b/packages/design/src/table/index.tsx
@@ -53,15 +53,16 @@ function Table<T>(props: TableProps<T>, ref: React.Ref<Reference>) {
   const extendedContext = useContext(ConfigProvider.ExtendedConfigContext);
   const pagination = useDefaultPagination(customPagination);
 
+  const { getPrefixCls, locale, table } = useContext(ConfigProvider.ConfigContext);
   const { batchOperationBar, ...restLocale } = {
+    ...locale.Table,
     ...customLocale,
     batchOperationBar: {
-      ...enUS.Table?.batchOperationBar,
+      ...locale.Table?.batchOperationBar,
       ...customLocale?.batchOperationBar,
     },
   };
 
-  const { getPrefixCls, table } = useContext(ConfigProvider.ConfigContext);
   const prefixCls = getPrefixCls('table', customizePrefixCls);
   const { wrapSSR } = useStyle(prefixCls);
   const tableCls = classNames(

--- a/packages/design/src/table/index.tsx
+++ b/packages/design/src/table/index.tsx
@@ -14,6 +14,7 @@ import useStyle from './style';
 import type { AnyObject } from '../_util/type';
 import useDefaultPagination from './hooks/useDefaultPagination';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
+import enUS from '../locale/en-US';
 
 export * from 'antd/es/table';
 
@@ -61,10 +62,12 @@ function Table<T>(props: TableProps<T>, ref: React.Ref<Reference>) {
 
   const { getPrefixCls, locale, table } = useContext(ConfigProvider.ConfigContext);
   const { batchOperationBar, ...restLocale } = {
-    ...locale.Table,
+    ...enUS.Table,
+    ...locale?.Table,
     ...customLocale,
     batchOperationBar: {
-      ...locale.Table?.batchOperationBar,
+      ...enUS.Table?.batchOperationBar,
+      ...locale?.Table?.batchOperationBar,
       ...customLocale?.batchOperationBar,
     },
   };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
1. BatchOperationBar less locale
2. BatchOperationBar don't related rowSelection
3. API Unrealized

| Before | After |
| :--- | :--- |
| ![image](https://github.com/oceanbase/oceanbase-design/assets/32009993/2e175231-931f-46dc-97ce-778f8583ad3f)| ![image](https://github.com/oceanbase/oceanbase-design/assets/32009993/41ad0186-c640-4212-aae7-085b568cc4cb)|

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix batchOperationBar don't related rowSelection and locale   |
| 🇨🇳 Chinese |    修复批量操作栏未关联 rowSelection ，以及缺少国际化 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
