### PR TITLE
improve(design): Update colorBgBase token

### DIFF
--- a/packages/design/src/theme/default.ts
+++ b/packages/design/src/theme/default.ts
@@ -56,7 +56,7 @@ const defaultTheme: ThemeConfig = {
     colorInfoTextHover: '#5189FB',
     colorInfoText: '#006AFF',
     colorInfoTextActive: '#004CE6',
-    colorTextBase: '#132039',
+    colorTextBase: '#000000',
     colorText: '#132039',
     colorTextSecondary: '#5c6b8a',
     colorTextQuaternary: '#c1cbe0',

--- a/packages/design/src/theme/style/compact.less
+++ b/packages/design/src/theme/style/compact.less
@@ -17,7 +17,7 @@
 @colorError: #f93939;
 @colorInfo: #006aff;
 @colorLink: #006aff;
-@colorTextBase: #132039;
+@colorTextBase: #000000;
 @colorBgBase: #ffffff;
 @fontFamily: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',

--- a/packages/design/src/theme/style/default.less
+++ b/packages/design/src/theme/style/default.less
@@ -17,7 +17,7 @@
 @colorError: #f93939;
 @colorInfo: #006aff;
 @colorLink: #006aff;
-@colorTextBase: #132039;
+@colorTextBase: #000000;
 @colorBgBase: #ffffff;
 @fontFamily: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [x] Design Token Update

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

- `#132039` => `#000000` for `colorBgBase`.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | - 💄 更新 Design Token `colorBgBase` 的颜色值 `#132039` => `#000000`。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
