### PR TITLE
[v1] feat(ui): ProCard support for ConfigProvider as Card

### DIFF
--- a/packages/ui/src/ProCard/demo/config-provider.tsx
+++ b/packages/ui/src/ProCard/demo/config-provider.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { ConfigProvider, Form, Switch } from '@oceanbase/design';
+import { ProCard } from '@oceanbase/ui';
+
+export default () => {
+  const [divided, setDivided] = useState(true);
+  const [bordered, setBordered] = useState(true);
+  return (
+    <ConfigProvider card={{ divided, variant: bordered ? 'outlined' : 'borderless' }}>
+      <Form layout="inline" style={{ marginBottom: 16 }}>
+        <Form.Item label="bordered" required={true}>
+          <Switch
+            size="small"
+            value={bordered}
+            onChange={value => {
+              setBordered(value);
+            }}
+          />
+        </Form.Item>
+        <Form.Item label="divided" required={true}>
+          <Switch
+            size="small"
+            value={divided}
+            onChange={value => {
+              setDivided(value);
+            }}
+          />
+        </Form.Item>
+      </Form>
+      <ProCard
+        bordered={bordered}
+        headerBordered={divided}
+        title="这是标题"
+        extra="extra"
+        tooltip="这是提示"
+        style={{ width: 300 }}
+      >
+        <div>Card content</div>
+        <div>Card content</div>
+        <div>Card content</div>
+      </ProCard>
+    </ConfigProvider>
+  );
+};

--- a/packages/ui/src/ProCard/index.md
+++ b/packages/ui/src/ProCard/index.md
@@ -15,6 +15,7 @@ nav:
 <code src="./demo/ghost.tsx" title="ghost 模式" description="去掉卡片背景颜色和内容区域的 padding。"></code>
 <code src="./demo/collapsible.tsx" title="卡片可折叠"></code>
 <code src="../../../design/src/table/demo/pro-card-table.tsx" title="和 Table 组合使用"></code>
+<code src="./demo/config-provider.tsx" title="ConfigProvider 全局配置"></code>
 
 ## API
 

--- a/packages/ui/src/ProCard/index.tsx
+++ b/packages/ui/src/ProCard/index.tsx
@@ -1,17 +1,18 @@
 import React, { useContext } from 'react';
 import { ProCard as AntProCard } from '@ant-design/pro-components';
 import type { ProCardProps } from '@ant-design/pro-components';
-import { ConfigProvider } from '@oceanbase/design';
+import { ConfigProvider, theme } from '@oceanbase/design';
 import { isHorizontalPaddingZero } from '@oceanbase/design/es/_util';
-import { theme } from '@oceanbase/design';
+import { CaretRightFilled } from '@oceanbase/icons';
 import classNames from 'classnames';
 import useStyle from './style';
-import { CaretRightFilled } from '@oceanbase/icons';
 
 export { ProCardProps };
 
-// @ts-ignore
-const ProCard: typeof AntProCard = ({
+export type ProCardType = typeof AntProCard;
+
+const ProCard = (({
+  bordered,
   ghost,
   title,
   tabs,
@@ -19,9 +20,14 @@ const ProCard: typeof AntProCard = ({
   bodyStyle,
   prefixCls: customizePrefixCls,
   className,
+  style,
   ...restProps
 }) => {
-  const { getPrefixCls, iconPrefixCls } = useContext(ConfigProvider.ConfigContext);
+  const {
+    getPrefixCls,
+    iconPrefixCls,
+    card: contextCard,
+  } = useContext(ConfigProvider.ConfigContext);
 
   const prefixCls = getPrefixCls('pro-card', customizePrefixCls);
   const { wrapSSR } = useStyle(prefixCls);
@@ -37,12 +43,16 @@ const ProCard: typeof AntProCard = ({
       [`${prefixCls}-no-divider`]: !headerBordered,
       [`${prefixCls}-contain-tabs`]: !!tabs,
     },
+    contextCard?.className,
     className
   );
 
   return wrapSSR(
     <AntProCard
       prefixCls={customizePrefixCls}
+      bordered={
+        bordered ?? (contextCard?.variant ? contextCard?.variant === 'outlined' : undefined)
+      }
       ghost={ghost}
       title={title}
       tabs={
@@ -53,9 +63,13 @@ const ProCard: typeof AntProCard = ({
             }
           : tabs
       }
-      headerBordered={headerBordered}
+      headerBordered={headerBordered ?? contextCard?.divided}
       bodyStyle={bodyStyle}
       className={proCardCls}
+      style={{
+        ...contextCard?.style,
+        ...style,
+      }}
       collapsibleIconRender={({ collapsed }) => {
         return (
           <CaretRightFilled
@@ -71,7 +85,7 @@ const ProCard: typeof AntProCard = ({
       {...restProps}
     />
   );
-};
+}) as ProCardType;
 
 if (process.env.NODE_ENV !== 'production') {
   ProCard.displayName = AntProCard.displayName;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<img width="976" height="570" alt="image" src="https://github.com/user-attachments/assets/eae88278-1b2f-49ce-9a1d-810eb3dc7c2f" />


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | - 🆕 ProCard 支持 ConfigProvider 全局配置。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
