### PR TITLE
improve(design): Table padding when Card styles.body.padding is 0

### DIFF
--- a/packages/design/src/card/index.tsx
+++ b/packages/design/src/card/index.tsx
@@ -31,6 +31,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
       tabList,
       prefixCls: customizePrefixCls,
       bodyStyle,
+      styles,
       className,
       ...restProps
     },
@@ -41,8 +42,11 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
     const tabsPrefixCls = getPrefixCls('tabs', customizePrefixCls);
     const { wrapSSR } = useStyle(prefixCls, tabsPrefixCls);
 
+    const zeroPaddingList = [0, '0', '0px'];
     // card body has no padding
-    const noBodyPadding = [0, '0', '0px'].includes(bodyStyle?.padding);
+    const noBodyPadding =
+      zeroPaddingList.includes(bodyStyle?.padding) ||
+      zeroPaddingList.includes(styles?.body?.padding);
 
     const cardCls = classNames(
       {
@@ -88,6 +92,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
           tabList={newTabList}
           prefixCls={customizePrefixCls}
           bodyStyle={bodyStyle}
+          styles={styles}
           className={cardCls}
           {...restProps}
         >


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

| Before | After |
| :--- | :--- |
| ![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/1077786c-e7fe-4fa8-aeca-71c1b6024fb4) | ![image](https://github.com/oceanbase/oceanbase-design/assets/14918822/cbec72db-89a0-4f00-993a-c1192044abe6) |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | 💄 优化 Table 在无间距卡片内的展示样式，包括第一列和卡片标题对齐、最后一列和卡片操作区对齐、分页器左右增加间距。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
