### PR TITLE
improve(design): Set required to true for Form.Item with Switch to hide optional mark

### DIFF
--- a/packages/design/src/form/FormItem.tsx
+++ b/packages/design/src/form/FormItem.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import React from 'react';
 import type { TooltipProps } from '../tooltip';
 import { useTooltipTypeList } from '../tooltip/hooks/useTooltipTypeList';
+import { isPlainObject } from 'lodash';
 
 const AntFormItem = AntForm.Item;
 
@@ -34,7 +35,13 @@ const Item: React.FC<FormItemProps> = ({ children, tooltip, ...restProps }) => {
   }
 
   return (
-    <AntFormItem tooltip={tooltip} {...restProps}>
+    <AntFormItem
+      tooltip={tooltip}
+      // auto set required for Switch children to hide optional mark
+      // @ts-ignore
+      required={isPlainObject(children) && children.type?.__ANT_SWITCH ? true : undefined}
+      {...restProps}
+    >
       {children}
     </AntFormItem>
   );

--- a/packages/design/src/form/__tests__/__snapshots__/switch.test.tsx.snap
+++ b/packages/design/src/form/__tests__/__snapshots__/switch.test.tsx.snap
@@ -1,0 +1,296 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Form.Item with Switch > dynamic Switch 1`] = `
+<form
+  class="ant-form ant-form-horizontal"
+>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class="ant-form-item-required ant-form-item-required-mark-optional"
+          for="switch"
+          title="Switch"
+        >
+          Switch
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <button
+              aria-checked="false"
+              aria-required="true"
+              class="ant-switch"
+              id="switch"
+              role="switch"
+              type="button"
+            >
+              <div
+                class="ant-switch-handle"
+              />
+              <span
+                class="ant-switch-inner"
+              >
+                <span
+                  class="ant-switch-inner-checked"
+                />
+                <span
+                  class="ant-switch-inner-unchecked"
+                />
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`Form.Item with Switch > nested Switch 1`] = `
+<form
+  class="ant-form ant-form-horizontal"
+>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class="ant-form-item-required-mark-optional"
+          for="switch"
+          title="Switch"
+        >
+          Switch
+          <span
+            class="ant-form-item-optional"
+            title=""
+          >
+            (optional)
+          </span>
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <span
+              id="switch"
+            >
+              <button
+                aria-checked="false"
+                class="ant-switch"
+                role="switch"
+                type="button"
+              >
+                <div
+                  class="ant-switch-handle"
+                />
+                <span
+                  class="ant-switch-inner"
+                >
+                  <span
+                    class="ant-switch-inner-checked"
+                  />
+                  <span
+                    class="ant-switch-inner-unchecked"
+                  />
+                </span>
+              </button>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`Form.Item with Switch > normal Switch 1`] = `
+<form
+  class="ant-form ant-form-horizontal"
+>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class="ant-form-item-required ant-form-item-required-mark-optional"
+          for="switch"
+          title="Switch"
+        >
+          Switch
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <button
+              aria-checked="false"
+              aria-required="true"
+              class="ant-switch"
+              id="switch"
+              role="switch"
+              type="button"
+            >
+              <div
+                class="ant-switch-handle"
+              />
+              <span
+                class="ant-switch-inner"
+              >
+                <span
+                  class="ant-switch-inner-checked"
+                />
+                <span
+                  class="ant-switch-inner-unchecked"
+                />
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`Form.Item with Switch > renderProps Switch 1`] = `
+<form
+  class="ant-form ant-form-horizontal"
+>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class="ant-form-item-required-mark-optional"
+          for="switch"
+          title="Switch"
+        >
+          Switch
+          <span
+            class="ant-form-item-optional"
+            title=""
+          >
+            (optional)
+          </span>
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`Form.Item with Switch > sub component Switch 1`] = `
+<form
+  class="ant-form ant-form-horizontal"
+>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class="ant-form-item-required-mark-optional"
+          for="switch"
+          title="Switch"
+        >
+          Switch
+          <span
+            class="ant-form-item-optional"
+            title=""
+          >
+            (optional)
+          </span>
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <button
+              aria-checked="false"
+              class="ant-switch"
+              role="switch"
+              type="button"
+            >
+              <div
+                class="ant-switch-handle"
+              />
+              <span
+                class="ant-switch-inner"
+              >
+                <span
+                  class="ant-switch-inner-checked"
+                />
+                <span
+                  class="ant-switch-inner-unchecked"
+                />
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;

--- a/packages/design/src/form/__tests__/switch.test.tsx
+++ b/packages/design/src/form/__tests__/switch.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ConfigProvider, Form, Switch } from '@oceanbase/design';
+import type { FormItemProps } from '@oceanbase/design';
+
+const FormItemTest: React.FC<FormItemProps> = ({ children }) => (
+  <Form>
+    <Form.Item label="Switch" name="switch">
+      {children}
+    </Form.Item>
+  </Form>
+);
+
+describe('Form.Item with Switch', () => {
+  it('normal Switch', () => {
+    const { container, asFragment } = render(
+      <FormItemTest>
+        <Switch />
+      </FormItemTest>
+    );
+    expect(container.querySelector('.ant-form-item-optional')).toBeFalsy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('dynamic Switch', () => {
+    const { container, asFragment } = render(
+      <FormItemTest>{true ? <Switch /> : null}</FormItemTest>
+    );
+    expect(container.querySelector('.ant-form-item-optional')).toBeFalsy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('nested Switch', () => {
+    const { container, asFragment } = render(
+      <FormItemTest>
+        <span>
+          <Switch />
+        </span>
+      </FormItemTest>
+    );
+    expect(container.querySelector('.ant-form-item-optional')).toBeTruthy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('renderProps Switch', () => {
+    const { container, asFragment } = render(
+      <FormItemTest>
+        {() => {
+          return true ? <Switch /> : null;
+        }}
+      </FormItemTest>
+    );
+    expect(container.querySelector('.ant-form-item-optional')).toBeTruthy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('sub component Switch', () => {
+    const SwitchComponent = () => <Switch />;
+    const { container, asFragment } = render(
+      <FormItemTest>
+        <SwitchComponent />
+      </FormItemTest>
+    );
+    expect(container.querySelector('.ant-form-item-optional')).toBeTruthy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

| Before | After |
| :--- | :--- |
| ![image](https://github.com/user-attachments/assets/e677cc57-a905-4df9-893b-f592cb419f20) | ![image](https://github.com/user-attachments/assets/f8227db8-e3af-44ea-923f-a52a44eb6ce2) |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | - 💄 默认去掉 Form.Item 包裹 Switch 时的可选样式。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
