### PR TITLE
chore(docs): Add changelog for @oceanbase/design@0.4.8 and @oceanbase/ui@0.4.9

### DIFF
--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,16 @@ group: 基础组件
 
 ---
 
+## 0.4.8
+
+`2025-02-13`
+
+- 📖 优化设计基础、设计原则和组件设计文档的内容和样式。[#966](https://github.com/oceanbase/oceanbase-design/pull/966)
+- 🐞 修复 `@ctrl/tinycolor` 依赖缺失的问题。[#973](https://github.com/oceanbase/oceanbase-design/pull/973)
+- Tooltip:
+  - 🔨 去掉 Tooltip `mouseFollow` 模式下控制台出现的 NaN 告警。[#968](https://github.com/oceanbase/oceanbase-design/pull/968)
+  - 🔨 将 [react-sticky-mouse-tooltip](https://github.com/marlo22/react-sticky-mouse-tooltip) 代码内置到 Tooltip，避免控制台告警和错误都指向 `MouseTooltip.jsx`、干扰问题排查。[#969](https://github.com/oceanbase/oceanbase-design/pull/969)
+
 ## 0.4.7
 
 `2025-02-05`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,13 +8,22 @@ group: 业务组件
 
 ---
 
+## 0.4.9
+
+`2025-02-13`
+
+- DateRanger
+  - 🆕 DateRanger 新增 `autoAdjustOverflow` 属性，用于控制弹出面板是否自动调整位置。[#972](https://github.com/oceanbase/oceanbase-design/pull/972) [@wzc520pyfm](https://github.com/wzc520pyfm)
+  - 🆕 DateRanger 新增 `overlayClassName` 和 `overlayStyle` 属性，用于设置弹出面板的样式。[#970](https://github.com/oceanbase/oceanbase-design/pull/970) [@wzc520pyfm](https://github.com/wzc520pyfm)
+- 🐞 修复 ProCard `ghost` 模式下卡片阴影和内容区 padding 不正确的问题。[#967](https://github.com/oceanbase/oceanbase-design/pull/967)
+
 ## 0.4.8
 
 `2025-02-05`
 
 - DateRanger
-  - 🆕 DateRanger 支持自定义快捷选项。[#952](https://github.com/oceanbase/oceanbase-design/pull/952)
-  - ⭐️ DateRanger 支持自动校验和交换起止时间。[#953](https://github.com/oceanbase/oceanbase-design/pull/953)
+  - 🆕 DateRanger 支持自定义快捷选项。[#952](https://github.com/oceanbase/oceanbase-design/pull/952) [@wzc520pyfm](https://github.com/wzc520pyfm)
+  - ⭐️ DateRanger 支持自动校验和交换起止时间。[#953](https://github.com/oceanbase/oceanbase-design/pull/953) [@linhf123](https://github.com/linhf123)
 - 💄 优化 ProTable 间距，以对齐 Table 在 Card 中的样式。[#948](https://github.com/oceanbase/oceanbase-design/pull/948)
 
 ## 0.4.7


### PR DESCRIPTION
## @oceanbase/design@0.4.8

`2025-02-13`

- 📖 优化设计基础、设计原则和组件设计文档的内容和样式。[#966](https://github.com/oceanbase/oceanbase-design/pull/966)
- 🐞 修复 `@ctrl/tinycolor` 依赖缺失的问题。[#973](https://github.com/oceanbase/oceanbase-design/pull/973)
- Tooltip:
  - 🔨 去掉 Tooltip `mouseFollow` 模式下控制台出现的 NaN 告警。[#968](https://github.com/oceanbase/oceanbase-design/pull/968)
  - 🔨 将 [react-sticky-mouse-tooltip](https://github.com/marlo22/react-sticky-mouse-tooltip) 代码内置到 Tooltip，避免控制台告警和错误都指向 `MouseTooltip.jsx`、干扰问题排查。[#969](https://github.com/oceanbase/oceanbase-design/pull/969)

---

## @oceanbase/ui@0.4.9

`2025-02-13`

- DateRanger
  - 🆕 DateRanger 新增 `autoAdjustOverflow` 属性，用于控制弹出面板是否自动调整位置。[#972](https://github.com/oceanbase/oceanbase-design/pull/972) [@wzc520pyfm](https://github.com/wzc520pyfm)
  - 🆕 DateRanger 新增 `overlayClassName` 和 `overlayStyle` 属性，用于设置弹出面板的样式。[#970](https://github.com/oceanbase/oceanbase-design/pull/970) [@wzc520pyfm](https://github.com/wzc520pyfm)
- 🐞 修复 ProCard `ghost` 模式下卡片阴影和内容区 padding 不正确的问题。[#967](https://github.com/oceanbase/oceanbase-design/pull/967)