### PR TITLE
chore(docs): Add changelog for @oceanbase/design@0.4.12 and @oceanbase/ui@0.4.15

### DIFF
--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,13 @@ group: 基础组件
 
 ---
 
+## 0.4.12
+
+`2025-07-10`
+
+- 🐞 修复 `boxShadow` 相关 Design Token 不正确的问题。[#1096](https://github.com/oceanbase/oceanbase-design/pull/1096)
+- 💄 更新 boxShadowTertiary token 的值。[#1097](https://github.com/oceanbase/oceanbase-design/pull/1097)
+
 ## 0.4.11
 
 `2025-07-01`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,13 @@ group: 业务组件
 
 ---
 
+## 0.4.15
+
+`2025-07-10`
+
+- 💄 Login 的背景图片居中展示。[#1094](https://github.com/oceanbase/oceanbase-design/pull/1094)
+- 💄 将 DateRanger 快捷选项的背景色从透明调整为白色。[#1095](https://github.com/oceanbase/oceanbase-design/pull/1095) [@wzc520pyfm](https://github.com/wzc520pyfm)
+
 ## 0.4.14
 
 `2025-07-01`


### PR DESCRIPTION
## @oceanbase/design@0.4.12

`2025-07-10`

- 🐞 修复 `boxShadow` 相关 Design Token 不正确的问题。[#1096](https://github.com/oceanbase/oceanbase-design/pull/1096)
- 💄 更新 boxShadowTertiary token 的值。[#1097](https://github.com/oceanbase/oceanbase-design/pull/1097)

---

## @oceanbase/ui@0.4.15

`2025-07-10`

- 💄 Login 的背景图片居中展示。[#1094](https://github.com/oceanbase/oceanbase-design/pull/1094)
- 💄 将 DateRanger 快捷选项的背景色从透明调整为白色。[#1095](https://github.com/oceanbase/oceanbase-design/pull/1095) [@wzc520pyfm](https://github.com/wzc520pyfm)