### PR TITLE
feat(design): Add DatePicker docs and demos

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -160,6 +160,7 @@ export default defineConfig({
             { title: 'InputNumber 数字输入框', link: '/components/input-number' },
             { title: 'Radio 单选框', link: '/components/radio' },
             { title: 'Checkbox 多选框', link: '/components/checkbox' },
+            { title: 'DatePicker 日期选择框', link: '/components/date-picker' },
             { title: 'Switch 开关', link: '/components/switch' },
             { title: 'Select 选择器', link: '/components/select' },
             { title: 'TreeSelect 树选择', link: '/components/tree-select' },

--- a/packages/design/src/date-picker/demo/basic.tsx
+++ b/packages/design/src/date-picker/demo/basic.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { DatePicker, Space } from '@oceanbase/design';
+import type { DatePickerProps } from '@oceanbase/design';
+
+const onChange: DatePickerProps['onChange'] = (date, dateString) => {
+  console.log(date, dateString);
+};
+
+const App: React.FC = () => (
+  <Space direction="vertical">
+    <DatePicker onChange={onChange} />
+    <DatePicker onChange={onChange} showTime />
+    <DatePicker onChange={onChange} picker="week" />
+    <DatePicker onChange={onChange} picker="month" />
+    <DatePicker onChange={onChange} picker="quarter" />
+    <DatePicker onChange={onChange} picker="year" />
+  </Space>
+);
+
+export default App;

--- a/packages/design/src/date-picker/demo/ranger-picker.tsx
+++ b/packages/design/src/date-picker/demo/ranger-picker.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { DatePicker, Space } from '@oceanbase/design';
+
+const { RangePicker } = DatePicker;
+
+const App: React.FC = () => (
+  <Space direction="vertical" size={12}>
+    <RangePicker />
+    <RangePicker showTime />
+    <RangePicker picker="week" />
+    <RangePicker picker="month" />
+    <RangePicker picker="quarter" />
+    <RangePicker picker="year" />
+  </Space>
+);
+
+export default App;

--- a/packages/design/src/date-picker/index.md
+++ b/packages/design/src/date-picker/index.md
@@ -1,0 +1,21 @@
+---
+title: DatePicker 日期选择框
+nav:
+  title: 基础组件
+  path: /components
+demo:
+  cols: 2
+---
+
+- 🔥 完全继承 antd [DatePicker](https://ant.design/components/date-picker-cn) 的能力和 API，可无缝切换。
+- 💄 定制主题和样式，符合 OceanBase Design 设计规范。
+
+## 代码演示
+
+<!-- prettier-ignore -->
+<code src="./demo/basic.tsx" title="选择器"></code> 
+<code src="./demo/ranger-picker.tsx" title="范围选择器"></code>
+
+## API
+
+- 详见 antd DatePicker 文档: https://ant.design/components/date-picker-cn


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

![image](https://github.com/user-attachments/assets/140bb295-493b-4c1c-9c27-7eda109b255c)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | - 📖 新增 DatePicker 的文档和示例。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
