### PR TITLE
fix(README): use `console` lang guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use Gitpod, a free online dev environment for GitHub.
 
 Or clone locally:
 
-```bash
+```console
 $ git clone git@github.com:oceanbase/oceanbase-design.git
 $ cd oceanbase-design
 $ npm install -g pnpm


### PR DESCRIPTION
Code snippets beginning in `$`, which they are bash, the markdown lang is `console`.