### PR TITLE
improve(design): Breadcrumb last item color

### DIFF
--- a/packages/design/src/theme/default.ts
+++ b/packages/design/src/theme/default.ts
@@ -90,6 +90,7 @@ const defaultTheme: ThemeConfig = {
       // @ts-ignore
       // fontHeight is internal token
       fontHeight: 20,
+      lastItemColor: '#5c6b8a',
     },
     InputNumber: {
       handleVisible: true,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

![image](https://github.com/user-attachments/assets/a82c1a2a-0cb9-4c91-bddf-8fd236f92c06)

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

| Before | After |
| :--- | :--- |
| ![image](https://github.com/user-attachments/assets/28a6caaf-fd93-466c-b80b-3db0507588ca) | ![image](https://github.com/user-attachments/assets/dbcf589f-5f07-4a21-9812-bacec727ec5c) |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.


-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  -         |
| 🇨🇳 Chinese |  - 💄 将 Breadcrumb 最后一项的字体颜色改为 `#5c6b8a`。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
