### PR TITLE
chore(docs): Add changelog for @oceanbase/design@0.4.17 and @oceanbase/ui@0.4.20

### DIFF
--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,17 @@ group: 基础组件
 
 ---
 
+## 0.4.17
+
+`2025-09-24`
+
+- Tabs
+  - 🆕 Tabs 新增 `divider` 属性，用于设置分割线。[#1179](https://github.com/oceanbase/oceanbase-design/pull/1179)
+  - 🐞 修复 Tabs `ref` 不生效的问题。[#1178](https://github.com/oceanbase/oceanbase-design/pull/1178)
+- 🐞 修复 Typography `Text` 和 `Paragraph` 类名样式 (行高、字体颜色和大小) 不生效的问题。[#1180](https://github.com/oceanbase/oceanbase-design/pull/1180)
+- TypeScript
+  - 🤖 导出 FormItem 类型，以兼容 antd 的类型用法。[#1171](https://github.com/oceanbase/oceanbase-design/pull/1171)
+
 ## 0.4.16
 
 `2025-08-29`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,15 @@ group: 业务组件
 
 ---
 
+## 0.4.20
+
+`2025-09-24`
+
+- DateRanger
+  - 🆕 DateRanger 新增历史记录功能。[#1149](https://github.com/oceanbase/oceanbase-design/pull/1149) [@wzc520pyfm](https://github.com/wzc520pyfm)
+  - 🐞 修复 DateRanger `上周` 时间段 label 过长的问题。[#1198](https://github.com/oceanbase/oceanbase-design/pull/1198) [@wzc520pyfm](https://github.com/wzc520pyfm)
+- 🐞 修复 ProTable 卡片底部间距过大的问题。[#1219](https://github.com/oceanbase/oceanbase-design/pull/1219)
+
 ## 0.4.19
 
 `2025-08-29`


### PR DESCRIPTION
## @oceanbase/design@0.4.17

`2025-09-24`

- Tabs
  - 🆕 Tabs 新增 `divider` 属性，用于设置分割线。[#1179](https://github.com/oceanbase/oceanbase-design/pull/1179)
  - 🐞 修复 Tabs `ref` 不生效的问题。[#1178](https://github.com/oceanbase/oceanbase-design/pull/1178)
- 🐞 修复 Typography `Text` 和 `Paragraph` 类名样式 (行高、字体颜色和大小) 不生效的问题。[#1180](https://github.com/oceanbase/oceanbase-design/pull/1180)
- TypeScript
  - 🤖 导出 FormItem 类型，以兼容 antd 的类型用法。[#1171](https://github.com/oceanbase/oceanbase-design/pull/1171)

---

## @oceanbase/ui@0.4.20

`2025-09-24`

- DateRanger
  - 🆕 DateRanger 新增历史记录功能。[#1149](https://github.com/oceanbase/oceanbase-design/pull/1149) [@wzc520pyfm](https://github.com/wzc520pyfm)
  - 🐞 修复 DateRanger `上周` 时间段 label 过长的问题。[#1198](https://github.com/oceanbase/oceanbase-design/pull/1198) [@wzc520pyfm](https://github.com/wzc520pyfm)
- 🐞 修复 ProTable 卡片底部间距过大的问题。[#1219](https://github.com/oceanbase/oceanbase-design/pull/1219)