### PR TITLE
fix(ui): [date-ranger]: omit style and className prop form params passed to antd picker

### DIFF
--- a/packages/ui/src/DateRanger/Ranger.tsx
+++ b/packages/ui/src/DateRanger/Ranger.tsx
@@ -475,7 +475,7 @@ const Ranger = React.forwardRef((props: DateRangerProps, ref) => {
                 size={size}
                 suffixIcon={null}
                 // 透传 props 到 antd Ranger
-                {...omit(rest, 'value', 'onChange')}
+                {...omit(rest, 'value', 'onChange', 'style')}
                 open={false}
               />
             </span>

--- a/packages/ui/src/DateRanger/Ranger.tsx
+++ b/packages/ui/src/DateRanger/Ranger.tsx
@@ -332,7 +332,7 @@ const Ranger = React.forwardRef((props: DateRangerProps, ref) => {
 
   return (
     <Space
-      className={classNames({
+      className={classNames(rest.className, {
         [prefix]: true,
         [`${prefix}-show-range`]: true,
         [`${prefix}-back-radio-focused`]: backRadioFocused,
@@ -475,7 +475,7 @@ const Ranger = React.forwardRef((props: DateRangerProps, ref) => {
                 size={size}
                 suffixIcon={null}
                 // 透传 props 到 antd Ranger
-                {...omit(rest, 'value', 'onChange', 'style')}
+                {...omit(rest, 'value', 'onChange', 'style', 'className')}
                 open={false}
               />
             </span>


### PR DESCRIPTION
Omit the style prop form the params passed to antd picker.

<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

外部传进来的 `style` 和 `className` 参数应当仅作用于`DateRanger` 跟组件，不应该传入到`DatePicker.RangePicker` 

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - fix(ui): [date-ranger]: omit the style and className prop form the params passed to antd picker.  |
| 🇨🇳 Chinese | - 🐞 修复 DateRanger `style` 和 `className` 应该仅对根组件生效、不应该对 RangePicker 生效的问题。  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
