### PR TITLE
fix(design): mouseFollow Tooltip should inherit `.ant-tooltip` className

### DIFF
--- a/packages/design/src/tooltip/MouseTooltip.tsx
+++ b/packages/design/src/tooltip/MouseTooltip.tsx
@@ -83,10 +83,10 @@ const MouseTooltip: React.FC<MouseTooltipProps> = ({
             boxShadow: token.boxShadowSecondary,
             borderRadius: token.borderRadius,
             // @ts-ignore
-            color: textColor || token.Tooltip.colorTextLightSolid || token.colorTextLightSolid,
+            color: textColor || token.Tooltip?.colorTextLightSolid || token.colorTextLightSolid,
             backgroundColor:
               // @ts-ignore
-              backgroundColor || token.Tooltip.colorBgSpotlight || token.colorBgSpotlight,
+              backgroundColor || token.Tooltip?.colorBgSpotlight || token.colorBgSpotlight,
             left: isOverWidth ? clientX - tooltipWidth - offset : clientX + offset,
             top: isOverHeight ? clientY - tooltipHeight - offset : clientY + offset,
             ...restOverlayInnerStyle,

--- a/packages/design/src/tooltip/__tests__/index.test.tsx
+++ b/packages/design/src/tooltip/__tests__/index.test.tsx
@@ -179,4 +179,17 @@ describe('Tooltip', () => {
     expect(isTooltipOpen()).toBeFalsy();
     expect(container.querySelector('.ant-tooltip-open')).toBeNull();
   });
+
+  it('mouseFollow Tooltip should inherit `.ant-tooltip` className', async () => {
+    const { container } = render(
+      <Tooltip title="This is prompt text" mouseFollow={true}>
+        <div id="hello">Hello world!</div>
+      </Tooltip>
+    );
+
+    const divElement = container.querySelector('#hello');
+    fireEvent.mouseEnter(divElement!);
+    await waitFakeTimer();
+    expect(container.querySelector('.ant-tooltip')).not.toBeNull();
+  });
 });

--- a/packages/design/src/tooltip/demo/mouse-follow.tsx
+++ b/packages/design/src/tooltip/demo/mouse-follow.tsx
@@ -38,7 +38,7 @@ const App: React.FC = () => {
         </Col>
         <Col span={12}>
           <Tooltip
-            title="This is prompt text. This is prompt text. This is prompt text. This is prompt text."
+            title="This is prompt text. This is prompt text. This is prompt text. This is prompt text. This is prompt text."
             type={type}
             mouseFollow={true}
           >

--- a/packages/design/src/tooltip/index.tsx
+++ b/packages/design/src/tooltip/index.tsx
@@ -59,7 +59,8 @@ const Tooltip = React.forwardRef<TooltipRef, TooltipProps>(
     const prefixCls = getPrefixCls('tooltip', customizePrefixCls);
     const { wrapSSR, hashId } = useStyle(prefixCls);
 
-    const tooltipCls = classNames(className, hashId);
+    const tooltipCls = classNames(className);
+    const mouseTooltipCls = classNames(prefixCls, className, hashId);
     const [innerOpen, setInnerOpen] = useState(open ?? visible ?? defaultOpen ?? defaultVisible);
 
     // 同步 ant-design noTitle 逻辑
@@ -108,7 +109,7 @@ const Tooltip = React.forwardRef<TooltipRef, TooltipProps>(
             color: typeItem?.color,
             ...overlayInnerStyle,
           }}
-          className={tooltipCls}
+          className={mouseTooltipCls}
           overlay={overlay}
           {...restProps}
         >


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| ![image](https://github.com/user-attachments/assets/b59e58d4-671b-4475-8bf0-f95f7855faac) | ![image](https://github.com/user-attachments/assets/5462a7c4-7943-4b51-9247-f7f956c46b69) |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | - 🐞 修复 Tooltip 开启 `mouseFollow` 后没有继承 `.ant-tooltip` 类名和样式的问题。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
