### PR TITLE
improve(ui): [pro-card] use new collapsible icon

### DIFF
--- a/packages/ui/src/ProCard/index.tsx
+++ b/packages/ui/src/ProCard/index.tsx
@@ -21,7 +21,7 @@ const ProCard: typeof AntProCard = ({
   className,
   ...restProps
 }) => {
-  const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
+  const { getPrefixCls, iconPrefixCls } = useContext(ConfigProvider.ConfigContext);
 
   const prefixCls = getPrefixCls('pro-card', customizePrefixCls);
   const { wrapSSR } = useStyle(prefixCls);
@@ -59,7 +59,7 @@ const ProCard: typeof AntProCard = ({
       collapsibleIconRender={({ collapsed }) => {
         return (
           <CaretRightFilled
-            className={`anticon anticon-right ${prefixCls}-collapsible-icon`}
+            className={`${iconPrefixCls} ${iconPrefixCls}-right ${prefixCls}-collapsible-icon`}
             style={{
               transition: 'transform 0.2s',
               transform: collapsed ? undefined : 'rotate(90deg)',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

与设计沟通后，ProCard的折叠icon使用实心三角
<img width="514" height="298" alt="image" src="https://github.com/user-attachments/assets/bcae2a29-f15a-4921-8292-1171b26e05e7" />


| Before | After |
| :--- | :--- |
| <img width="731" height="398" alt="image" src="https://github.com/user-attachments/assets/7f78b9ca-6e38-4156-9faf-8c5d4681b065" />| <img width="523" height="391" alt="image" src="https://github.com/user-attachments/assets/5329df60-3ec2-44d3-9eec-9e877c747913" /> |

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | use new collapsible icon for pro card |
| 🇨🇳 Chinese | 💄 ProCard 折叠图标使用实心箭头、图标颜色改为二级文本色。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
