### PR TITLE
improve(design): Add cursor style for expandRowByClick Table

### DIFF
--- a/.dumi/theme/common/styles/Markdown.tsx
+++ b/.dumi/theme/common/styles/Markdown.tsx
@@ -518,6 +518,10 @@ const GlobalStyle: React.FC = () => {
           }
         }
 
+        .dumi-default-previewer-demo {
+          padding: 24px 24px;
+        }
+
         [id='components-grid-demo-playground'],
         [id='components-grid-demo-gutter'] {
           > .code-box-demo ${antCls}-row > div {

--- a/packages/design/src/table/demo/expandable.tsx
+++ b/packages/design/src/table/demo/expandable.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import type { TableColumnsType } from '@oceanbase/design';
+import { Form, Switch, Table } from '@oceanbase/design';
+
+interface DataType {
+  key: React.Key;
+  name: string;
+  platform: string;
+  version: string;
+  upgradeNum: number;
+  creator: string;
+  createdAt: string;
+}
+
+const App: React.FC = () => {
+  const [expandRowByClick, setExpandRowByClick] = useState(false);
+
+  const columns: TableColumnsType<DataType> = [
+    { title: 'Name', dataIndex: 'name', key: 'name' },
+    { title: 'Platform', dataIndex: 'platform', key: 'platform' },
+    { title: 'Version', dataIndex: 'version', key: 'version' },
+    { title: 'Upgraded', dataIndex: 'upgradeNum', key: 'upgradeNum' },
+    { title: 'Creator', dataIndex: 'creator', key: 'creator' },
+    { title: 'Date', dataIndex: 'createdAt', key: 'createdAt' },
+    { title: 'Action', key: 'operation', render: () => <a>Publish</a> },
+  ];
+
+  const data: DataType[] = [];
+  for (let i = 0; i < 3; ++i) {
+    data.push({
+      key: i.toString(),
+      name: 'Screem',
+      platform: 'iOS',
+      version: '10.3.4.5654',
+      upgradeNum: 500,
+      creator: 'Jack',
+      createdAt: '2014-12-24 23:12:00',
+    });
+  }
+
+  return (
+    <>
+      <Form layout="inline" style={{ marginBottom: 16 }}>
+        <Form.Item label="expandRowByClick" required={true}>
+          <Switch
+            size="small"
+            value={expandRowByClick}
+            onClick={value => {
+              setExpandRowByClick(value);
+            }}
+          />
+        </Form.Item>
+      </Form>
+      <Table
+        columns={columns}
+        expandable={{
+          expandRowByClick,
+          expandedRowRender: () => <div>This is expanded content</div>,
+          defaultExpandedRowKeys: ['0'],
+        }}
+        dataSource={data}
+      />
+    </>
+  );
+};
+
+export default App;

--- a/packages/design/src/table/demo/multiple-nesting-tables.tsx
+++ b/packages/design/src/table/demo/multiple-nesting-tables.tsx
@@ -54,7 +54,6 @@ const App: React.FC = () => {
         key: 'operation',
         render: () => (
           <Space size="middle">
-            <a>Pause</a>
             <a>Stop</a>
             <Dropdown menu={{ items }}>
               <a>
@@ -115,7 +114,7 @@ const App: React.FC = () => {
 
   return (
     <>
-      <Form style={{ marginBottom: 24 }}>
+      <Form style={{ marginBottom: 16 }}>
         <Form.Item label="Size" required={true}>
           <Radio.Group
             value={size}

--- a/packages/design/src/table/demo/nesting-tables.tsx
+++ b/packages/design/src/table/demo/nesting-tables.tsx
@@ -45,7 +45,6 @@ const App: React.FC = () => {
         key: 'operation',
         render: () => (
           <Space size="middle">
-            <a>Pause</a>
             <a>Stop</a>
             <Dropdown menu={{ items }}>
               <a>
@@ -94,7 +93,7 @@ const App: React.FC = () => {
 
   return (
     <>
-      <Form style={{ marginBottom: 24 }}>
+      <Form style={{ marginBottom: 16 }}>
         <Form.Item label="Size" required={true}>
           <Radio.Group
             value={size}

--- a/packages/design/src/table/index.md
+++ b/packages/design/src/table/index.md
@@ -15,11 +15,12 @@ nav:
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx" title="基本"></code>
 <code src="./demo/bordered.tsx" title="带边框" description="添加表格边框线"></code>
+<code src="./demo/ellipsis.tsx" title="单元格自动省略" description="设置 `column.ellipsis` 可以让单元格内容根据宽度自动省略，并使用 Tooltip 展示全部内容。`说明`: 列头缩略暂不支持和排序筛选一起使用。"></code>
 <code src="./demo/fixed-columns-header-tables.tsx" title="固定头和列"></code>
 <code src="./demo/row-selection.tsx" title="选择和操作"></code>
+<code src="./demo/expandable.tsx" title="可展开"></code>
 <code src="./demo/nesting-tables.tsx" title="嵌套子表格"></code>
 <code src="./demo/multiple-nesting-tables.tsx" title="可选择的嵌套子表格"></code>
-<code src="./demo/ellipsis.tsx" title="单元格自动省略" description="设置 `column.ellipsis` 可以让单元格内容根据宽度自动省略，并使用 Tooltip 展示全部内容。`说明`: 列头缩略暂不支持和排序筛选一起使用。"></code>
 <code src="./demo/tree-table.tsx" title="树形表格" description="当数据中有 `children` 字段时会自动展示为树形表格，如果不需要或配置为其他字段可以用 childrenColumnName 进行配置。可以通过设置 indentSize 以控制每一层的缩进宽度。"></code>
 <code src="./demo/grouping-columns.tsx" title="表头分组" description="columns 可以通过嵌套 children，实现表头分组。"></code>
 <code src="./demo/rowspan.tsx" title="行合并" description="通过 onCell 设置单元格属性 rowSpan，可以实现行合并。"></code>

--- a/packages/design/src/table/index.tsx
+++ b/packages/design/src/table/index.tsx
@@ -48,6 +48,7 @@ function Table<T extends Record<string, any>>(props: TableProps<T>, ref: React.R
     footer,
     pagination: customPagination,
     rowSelection,
+    rowClassName,
     toolAlertRender,
     toolOptionsRender,
     toolSelectedContent,
@@ -223,6 +224,14 @@ function Table<T extends Record<string, any>>(props: TableProps<T>, ref: React.R
         ),
       }}
       columns={newColumns}
+      rowClassName={(...args) => {
+        return classNames(
+          typeof rowClassName === 'function' ? rowClassName(...args) : rowClassName,
+          {
+            [`${prefixCls}-expand-row-by-click`]: expandable?.expandRowByClick,
+          }
+        );
+      }}
       expandable={
         expandable
           ? {

--- a/packages/design/src/table/style/index.ts
+++ b/packages/design/src/table/style/index.ts
@@ -69,6 +69,10 @@ export const genTableStyle: GenerateStyle<TableToken> = (token: TableToken): CSS
         [`${componentCls}-tbody-virtual-scrollbar ${componentCls}-tbody-virtual-scrollbar-thumb`]: {
           background: `${token.colorFillSecondary} !important`,
         },
+        // expandRowByClick 行样式
+        [`tr${componentCls}-expand-row-by-click`]: {
+          cursor: 'pointer',
+        },
         // 去掉可展开行在展开时的底部 border
         [`tr > td:has(${componentCls}-row-expand-icon-expanded)`]: {
           borderBottom: 'none',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

![image](https://github.com/user-attachments/assets/194cb307-0013-430f-943f-5a7bcbdf03ee)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | - 💄 Table 点击行可展开时，设置行样式为 `cursor: pointer`。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
