### PR TITLE
chore(docs): Add changelog for @oceanbase/design@0.4.9

### DIFF
--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,19 @@ group: 基础组件
 
 ---
 
+## 0.4.9
+
+`2025-02-20`
+
+- 📖 Table 设计文档新增 高亮显式 规范。[#986](https://github.com/oceanbase/oceanbase-design/pull/986)
+- 📖 Typography 新增可复制和在 Modal 中编辑的示例。[#985](https://github.com/oceanbase/oceanbase-design/pull/985)
+- ⭐️ ConfigProvider 移除 `injectStaticFunction` 属性，改为自动判断是否注入可消费全局配置的静态方法。[#981](https://github.com/oceanbase/oceanbase-design/pull/981)
+- Table
+  - 🐞 修复 Table 可展开&固定列时的间距问题。[#982](https://github.com/oceanbase/oceanbase-design/pull/982)
+  - 🐞 修复 Table 可展开&可滚动时不应该展示斑马条的问题。[#983](https://github.com/oceanbase/oceanbase-design/pull/983)
+- 💄 Alert 改为使用线性图标，以对齐最新的设计规范。[#987](https://github.com/oceanbase/oceanbase-design/pull/987)
+- 💄 Dropdown.Button 默认图标改为 `DownOutlined` 向下箭头。[#984](https://github.com/oceanbase/oceanbase-design/pull/984)
+
 ## 0.4.8
 
 `2025-02-13`


### PR DESCRIPTION
## @oceanbase/design@0.4.9

`2025-02-20`

- 📖 Table 设计文档新增 高亮显式 规范。[#986](https://github.com/oceanbase/oceanbase-design/pull/986)
- 📖 Typography 新增可复制和在 Modal 中编辑的示例。[#985](https://github.com/oceanbase/oceanbase-design/pull/985)
- ⭐️ ConfigProvider 移除 `injectStaticFunction` 属性，改为自动判断是否注入可消费全局配置的静态方法。[#981](https://github.com/oceanbase/oceanbase-design/pull/981)
- Table
  - 🐞 修复 Table 可展开&固定列时的间距问题。[#982](https://github.com/oceanbase/oceanbase-design/pull/982)
  - 🐞 修复 Table 可展开&可滚动时不应该展示斑马条的问题。[#983](https://github.com/oceanbase/oceanbase-design/pull/983)
- 💄 Alert 改为使用线性图标，以对齐最新的设计规范。[#987](https://github.com/oceanbase/oceanbase-design/pull/987)
- 💄 Dropdown.Button 默认图标改为 `DownOutlined` 向下箭头。[#984](https://github.com/oceanbase/oceanbase-design/pull/984)