### PR TITLE
[v1] fix(ui): ProTable cardProps.headerBordered should work

### DIFF
--- a/packages/ui/src/ProTable/demo/header-bordered.tsx
+++ b/packages/ui/src/ProTable/demo/header-bordered.tsx
@@ -32,9 +32,11 @@ const App: React.FC = () => {
 
   return (
     <ProTable
-      innerBordered={true}
       headerTitle="高级表格"
       cardBordered={true}
+      cardProps={{
+        headerBordered: true,
+      }}
       columns={columns}
       dataSource={dataSource}
     />

--- a/packages/ui/src/ProTable/index.md
+++ b/packages/ui/src/ProTable/index.md
@@ -13,10 +13,10 @@ nav:
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx" title="基本" description="卡片带边框"></code>
+<code src="./demo/header-bordered.tsx" title="表格标题区和内容区分隔"></code>
 <code src="./demo/light-filter.tsx" title="轻量筛选"></code>
 <code src="./demo/expandable.tsx" title="可展开表格"></code>
 <code src="./demo/bordered.tsx" title="卡片不带边框、表格带边框"></code>
-<code src="./demo/inner-bordered.tsx" title="表格带内部边框"></code>
 <code src="./demo/empty.tsx" title="空状态"></code>
 
 ## API

--- a/packages/ui/src/ProTable/style/index.ts
+++ b/packages/ui/src/ProTable/style/index.ts
@@ -15,6 +15,13 @@ export const genProTableStyle: GenerateStyle<OBToken> = (token: OBToken): CSSObj
           flexDirection: 'row-reverse',
         },
       },
+      [`${proCardComponentCls}:not(${proCardComponentCls}-no-divider)`]: {
+        [`${proCardComponentCls}-body`]: {
+          [`${componentCls}-list-toolbar-container`]: {
+            borderBottom: `${token.lineWidth}px solid ${token.colorBorderSecondary}`,
+          },
+        },
+      },
       [`${proCardComponentCls}${proCardComponentCls}-no-padding`]: {
         [`${proCardComponentCls}-body`]: {
           paddingInline: 0,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

| Before | After |
| :--- | :--- |
| <img width="1674" height="1334" alt="image" src="https://github.com/user-attachments/assets/87457615-89f8-4a86-90c7-9feaacb7f729" /> | <img width="1674" height="1332" alt="image" src="https://github.com/user-attachments/assets/192c6c0d-d0ea-4e93-89d3-bf53d883f9c5" /> |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | -          |
| 🇨🇳 Chinese | - 🐞 修复 ProTable `cardProps.headerBordered` 属性不生效的问题。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
