### PR TITLE
[v1] fix(ui): ConfigProvider card should work for ProTable cardBordered and cardProps

### DIFF
--- a/packages/ui/src/ProTable/index.md
+++ b/packages/ui/src/ProTable/index.md
@@ -12,11 +12,11 @@ nav:
 ## 代码演示
 
 <!-- prettier-ignore -->
-<code src="./demo/basic.tsx" title="基本"></code>
+<code src="./demo/basic.tsx" title="基本" description="卡片带边框"></code>
 <code src="./demo/light-filter.tsx" title="轻量筛选"></code>
 <code src="./demo/expandable.tsx" title="可展开表格"></code>
-<code src="./demo/bordered.tsx" title="带边框"></code>
-<code src="./demo/inner-bordered.tsx" title="带内部边框"></code>
+<code src="./demo/bordered.tsx" title="卡片不带边框、表格带边框"></code>
+<code src="./demo/inner-bordered.tsx" title="表格带内部边框"></code>
 <code src="./demo/empty.tsx" title="空状态"></code>
 
 ## API

--- a/packages/ui/src/ProTable/index.tsx
+++ b/packages/ui/src/ProTable/index.tsx
@@ -3,7 +3,7 @@ import { ProTable as AntProTable } from '@ant-design/pro-components';
 import type { ProTableProps as AntProTableProps } from '@ant-design/pro-components';
 import { ConfigProvider, Empty, Table } from '@oceanbase/design';
 import classNames from 'classnames';
-import { isEmpty } from 'lodash';
+import { isEmpty, merge } from 'lodash';
 import useLightFilterStyle from '../LightFilter/style';
 import useStyle from './style';
 
@@ -23,6 +23,7 @@ function ProTable<T, U, ValueType>({
   size,
   bordered,
   innerBordered,
+  cardBordered,
   expandable,
   rowSelection,
   pagination: customPagination,
@@ -34,7 +35,7 @@ function ProTable<T, U, ValueType>({
   className,
   ...restProps
 }: ProTableProps<T, U, ValueType>) {
-  const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
+  const { getPrefixCls, card: contextCard } = useContext(ConfigProvider.ConfigContext);
 
   // customize Table style
   const tablePrefixCls = getPrefixCls('table', customizePrefixCls);
@@ -61,7 +62,11 @@ function ProTable<T, U, ValueType>({
   const { emptyText = <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />, ...restLocale } =
     locale || {};
 
-  const cardProps = typeof outerCardProps === 'boolean' ? {} : outerCardProps;
+  const cardProps = merge(
+    {},
+    contextCard,
+    typeof outerCardProps === 'boolean' ? {} : outerCardProps
+  );
   const proCardCls = getPrefixCls('pro-card', customizePrefixCls);
 
   return tableWrapSSR(
@@ -72,6 +77,9 @@ function ProTable<T, U, ValueType>({
           defaultSize="large"
           size={size}
           bordered={bordered || innerBordered}
+          cardBordered={
+            cardBordered ?? (contextCard?.variant ? contextCard?.variant === 'outlined' : undefined)
+          }
           form={{
             // query form should remove required mark
             requiredMark: false,
@@ -93,7 +101,7 @@ function ProTable<T, U, ValueType>({
                   optionsRender ||
                   toolbar ||
                   toolBarRender,
-                [`${proCardCls}-no-divider`]: !cardProps?.headerBordered,
+                [`${proCardCls}-no-divider`]: !cardProps?.headerBordered && !cardProps?.divided,
                 [`${proCardCls}-no-padding`]: true,
                 [`${proCardCls}-contain-tabs`]: !!cardProps?.tabs,
               },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

- None

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | - 🐞 修复 ProTable `cardBordered` 和 `cardProps` 不受 ConfigProvider `card` 配置影响的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
