### PR TITLE
[v1] chore(docs): Add changelog for @oceanbase/design@1.0.0-alpha.1, @oceanbase/ui@1.0.0-alpha.1 and @oceanbase/codemod@1.0.0-alpha.1

### DIFF
--- a/docs/codemod/codemod-CHANGELOG.md
+++ b/docs/codemod/codemod-CHANGELOG.md
@@ -8,6 +8,16 @@ group: 自动化迁移工具
 
 ---
 
+## 1.0.0-alpha.1
+
+`2025-09-10`
+
+- style-to-token
+  - ⭐️ 优化 `style-to-token` 对匿名函数组件的改写结果。[#1188](https://github.com/oceanbase/oceanbase-design/pull/1188)
+  - ⭐️ `style-to-token` 工具支持更多 `fontSize` 的改写场景。[#1190](https://github.com/oceanbase/oceanbase-design/pull/1190)
+  - 🐞 修复 `style-to-token` 对单个函数的改写结果错误的问题。[#1189](https://github.com/oceanbase/oceanbase-design/pull/1189)
+- 🐞 修复依赖升级的目标版本不正确的问题。[#1192](https://github.com/oceanbase/oceanbase-design/pull/1192)
+
 ## 1.0.0-alpha.0
 
 `2025-09-08`

--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,13 @@ group: 基础组件
 
 ---
 
+## 1.0.0-alpha.1
+
+`2025-09-10`
+
+- 🌈 更新主题色、文本色、填充色相关的 Design Token。[#1186](https://github.com/oceanbase/oceanbase-design/pull/1186)
+- 🌈 [图标]更新双色图标的主题色 `#006AFF` => `#0D6CF2`。[#1191](https://github.com/oceanbase/oceanbase-design/pull/1191)
+
 ## 1.0.0-alpha.0
 
 `2025-09-08`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,13 @@ group: 业务组件
 
 ---
 
+## 1.0.0-alpha.1
+
+`2025-09-10`
+
+- 🆕 ProCard 支持 ConfigProvider 全局配置。[#1187](https://github.com/oceanbase/oceanbase-design/pull/1187)
+- 🐞 修复 DateRanger、GraphToolbar 和 Highlight 圆角样式不生效的问题。[#1185](https://github.com/oceanbase/oceanbase-design/pull/1185)
+
 ## 1.0.0-alpha.0
 
 `2025-09-08`


### PR DESCRIPTION
## @oceanbase/design@1.0.0-alpha.1

`2025-09-10`

- 🌈 更新主题色、文本色、填充色相关的 Design Token。[#1186](https://github.com/oceanbase/oceanbase-design/pull/1186)
- 🌈 [图标]更新双色图标的主题色 `#006AFF` => `#0D6CF2`。[#1191](https://github.com/oceanbase/oceanbase-design/pull/1191)

---

## @oceanbase/ui@1.0.0-alpha.1

`2025-09-10`

- 🆕 ProCard 支持 ConfigProvider 全局配置。[#1187](https://github.com/oceanbase/oceanbase-design/pull/1187)
- 🐞 修复 DateRanger、GraphToolbar 和 Highlight 圆角样式不生效的问题。[#1185](https://github.com/oceanbase/oceanbase-design/pull/1185)

---

- style-to-token
  - ⭐️ 优化 `style-to-token` 对匿名函数组件的改写结果。[#1188](https://github.com/oceanbase/oceanbase-design/pull/1188)
  - ⭐️ `style-to-token` 工具支持更多 `fontSize` 的改写场景。[#1190](https://github.com/oceanbase/oceanbase-design/pull/1190)
  - 🐞 修复 `style-to-token` 对单个函数的改写结果错误的问题。[#1189](https://github.com/oceanbase/oceanbase-design/pull/1189)
- 🐞 修复依赖升级的目标版本不正确的问题。[#1192](https://github.com/oceanbase/oceanbase-design/pull/1192)

## @oceanbase/codemod@1.0.0-alpha.1