### PR TITLE
feat(ui): [date-ranger] add overlayClassName and overlayStyle props

### DIFF
--- a/packages/ui/src/DateRanger/Ranger.tsx
+++ b/packages/ui/src/DateRanger/Ranger.tsx
@@ -89,6 +89,8 @@ export interface DateRangerProps
   size?: 'small' | 'large' | 'middle';
   tooltipProps?: TooltipProps;
   autoAdjustOverflow?: boolean;
+  overlayClassName?: string;
+  overlayStyle?: React.CSSProperties;
   locale?: any;
 }
 
@@ -130,6 +132,8 @@ const Ranger = React.forwardRef((props: DateRangerProps, ref) => {
     rules,
     tip,
     autoAdjustOverflow,
+    overlayClassName,
+    overlayStyle,
     ...rest
   } = props;
 
@@ -358,7 +362,10 @@ const Ranger = React.forwardRef((props: DateRangerProps, ref) => {
             }}
             dropdownRender={originNode => {
               return (
-                <div className={`${prefix}-dropdown-picker`}>
+                <div
+                  className={classNames(`${prefix}-dropdown-picker`, overlayClassName)}
+                  style={overlayStyle}
+                >
                   {originNode}
                   <Divider type="vertical" style={{ height: 'auto', margin: '0px 4px 0px 0px' }} />
                   <InternalPickerPanel

--- a/packages/ui/src/DateRanger/index.md
+++ b/packages/ui/src/DateRanger/index.md
@@ -43,6 +43,9 @@ markdown: |
 | hideYear | 当时间范围在本年时，隐藏年份 | boolean | false | - |
 | hideSecond | 隐藏"秒” | boolean | false | - |
 | autoCalcRange | 自动计算时间范围并回显到选择器tag | boolean | false | - |
+| autoAdjustOverflow | 选择面板被遮挡时自动调整位置 | boolean | true | - |
+| overlayClassName | 选择面板根元素的类名称 | string | - | - |
+| overlayStyle | 选择面板根元素的样式 | CSSProperties | - | - |
 | ref | updateCurrentTime 手动更新当前时间 | function | - | - |
 | 其他 antd/RangePicker 的 `props` | [antd-RangePicker](https://ant.design/components/date-picker-cn/#RangePicker) | - | - | - |
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

特殊场景需要做单独适配，目前无法自定义时间选择面板的样式，因此添加两个参数用于自定义时间选择面板的样式。

使用：

```tsx
<DateRanger
   overlayClassName="overlay-custom-date-ranger"
   overlayStyle={{ color: 'red' }}
/>
```

![image](https://github.com/user-attachments/assets/ba4870cc-9c24-4bd1-87d6-89b19dfbfbf5)


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add overlayClassName and overlayStyle props |
| 🇨🇳 Chinese | - 🆕 DateRanger 新增 `overlayClassName` 和 `overlayStyle` 属性，用于设置弹出面板的样式。  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
