### PR TITLE
docs(design): Add docs and demo for AutoComplete

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -157,6 +157,7 @@ export default defineConfig({
         {
           title: '数据录入',
           children: [
+            { title: 'AutoComplete 自动完成', link: '/components/auto-complete' },
             { title: 'Cascader 级联选择', link: '/components/cascader' },
             { title: 'Form 表单', link: '/components/form' },
             { title: 'Input 输入框', link: '/components/input' },

--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -12,7 +12,7 @@ group: 基础组件
 
 `2025-02-20`
 
-- 📖 Table 设计文档新增 高亮显式 规范。[#986](https://github.com/oceanbase/oceanbase-design/pull/986)
+- 📖 Table 设计文档新增 `高亮显式` 规范。[#986](https://github.com/oceanbase/oceanbase-design/pull/986)
 - 📖 Typography 新增可复制和在 Modal 中编辑的示例。[#985](https://github.com/oceanbase/oceanbase-design/pull/985)
 - ⭐️ ConfigProvider 移除 `injectStaticFunction` 属性，改为自动判断是否注入可消费全局配置的静态方法。[#981](https://github.com/oceanbase/oceanbase-design/pull/981)
 - Table

--- a/packages/design/src/auto-complete/demo/basic.tsx
+++ b/packages/design/src/auto-complete/demo/basic.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { AutoComplete } from '@oceanbase/design';
+import type { AutoCompleteProps } from '@oceanbase/design';
+
+const App: React.FC = () => {
+  const [options, setOptions] = React.useState<AutoCompleteProps['options']>([]);
+  const handleSearch = (value: string) => {
+    setOptions(() => {
+      if (!value || value.includes('@')) {
+        return [];
+      }
+      return ['gmail.com', '163.com', 'qq.com'].map(domain => ({
+        label: `${value}@${domain}`,
+        value: `${value}@${domain}`,
+      }));
+    });
+  };
+  return (
+    <AutoComplete
+      style={{ width: 200 }}
+      onSearch={handleSearch}
+      placeholder="input here"
+      options={options}
+    />
+  );
+};
+
+export default App;

--- a/packages/design/src/auto-complete/demo/non-case-sensitive.tsx
+++ b/packages/design/src/auto-complete/demo/non-case-sensitive.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { AutoComplete } from '@oceanbase/design';
+
+const options = [
+  { value: 'Burns Bay Road' },
+  { value: 'Downing Street' },
+  { value: 'Wall Street' },
+];
+
+const App: React.FC = () => (
+  <AutoComplete
+    style={{ width: 200 }}
+    options={options}
+    placeholder="try to type `b`"
+    filterOption={(inputValue, option) =>
+      option!.value.toUpperCase().indexOf(inputValue.toUpperCase()) !== -1
+    }
+  />
+);
+
+export default App;

--- a/packages/design/src/auto-complete/index.md
+++ b/packages/design/src/auto-complete/index.md
@@ -1,0 +1,21 @@
+---
+title: AutoComplete 自动完成
+nav:
+  title: 基础组件
+  path: /components
+demo:
+  cols: 2
+---
+
+- 🔥 完全继承 antd [AutoComplete](https://ant.design/components/auto-complete-cn) 的能力和 API，可无缝切换。
+- 💄 定制主题和样式，符合 OceanBase Design 设计规范。
+
+## 代码演示
+
+<!-- prettier-ignore -->
+<code src="./demo/basic.tsx" title="基本" description="通过 `options` 设置自动完成的数据源。"></code>
+<code src="./demo/non-case-sensitive.tsx" title="不区分大小写"></code>
+
+## API
+
+- 详见 antd AutoComplete 文档: https://ant.design/components/auto-complete-cn


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

![image](https://github.com/user-attachments/assets/c5f92d3c-ff60-4474-8f9c-a6c45c4f2407)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | - 📖 新增 AutoComplete 的示例和文档。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
