### PR TITLE
feat(ui): [date-ranger] support hidden second at panel

### DIFF
--- a/packages/ui/src/DateRanger/PickerPanel.tsx
+++ b/packages/ui/src/DateRanger/PickerPanel.tsx
@@ -48,6 +48,7 @@ export interface PickerPanelProps {
   onOk: (v: RangeValue) => void;
   isMoment: boolean;
   disabledDate: any;
+  hideSecond?: boolean;
   locale: any;
 }
 
@@ -90,6 +91,7 @@ const InternalPickerPanel = (props: PickerPanelProps) => {
     onOk = noop,
     onCancel = noop,
     disabledDate,
+    hideSecond,
   } = props;
   const rootCls = useCSSVarCls(prefixCls);
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
@@ -236,7 +238,7 @@ const InternalPickerPanel = (props: PickerPanelProps) => {
                   getPopupContainer={triggerNode => triggerNode.parentNode as HTMLElement}
                   style={{ width: '100%' }}
                   format={{
-                    format: 'HH:mm:ss',
+                    format: hideSecond ? 'HH:mm' : 'HH:mm:ss',
                     type: 'mask',
                   }}
                 />
@@ -292,7 +294,7 @@ const InternalPickerPanel = (props: PickerPanelProps) => {
                   getPopupContainer={triggerNode => triggerNode.parentNode as HTMLElement}
                   style={{ width: '100%' }}
                   format={{
-                    format: 'HH:mm:ss',
+                    format: hideSecond ? 'HH:mm' : 'HH:mm:ss',
                     type: 'mask',
                   }}
                 />

--- a/packages/ui/src/DateRanger/Ranger.tsx
+++ b/packages/ui/src/DateRanger/Ranger.tsx
@@ -376,6 +376,7 @@ const Ranger = React.forwardRef((props: DateRangerProps, ref) => {
                     tip={tip}
                     isMoment={isMoment}
                     rules={rules}
+                    hideSecond={hideSecond}
                     onOk={vList => {
                       setIsPlay(false);
                       handleNameChange(CUSTOMIZE);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

![image](https://github.com/user-attachments/assets/037849a8-1592-4dc9-b44a-72d1e35f39b7)

| Before | After |
| :--- | :--- |
| ![image](https://github.com/user-attachments/assets/7d9a059d-71c7-45cc-b8ee-bd4e4ad97004) | ![image](https://github.com/user-attachments/assets/037849a8-1592-4dc9-b44a-72d1e35f39b7) |

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | support hidden second at panel |
| 🇨🇳 Chinese | 设置`hideSecond`时隐藏面板内时间选择器的秒 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
