### PR TITLE
chore(docs): Add changelog for @oceanbase/design@0.4.13 and @oceanbase/ui@0.4.16

### DIFF
--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,14 @@ group: 基础组件
 
 ---
 
+## 0.4.13
+
+`2025-07-27`
+
+- 🆕 Segmented `options` 新增 `badge` 属性，用于设置选项卡后面的徽标。[#1100](https://github.com/oceanbase/oceanbase-design/pull/1100) [@wzc520pyfm](https://github.com/wzc520pyfm)
+- 🆕 Tabs `options` 新增 `badge` 属性，用于设置选项卡后面的徽标。原 `tag` 属性标记为即将废弃，后续不推荐使用。[#1110](https://github.com/oceanbase/oceanbase-design/pull/1110) [@wzc520pyfm](https://github.com/wzc520pyfm)
+- 💄 优化 Slider 在最大值和最小值相等时的 `marks` 样式。[#1105](https://github.com/oceanbase/oceanbase-design/pull/1105)
+
 ## 0.4.12
 
 `2025-07-10`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,12 @@ group: 业务组件
 
 ---
 
+## 0.4.16
+
+`2025-07-27`
+
+- 💄 ProCard 折叠图标使用实心箭头、图标颜色改为二级文本色。[#1111](https://github.com/oceanbase/oceanbase-design/pull/1111) [@wzc520pyfm](https://github.com/wzc520pyfm)
+
 ## 0.4.15
 
 `2025-07-10`


### PR DESCRIPTION
## @oceanbase/design@0.4.13

`2025-07-27`

- 🆕 Segmented `options` 新增 `badge` 属性，用于设置选项卡后面的徽标。[#1100](https://github.com/oceanbase/oceanbase-design/pull/1100) [@wzc520pyfm](https://github.com/wzc520pyfm)
- 🆕 Tabs `options` 新增 `badge` 属性，用于设置选项卡后面的徽标。原 `tag` 属性标记为即将废弃，后续不推荐使用。[#1110](https://github.com/oceanbase/oceanbase-design/pull/1110) [@wzc520pyfm](https://github.com/wzc520pyfm)
- 💄 优化 Slider 在最大值和最小值相等时的 `marks` 样式。[#1105](https://github.com/oceanbase/oceanbase-design/pull/1105)

## @oceanbase/ui@0.4.16

`2025-07-27`

- 💄 ProCard 折叠图标使用实心箭头、图标颜色改为二级文本色。[#1111](https://github.com/oceanbase/oceanbase-design/pull/1111) [@wzc520pyfm](https://github.com/wzc520pyfm)