### PR TITLE
[v1] chore(docs): Add changelog for @oceanbase/design@1.0.0-alpha.2, @oceanbase/ui@1.0.0-alpha.2 and @oceanbase/codemod@1.0.0-alpha.2

### DIFF
--- a/docs/codemod/codemod-CHANGELOG.md
+++ b/docs/codemod/codemod-CHANGELOG.md
@@ -8,6 +8,13 @@ group: 自动化迁移工具
 
 ---
 
+## 1.0.0-alpha.2
+
+`2025-09-24`
+
+- ⭐️ 支持 `#f93939` => `colorError` 和 `#f8fafe` => `colorBgLayout` 的 Design Token 自动改写。[#1217](https://github.com/oceanbase/oceanbase-design/pull/1217)
+- 🐞 修复 `less-to-token` 可能重复导入主题文件的问题。[#1199](https://github.com/oceanbase/oceanbase-design/pull/1199)
+
 ## 1.0.0-alpha.1
 
 `2025-09-10`

--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,24 @@ group: 基础组件
 
 ---
 
+## 1.0.0-alpha.2
+
+`2025-09-24`
+
+- Design Token
+  - 🌈 更新 `fontSizeLG` 和 `fontSizeHeading` 字体大小。[#1200](https://github.com/oceanbase/oceanbase-design/pull/1200)
+  - 🌈 更新 `controlHeight` 控件高度 `32` => `28`。[#1201](https://github.com/oceanbase/oceanbase-design/pull/1201)
+  - 🌈 更新 `borderRadiusLG` 大号圆角 `6` => `8`。[#1206](https://github.com/oceanbase/oceanbase-design/pull/1206)
+  - 🌈 更新 Table `cellPaddingBlock` 单元格纵向间距。[#1208](https://github.com/oceanbase/oceanbase-design/pull/1208)
+- Badge
+  - 🐞 修复 Badge 状态文本字体大小不会继承父元素的问题，便于和其他组件组合使用。[#1214](https://github.com/oceanbase/oceanbase-design/pull/1214)
+  - 💄 调整 Badge `processing` 态的颜色和圆点大小。[#1205](https://github.com/oceanbase/oceanbase-design/pull/1205)
+- Card
+  - 💄 Card `tabs` 默认尺寸改为 `middle`。[#1216](https://github.com/oceanbase/oceanbase-design/pull/1216)
+  - 💄 优化 Card 嵌套时的圆角样式，内层卡片的圆角逐级递减。[#1211](https://github.com/oceanbase/oceanbase-design/pull/1211)
+- 💄 优化 Descriptions `label` 的字体颜色和垂直布局下的间距。[#1204](https://github.com/oceanbase/oceanbase-design/pull/1204)
+- 💄 优化 Skeleton 的骨架屏圆角 `2` => `4`。[#1212](https://github.com/oceanbase/oceanbase-design/pull/1212)
+
 ## 1.0.0-alpha.1
 
 `2025-09-10`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,21 @@ group: 业务组件
 
 ---
 
+## 1.0.0-alpha.2
+
+`2025-09-24`
+
+- PageContainer
+  - 💄 更新 PageContainer 的返回图标。[#1215](https://github.com/oceanbase/oceanbase-design/pull/1215)
+  - 💄 优化 PageContainer 标题和操作区的样式。[#1202](https://github.com/oceanbase/oceanbase-design/pull/1202)
+- ProCard
+  - 🐞 修复 ProCard 边框颜色和 Card 不一致的问题。[#1207](https://github.com/oceanbase/oceanbase-design/pull/1207)
+  - 🐞 修复 ProCard 加载态骨架屏和 Card 不一致的问题。[#1213](https://github.com/oceanbase/oceanbase-design/pull/1213)
+- ProTable
+  - 🐞 修复 ProTable `cardBordered` 和 `cardProps` 不受 ConfigProvider `card` 配置影响的问题。[#1209](https://github.com/oceanbase/oceanbase-design/pull/1209)
+  - 🐞 修复 ProTable `cardProps.headerBordered` 属性不生效的问题。[#1210](https://github.com/oceanbase/oceanbase-design/pull/1210)
+  - 🐞 修复 ProTable 卡片底部间距过大的问题。[#1219](https://github.com/oceanbase/oceanbase-design/pull/1219)
+
 ## 1.0.0-alpha.1
 
 `2025-09-10`


### PR DESCRIPTION
## @oceanbase/design@1.0.0-alpha.2

`2025-09-24`

- Design Token
  - 🌈 更新 `fontSizeLG` 和 `fontSizeHeading` 字体大小。[#1200](https://github.com/oceanbase/oceanbase-design/pull/1200)
  - 🌈 更新 `controlHeight` 控件高度 `32` => `28`。[#1201](https://github.com/oceanbase/oceanbase-design/pull/1201)
  - 🌈 更新 `borderRadiusLG` 大号圆角 `6` => `8`。[#1206](https://github.com/oceanbase/oceanbase-design/pull/1206)
  - 🌈 更新 Table `cellPaddingBlock` 单元格纵向间距。[#1208](https://github.com/oceanbase/oceanbase-design/pull/1208)
- Badge
  - 🐞 修复 Badge 状态文本字体大小不会继承父元素的问题，便于和其他组件组合使用。[#1214](https://github.com/oceanbase/oceanbase-design/pull/1214)
  - 💄 调整 Badge `processing` 态的颜色和圆点大小。[#1205](https://github.com/oceanbase/oceanbase-design/pull/1205)
- Card
  - 💄 Card `tabs` 默认尺寸改为 `middle`。[#1216](https://github.com/oceanbase/oceanbase-design/pull/1216)
  - 💄 优化 Card 嵌套时的圆角样式，内层卡片的圆角逐级递减。[#1211](https://github.com/oceanbase/oceanbase-design/pull/1211)
- 💄 优化 Descriptions `label` 的字体颜色和垂直布局下的间距。[#1204](https://github.com/oceanbase/oceanbase-design/pull/1204)
- 💄 优化 Skeleton 的骨架屏圆角 `2` => `4`。[#1212](https://github.com/oceanbase/oceanbase-design/pull/1212)

---

## @oceanbase/ui@1.0.0-alpha.2

`2025-09-24`

- PageContainer
  - 💄 更新 PageContainer 的返回图标。[#1215](https://github.com/oceanbase/oceanbase-design/pull/1215)
  - 💄 优化 PageContainer 标题和操作区的样式。[#1202](https://github.com/oceanbase/oceanbase-design/pull/1202)
- ProCard
  - 🐞 修复 ProCard 边框颜色和 Card 不一致的问题。[#1207](https://github.com/oceanbase/oceanbase-design/pull/1207)
  - 🐞 修复 ProCard 加载态骨架屏和 Card 不一致的问题。[#1213](https://github.com/oceanbase/oceanbase-design/pull/1213)
- ProTable
  - 🐞 修复 ProTable `cardBordered` 和 `cardProps` 不受 ConfigProvider `card` 配置影响的问题。[#1209](https://github.com/oceanbase/oceanbase-design/pull/1209)
  - 🐞 修复 ProTable `cardProps.headerBordered` 属性不生效的问题。[#1210](https://github.com/oceanbase/oceanbase-design/pull/1210)
  - 🐞 修复 ProTable 卡片底部间距过大的问题。[#1219](https://github.com/oceanbase/oceanbase-design/pull/1219)

---

## @oceanbase/codemod@1.0.0-alpha.2

`2025-09-24`

- ⭐️ 支持 `#f93939` => `colorError` 和 `#f8fafe` => `colorBgLayout` 的 Design Token 自动改写。[#1217](https://github.com/oceanbase/oceanbase-design/pull/1217)
- 🐞 修复 `less-to-token` 可能重复导入主题文件的问题。[#1199](https://github.com/oceanbase/oceanbase-design/pull/1199)