### PR TITLE
feat(design): Add Popconfirm docs and demos

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -192,6 +192,7 @@ export default defineConfig({
             { title: 'Modal 对话框', link: '/components/modal' },
             { title: 'Drawer 抽屉', link: '/components/drawer' },
             { title: 'Notification 通知提醒框', link: '/components/notification' },
+            { title: 'Popconfirm 气泡确认框', link: '/components/popconfirm' },
             { title: 'Progress 进度条', link: '/components/progress' },
             { title: 'Result 结果', link: '/components/result' },
             { title: 'Skeleton 骨架屏', link: '/components/skeleton' },

--- a/packages/design/src/popconfirm/demo/basic.tsx
+++ b/packages/design/src/popconfirm/demo/basic.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Button, message, Popconfirm } from '@oceanbase/design';
+
+const App: React.FC = () => (
+  <Popconfirm
+    title="Delete the task"
+    description="Are you sure to delete this task?"
+    onConfirm={e => {
+      console.log(e);
+      message.success('Click on Yes');
+    }}
+    onCancel={e => {
+      console.log(e);
+      message.info('Click on No');
+    }}
+  >
+    <Button danger>Delete</Button>
+  </Popconfirm>
+);
+
+export default App;

--- a/packages/design/src/popconfirm/demo/promise.tsx
+++ b/packages/design/src/popconfirm/demo/promise.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Button, message, Popconfirm } from '@oceanbase/design';
+
+const App: React.FC = () => (
+  <Popconfirm
+    title="Delete the task"
+    description="Are you sure to delete this task?"
+    onConfirm={() => {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          resolve(null);
+          message.success('The task is deleted');
+        }, 3000);
+      });
+    }}
+  >
+    <Button danger>Delete</Button>
+  </Popconfirm>
+);
+
+export default App;

--- a/packages/design/src/popconfirm/index.md
+++ b/packages/design/src/popconfirm/index.md
@@ -1,0 +1,19 @@
+---
+title: Popconfirm 气泡确认框
+nav:
+  title: 基础组件
+  path: /components
+---
+
+- 🔥 完全继承 antd [Popconfirm](https://ant.design/components/popconfirm-cn) 的能力和 API，可无缝切换。
+- 💄 定制主题和样式，符合 OceanBase Design 设计规范。
+
+## 代码演示
+
+<code src="./demo/basic.tsx" title="基本"></code>
+
+<code src="./demo/promise.tsx" title="基于 Promise 的异步关闭" description="点击确定后异步关闭气泡确认框。"></code>
+
+## API
+
+- 详见 antd Popconfirm 文档: https://ant.design/components/popconfirm-cn


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

![image](https://github.com/user-attachments/assets/ccbabe37-cdf8-44c3-961c-42e442033582)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | - 📖 新增 Popconfirm 的文档和示例。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
