### PR TITLE
chore(docs): Add changelog for @oceanbase/design@0.3.7 and @oceanbase/codemod@0.3.6

### DIFF
--- a/docs/codemod/codemod-CHANGELOG.md
+++ b/docs/codemod/codemod-CHANGELOG.md
@@ -8,6 +8,13 @@ group: 自动化迁移工具
 
 ---
 
+## 0.3.6
+
+`2024-07-26`
+
+- ⭐️ 新增 `rgba(0,0,0,xx%)` 颜色值到 Design Token 的自动改写。[#656](https://github.com/oceanbase/oceanbase-design/pull/656)
+- ⭐️ 支持 `#000000xx` 等颜色值到 Design Token 的自动改写。[#639](https://github.com/oceanbase/oceanbase-design/pull/639)
+
 ## 0.3.4
 
 `2024-06-27`

--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,16 @@ group: 基础组件
 
 ---
 
+## 0.3.7
+
+`2024-07-26`
+
+- 📖 补充 Button、Input 和 Switch 的示例和文档。[#640](https://github.com/oceanbase/oceanbase-design/pull/640) [#657](https://github.com/oceanbase/oceanbase-design/pull/657) [#658](https://github.com/oceanbase/oceanbase-design/pull/658)
+- 📖 新增阿里云和 less 主题使用文档，优化暗色主题使用文档。[#644](https://github.com/oceanbase/oceanbase-design/pull/644)
+- ⭐️ 新增阿里云主题的 less 变量文件，方便在 less 中使用。[#643](https://github.com/oceanbase/oceanbase-design/pull/643)
+- 💄 更新 Design Token `colorBgBase` 的颜色值 `#132039` => `#000000`。[#642](https://github.com/oceanbase/oceanbase-design/pull/642)
+- 💄 优化 Table 表头的字体颜色，以对齐设计规范。[#641](https://github.com/oceanbase/oceanbase-design/pull/641)
+
 ## 0.3.6
 
 `2024-07-10`


### PR DESCRIPTION
## @oceanbase/design@0.3.7

`2024-07-26`

- 📖 补充 Button、Input 和 Switch 的示例和文档。[#640](https://github.com/oceanbase/oceanbase-design/pull/640) [#657](https://github.com/oceanbase/oceanbase-design/pull/657) [#658](https://github.com/oceanbase/oceanbase-design/pull/658)
- 📖 新增阿里云和 less 主题使用文档，优化暗色主题使用文档。[#644](https://github.com/oceanbase/oceanbase-design/pull/644)
- ⭐️ 新增阿里云主题的 less 变量文件，方便在 less 中使用。[#643](https://github.com/oceanbase/oceanbase-design/pull/643)
- 💄 更新 Design Token `colorBgBase` 的颜色值 `#132039` => `#000000`。[#642](https://github.com/oceanbase/oceanbase-design/pull/642)
- 💄 优化 Table 表头的字体颜色，以对齐设计规范。[#641](https://github.com/oceanbase/oceanbase-design/pull/641)

---

## @oceanbase/codemod@0.3.6

`2024-07-26`

- ⭐️ 新增 `rgba(0,0,0,xx%)` 颜色值到 Design Token 的自动改写。[#656](https://github.com/oceanbase/oceanbase-design/pull/656)
- ⭐️ 支持 `#000000xx` 等颜色值到 Design Token 的自动改写。[#639](https://github.com/oceanbase/oceanbase-design/pull/639)