### PR TITLE
chore(ui): Add Action demo with tooltip and popconfirm

### DIFF
--- a/packages/ui/src/Action/demo/with-tooltip-popconfirm.tsx
+++ b/packages/ui/src/Action/demo/with-tooltip-popconfirm.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Popconfirm, Space } from '@oceanbase/design';
+import { Action } from '@oceanbase/ui';
+import { DownOutlined } from '@oceanbase/icons';
+
+export default () => {
+  return (
+    <Action.Group
+      moreText={
+        <Space size={4}>
+          更多
+          <DownOutlined />
+        </Space>
+      }
+    >
+      <Action.Button type="primary" tooltip="This is tooltip">
+        action1
+      </Action.Button>
+      <Popconfirm placement="bottom" title="Confirm to delete it?">
+        <Action.Button danger tooltip="This is tooltip">
+          危险按钮
+        </Action.Button>
+      </Popconfirm>
+      <Action.Button>action3</Action.Button>
+      <Action.Button>action4</Action.Button>
+      <Action.Button>action5</Action.Button>
+    </Action.Group>
+  );
+};

--- a/packages/ui/src/Action/index.md
+++ b/packages/ui/src/Action/index.md
@@ -7,14 +7,12 @@ nav:
 
 ## 代码演示
 
+<!-- prettier-ignore -->
 <code src="./demo/link.tsx" title="Action.Link"></code>
-
 <code src="./demo/button.tsx" title="Action.Button"></code>
-
 <code src="./demo/loading.tsx" title="loading 状态"></code>
-
+<code src="./demo/with-tooltip-popconfirm.tsx" title="带 Tooltip 和 Popconfirm"></code>
 <code src="./demo/fixed.tsx" title="固定展示、不被折叠的 Action"></code>
-
 <code src="./demo/groupControl.tsx" title="整体控制状态"></code>
 
 ## API


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

![image](https://github.com/user-attachments/assets/d1222491-0fa0-48b2-9e38-fb84bdacc6b4)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | - 📖 Action 新增带 Tooltip 和 Popconfirm 的示例。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
