### PR TITLE
feat(ui): Action onClick add event param

### DIFF
--- a/packages/ui/src/Action/Item.tsx
+++ b/packages/ui/src/Action/Item.tsx
@@ -8,7 +8,7 @@ export interface BaseProps extends ButtonProps {
   visible?: boolean;
   /** 固定展示、不会被折叠 */
   fixed?: boolean;
-  onClick?: () => Promise<void> | void;
+  onClick?: (e: React.MouseEvent<HTMLElement, MouseEvent>) => Promise<void> | void;
   children?: React.ReactElement | string;
   enableLoading?: boolean;
   tooltip?: string;
@@ -26,8 +26,8 @@ export class ActionButton extends React.PureComponent<BaseProps> {
       <Tooltip placement="top" title={tooltip}>
         <Button
           loading={enableLoading && (loading || this.state.loading)}
-          onClick={_ => {
-            const handle = onClick?.();
+          onClick={e => {
+            const handle = onClick?.(e);
 
             if (enableLoading && (handle as Promise<void>)?.then) {
               this.setState({ loading: true });
@@ -68,8 +68,8 @@ export class ActionLink extends React.PureComponent<BaseProps> {
       <Typography.Link
         style={{ padding: 0, ...style }}
         disabled={loading || disabled || this.state.disabled}
-        onClick={_ => {
-          const handle = onClick?.();
+        onClick={e => {
+          const handle = onClick?.(e);
 
           if (enableLoading && (handle as Promise<void>)?.then) {
             this.setState({ loading: true, disabled: true });

--- a/packages/ui/src/Action/index.md
+++ b/packages/ui/src/Action/index.md
@@ -33,27 +33,27 @@ nav:
 
 ### Action.Link
 
-| 参数      | 说明               | 类型                           | 默认值 |
-| :-------- | :----------------- | :----------------------------- | :----- |
-| visible   | 是否可见           | boolean                        | true   |
-| loading   | 设置加载状态       | boolean                        | false  |
-| tooltip   | 设置提示文案       | string                         | -      |
-| disabled  | 是否禁用           | boolean                        | false  |
-| fixed     | 固定展示、不被折叠 | boolean                        | false  |
-| onClick   | 点击链接的回调     | async () => void \| () => void | -      |
-| className | 设置 link 的样式名 | string                         | -      |
+| 参数 | 说明 | 类型 | 默认值 |
+| :-- | :-- | :-- | :-- |
+| visible | 是否可见 | boolean | true |
+| loading | 设置加载状态 | boolean | false |
+| tooltip | 设置提示文案 | string | - |
+| disabled | 是否禁用 | boolean | false |
+| fixed | 固定展示、不被折叠 | boolean | false |
+| onClick | 点击链接的回调 | async (event: React.MouseEvent<HTMLElement, MouseEvent>) => void \| (event: React.MouseEvent<HTMLElement, MouseEvent>) => void | - |
+| className | 设置 link 的样式名 | string | - |
 
 ### Action.Button
 
-| 参数      | 说明               | 类型                           | 默认值  |
-| :-------- | :----------------- | :----------------------------- | :------ |
-| visible   | 是否可见           | boolean                        | true    |
-| type      | 设置按钮类型       | primary \| default             | default |
-| size      | 设置按钮大小       | large \| middle \| small       | middle  |
-| danger    | 设置危险按钮       | boolean                        | false   |
-| disabled  | 是否禁用           | boolean                        | false   |
-| loading   | 设置加载状态       | boolean                        | false   |
-| tooltip   | 设置提示文案       | string                         | -       |
-| fixed     | 固定展示、不被折叠 | boolean                        | false   |
-| onClick   | 点击链接的回调     | async () => void \| () => void | -       |
-| className | 设置按钮的样式名   | string                         | -       |
+| 参数 | 说明 | 类型 | 默认值 |
+| :-- | :-- | :-- | :-- |
+| visible | 是否可见 | boolean | true |
+| type | 设置按钮类型 | primary \| default | default |
+| size | 设置按钮大小 | large \| middle \| small | middle |
+| danger | 设置危险按钮 | boolean | false |
+| disabled | 是否禁用 | boolean | false |
+| loading | 设置加载状态 | boolean | false |
+| tooltip | 设置提示文案 | string | - |
+| fixed | 固定展示、不被折叠 | boolean | false |
+| onClick | 点击链接的回调 | async (event: React.MouseEvent<HTMLElement, MouseEvent>) => void \| (event: React.MouseEvent<HTMLElement, MouseEvent>) => void | - |
+| className | 设置按钮的样式名 | string | - |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

Sometimes we need like `event.stopPropagation` to customize event behavior.

![image](https://github.com/user-attachments/assets/59a3b73d-afb6-4c32-afab-fd6aad25803c)
![image](https://github.com/user-attachments/assets/dfd484ea-d357-4d37-9e3e-5cbe90512d9c)


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - 🆕 The click event of the Action component supports the e param。 |
| 🇨🇳 Chinese | - 🆕 Action 组件 onClick 函数增加 event 参数。  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
