### PR TITLE
chore(docs): Add changelog for @oceanbase/design@0.4.7, @oceanbase/ui@0.4.8 and @oceanbase/codemod@0.4.7

### DIFF
--- a/docs/codemod/codemod-CHANGELOG.md
+++ b/docs/codemod/codemod-CHANGELOG.md
@@ -8,6 +8,12 @@ group: 自动化迁移工具
 
 ---
 
+## 0.4.7
+
+`2025-02-05`
+
+- ⭐️ 支持颜色值 `rgb(240,242,245)` 到 `colorBgLayout` 的自动改写。[#946](https://github.com/oceanbase/oceanbase-design/pull/946)
+
 ## 0.4.0
 
 `2024-10-09`

--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,16 @@ group: 基础组件
 
 ---
 
+## 0.4.7
+
+`2025-02-05`
+
+- 🔥 新增 11 篇设计规范文档，包括 5 篇设计原则、6 篇设计基础。[#954](https://github.com/oceanbase/oceanbase-design/pull/954)
+- 🔥 新增 6 篇组件规范文档，包括 Alert、Button、Tabs、Table、Modal 和 DateRanger。[#955](https://github.com/oceanbase/oceanbase-design/pull/955)
+- 📖 优化官网在移动端的样式和访问体验。[#956](https://github.com/oceanbase/oceanbase-design/pull/956)
+- 💄 默认去掉 Form.Item 包裹 Switch 时的可选样式。[#949](https://github.com/oceanbase/oceanbase-design/pull/949)
+- 💄 优化 Table 空状态的高度，大中小尺寸分别为 360px、260px 和 160px。[#947](https://github.com/oceanbase/oceanbase-design/pull/947)
+
 ## 0.4.6
 
 `2025-01-15`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,15 @@ group: 业务组件
 
 ---
 
+## 0.4.8
+
+`2025-02-05`
+
+- DateRanger
+  - 🆕 DateRanger 支持自定义快捷选项。[#952](https://github.com/oceanbase/oceanbase-design/pull/952)
+  - ⭐️ DateRanger 支持自动校验和交换起止时间。[#953](https://github.com/oceanbase/oceanbase-design/pull/953)
+- 💄 优化 ProTable 间距，以对齐 Table 在 Card 中的样式。[#948](https://github.com/oceanbase/oceanbase-design/pull/948)
+
 ## 0.4.7
 
 `2025-01-15`


### PR DESCRIPTION
## @oceanbase/design@0.4.7

`2025-02-05`

- 🔥 新增 11 篇设计规范文档，包括 5 篇设计原则、6 篇设计基础。[#954](https://github.com/oceanbase/oceanbase-design/pull/954)
- 🔥 新增 6 篇组件规范文档，包括 Alert、Button、Tabs、Table、Modal 和 DateRanger。[#955](https://github.com/oceanbase/oceanbase-design/pull/955)
- 📖 优化官网在移动端的样式和访问体验。[#956](https://github.com/oceanbase/oceanbase-design/pull/956)
- 💄 默认去掉 Form.Item 包裹 Switch 时的可选样式。[#949](https://github.com/oceanbase/oceanbase-design/pull/949)
- 💄 优化 Table 空状态的高度，大中小尺寸分别为 360px、260px 和 160px。[#947](https://github.com/oceanbase/oceanbase-design/pull/947)

---

## @oceanbase/ui@0.4.8

`2025-02-05`

- DateRanger
  - 🆕 DateRanger 支持自定义快捷选项。[#952](https://github.com/oceanbase/oceanbase-design/pull/952)
  - ⭐️ DateRanger 支持自动校验和交换起止时间。[#953](https://github.com/oceanbase/oceanbase-design/pull/953)
- 💄 优化 ProTable 间距，以对齐 Table 在 Card 中的样式。[#948](https://github.com/oceanbase/oceanbase-design/pull/948)

---

## @oceanbase/codemod@0.4.7

`2025-02-05`

- ⭐️ 支持颜色值 `rgb(240,242,245)` 到 `colorBgLayout` 的自动改写。[#946](https://github.com/oceanbase/oceanbase-design/pull/946)