### PR TITLE
feat(design): vertical Form.Item add action prop

### DIFF
--- a/packages/design/src/form/__tests__/__snapshots__/item.test.tsx.snap
+++ b/packages/design/src/form/__tests__/__snapshots__/item.test.tsx.snap
@@ -1,0 +1,212 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Form.Item > action should not work by default 1`] = `
+<form
+  class="ant-form ant-form-horizontal"
+>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class="ant-form-item-required-mark-optional"
+          for="name"
+          title="Name"
+        >
+          Name
+          <span
+            class="ant-form-item-optional"
+            title=""
+          >
+            (optional)
+          </span>
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <input
+              class="ant-input ant-input-outlined"
+              id="name"
+              placeholder="Please enter"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`Form.Item > action should not work for default layout 1`] = `
+<form
+  class="ant-form ant-form-horizontal"
+>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class="ant-form-item-required-mark-optional"
+          for="name"
+          title="Name"
+        >
+          Name
+          <span
+            class="ant-form-item-optional"
+            title=""
+          >
+            (optional)
+          </span>
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <input
+              class="ant-input ant-input-outlined"
+              id="name"
+              placeholder="Please enter"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`Form.Item > action should not work for horizontal layout 1`] = `
+<form
+  class="ant-form ant-form-horizontal"
+>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class="ant-form-item-required-mark-optional"
+          for="name"
+          title="Name"
+        >
+          Name
+          <span
+            class="ant-form-item-optional"
+            title=""
+          >
+            (optional)
+          </span>
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <input
+              class="ant-input ant-input-outlined"
+              id="name"
+              placeholder="Please enter"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`Form.Item > action should work for vertical layout 1`] = `
+<form
+  class="ant-form ant-form-vertical"
+>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class="ant-form-item-required-mark-optional"
+          for="name"
+          title=""
+        >
+          Name
+          <span
+            class="ant-form-item-action"
+          >
+            <a>
+              Action
+            </a>
+          </span>
+          <span
+            class="ant-form-item-optional"
+            title=""
+          >
+            (optional)
+          </span>
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <input
+              class="ant-input ant-input-outlined"
+              id="name"
+              placeholder="Please enter"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;

--- a/packages/design/src/form/__tests__/item.test.tsx
+++ b/packages/design/src/form/__tests__/item.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ConfigProvider, Form, Input } from '@oceanbase/design';
+import type { FormItemProps } from '@oceanbase/design';
+
+const FormItemTest: React.FC<FormItemProps> = props => (
+  <Form.Item label="Name" name="name" {...props}>
+    <Input />
+  </Form.Item>
+);
+
+describe('Form.Item', () => {
+  it('action should not work by default', () => {
+    const { container, asFragment } = render(
+      <Form>
+        <FormItemTest />
+      </Form>
+    );
+    expect(container.querySelector('.ant-form-item-action')).toBeFalsy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('action should not work for default layout', () => {
+    const { container, asFragment } = render(
+      <Form layout="horizontal">
+        <FormItemTest action={<a>Action</a>} />
+      </Form>
+    );
+    expect(container.querySelector('.ant-form-item-action')).toBeFalsy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('action should not work for horizontal layout', () => {
+    const { container, asFragment } = render(
+      <Form layout="horizontal">
+        <FormItemTest action={<a>Action</a>} />
+      </Form>
+    );
+    expect(container.querySelector('.ant-form-item-action')).toBeFalsy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('action should work for vertical layout', () => {
+    const { container, asFragment } = render(
+      <Form layout="vertical">
+        <FormItemTest action={<a>Action</a>} />
+      </Form>
+    );
+    expect(container.querySelector('.ant-form-item-action')).toBeTruthy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+});

--- a/packages/design/src/form/demo/form-item-action.tsx
+++ b/packages/design/src/form/demo/form-item-action.tsx
@@ -13,22 +13,23 @@ const onFinishFailed = (errorInfo: any) => {
 const App: React.FC = () => (
   <Form
     name="basic"
-    labelCol={{ span: 6 }}
-    wrapperCol={{ span: 10 }}
+    layout="horizontal"
     onFinish={onFinish}
     onFinishFailed={onFinishFailed}
+    style={{ maxWidth: 400 }}
   >
     <Form.Item
       label="Username"
       name="username"
+      action={<a>Action</a>}
       rules={[{ required: true, message: 'Please input your username!' }]}
     >
       <Input />
     </Form.Item>
-    <Form.Item label="Address" name="address">
+    <Form.Item label="Address" name="address" action={<a>Action</a>}>
       <Input />
     </Form.Item>
-    <Form.Item wrapperCol={{ offset: 6, span: 10 }}>
+    <Form.Item>
       <Button type="primary" htmlType="submit">
         Submit
       </Button>

--- a/packages/design/src/form/demo/form-item-tooltip.tsx
+++ b/packages/design/src/form/demo/form-item-tooltip.tsx
@@ -7,7 +7,6 @@ const onFinish = (values: any) => {
 };
 
 const onFinishFailed = (errorInfo: any) => {
-  message.error('Failed');
   console.log(errorInfo);
 };
 

--- a/packages/design/src/form/demo/hideRequiredMark.tsx
+++ b/packages/design/src/form/demo/hideRequiredMark.tsx
@@ -7,7 +7,6 @@ const onFinish = (values: any) => {
 };
 
 const onFinishFailed = (errorInfo: any) => {
-  message.error('Failed');
   console.log(errorInfo);
 };
 

--- a/packages/design/src/form/demo/requiredMark-same-with-antd.tsx
+++ b/packages/design/src/form/demo/requiredMark-same-with-antd.tsx
@@ -7,7 +7,6 @@ const onFinish = (values: any) => {
 };
 
 const onFinishFailed = (errorInfo: any) => {
-  message.error('Failed');
   console.log(errorInfo);
 };
 

--- a/packages/design/src/form/index.md
+++ b/packages/design/src/form/index.md
@@ -17,6 +17,7 @@ nav:
 <code src="./demo/basic.tsx" title="基本" description="默认为可选样式。"></code>
 <code src="./demo/requiredMark-same-with-antd.tsx" title="设置为必选样式" description="通过 `requiredMark` 进行设置。"></code>
 <code src="./demo/form-item-tooltip.tsx" title="设置提示信息" description="可在 `Form.Item` 上设置 `tooltip` 和 `extra` 提示信息。"></code>
+<code src="./demo/form-item-action.tsx" title="操作项" description="可在 `Form.Item` 上设置 `action` 操作项，仅垂直布局生效。"></code>
 <code src="./demo/layout.tsx" title="表单布局"></code>
 <code src="./demo/multiple-layout.tsx" title="表单混合布局"></code>
 <code src="./demo/hideRequiredMark.tsx" title="hideRequiredMark" debug></code>
@@ -28,5 +29,11 @@ nav:
 | :-- | :-- | :-- | :-- | :-- |
 | preserve | 当字段被删除时保留字段值。你可以通过 `getFieldsValue(true)` 来获取保留字段值 | boolean | false | 0.3.1 |
 | requiredMark | 设置必选或可选样式。此为 Form 配置，Form.Item 无法单独配置 | boolean \| `optional` \| ((label: ReactNode, info: { required: boolean }) => ReactNode) | `optional` | - |
+
+### Form.Item
+
+| 参数   | 说明                   | 类型      | 默认值 | 版本   |
+| :----- | :--------------------- | :-------- | :----- | :----- |
+| action | 操作项，仅垂直布局生效 | ReactNode | -      | 0.4.10 |
 
 - 更多 API 详见 antd Form 文档: https://ant.design/components/form-cn

--- a/packages/design/src/form/style/index.ts
+++ b/packages/design/src/form/style/index.ts
@@ -7,10 +7,14 @@ export type FormToken = FullToken<'Form'>;
 export const genFormStyle: GenerateStyle<FormToken> = (token: FormToken): CSSObject => {
   const { componentCls } = token;
   return {
-    [`${componentCls}`]: {
-      [`${componentCls}-item`]: {
-        [`${componentCls}-item-additional`]: {
-          marginTop: token.marginXXS,
+    [`${componentCls}${componentCls}-vertical`]: {
+      [`${componentCls}-item:not(${componentCls}-item-horizontal)`]: {
+        [`${componentCls}-item-label > label`]: {
+          width: '100%',
+          [`${componentCls}-item-action`]: {
+            position: 'absolute',
+            right: 0,
+          },
         },
       },
     },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

![image](https://github.com/user-attachments/assets/ab99b625-3964-4041-8d4d-8c161f268320)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | - 🆕 Form.Item 新增 `action` 属性，用于设置操作项。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
