### PR TITLE
chore(ci): add pull request labeler with path-to-label mapping

### DIFF
--- a/.cursor/skills/github-pr-submit/SKILL.md
+++ b/.cursor/skills/github-pr-submit/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: github-pr-submit
+description: >-
+  Opens and updates GitHub pull requests for this repository using GitHub CLI (gh), filling the title and body from .github/PULL_REQUEST_TEMPLATE.md and team conventions. Covers optional issue links, self-check, and post-create label editing. Use when the user wants to submit a PR, open a pull request, use gh to create a PR, or align description with the repository PR template for oceanbase/oceanbase-design.
+---
+
+# 向 oceanbase/oceanbase-design 提交 PR
+
+## 适用场景
+
+- 本地分支已推送到 `origin`，需要开 PR 到 `master`（或指定 base）。
+- 需要按仓库模板写 **标题、描述、自检项**，并可选为 PR **补打标签**。
+
+## 前置条件
+
+- 已安装并登录 [GitHub CLI](https://cli.github.com/)：`gh auth status` 成功。
+- 远程为 `github.com/oceanbase/oceanbase-design`；当前工作目录为仓库根目录。
+- 若刚做过 `rebase` / 修改历史，需 `git push --force-with-lease origin <branch>` 后再开或更新 PR。
+
+## 标题（Title）
+
+- 使用**英文**、**单行**，与主要 commit 或变更范围一致。
+- 格式与历史 PR 一致：`type(scope): short description`（如 `chore(ci): …`、`fix(design): …`、`feat(ui): …`）。
+- `type` 常见：`feat`、`fix`、`chore`、`docs`、`improve` 等；`scope` 可为包名或区域（`design`、`ui`、`root`、`ci`）。
+
+## 描述（Body）
+
+1. 打开并遵循仓库模板：`.github/PULL_REQUEST_TEMPLATE.md`。
+2. 在正文中**勾选**与本次改动对应的项（Modified package、This is a...）。
+3. 填写 **Background and solution**、**Changelog** 的中英表格；无关联 issue 可写 `N/A`。
+4. 勾选 **Self-Check before Merge** 中已确认或明确不需要的项。
+
+可将正文保存为临时文件后传给 `gh`（用完后删除临时文件，避免误提交）：
+
+```bash
+gh pr create --repo oceanbase/oceanbase-design --base master --head <你的分支名> \
+  --title "type(scope): English title here" \
+  --body-file path/to/body.md
+```
+
+仅查看现有 PR：
+
+```bash
+gh pr list --head <你的分支名> --base master
+gh pr view <number> --web
+```
+
+## 打标签（可选）
+
+合并后或创建后，CI 可能通过 **PR Labeler**（`.github/labeler.yml`、工作流为 `pull_request_target`）按**变更路径**自动加标签，**同仓库分支与 fork 的 PR 均可**；若需**手动**补打仓库已有标签：
+
+```bash
+gh pr edit <PR_NUMBER> --repo oceanbase/oceanbase-design \
+  --add-label "chore" \
+  --add-label "workflow"
+```
+
+注意：标签名须与 [仓库已有 Labels](https://github.com/oceanbase/oceanbase-design/labels) 完全一致；无权限创建新标签时只加已有项。
+
+**可选建议标签（按改动类型选，非必须）**
+
+| 改动区域                | 可参考标签                              |
+| ----------------------- | --------------------------------------- |
+| 根目录 / CI / `.github` | `chore`, `workflow`, `CI`               |
+| 仅文档 / changelog      | `documentation`, `changelog`            |
+| 某子包                  | `@oceanbase/design`, `@oceanbase/ui` 等 |
+
+## 与上一提交合并后推送
+
+若需把多次提交**压成一条**再开 PR 或更新同一分支：
+
+```bash
+git reset --soft HEAD~<N>   # N 为要合并的提交个数
+git commit -m "type(scope): single final message"
+git push --force-with-lease origin <branch>
+```
+
+## 无 gh 时的后备
+
+在浏览器打开：`https://github.com/oceanbase/oceanbase-design/compare/master...<分支名>?expand=1`，将模板内容粘贴到描述框。
+
+## 反模式
+
+- 在仓库中**长期保留** `body.md` 等仅用于 `gh` 的临时文件；用毕应删除，勿加入版本控制。

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,65 @@
+# Maps changed paths to existing repo labels (see https://github.com/actions/labeler).
+# Labels must already exist on the repository.
+# Omit `changed-files-labels-limit`: some actions/labeler@v6 releases treat unknown top-level keys as labels (integer → parse error).
+
+'@oceanbase/design':
+  - changed-files:
+    - any-glob-to-any-file: 'packages/design/**'
+
+'@oceanbase/ui':
+  - changed-files:
+    - any-glob-to-any-file: 'packages/ui/**'
+
+'@oceanbase/icons':
+  - changed-files:
+    - any-glob-to-any-file: 'packages/icons/**'
+
+'@oceanbase/charts':
+  - changed-files:
+    - any-glob-to-any-file: 'packages/charts/**'
+
+'@oceanbase/util':
+  - changed-files:
+    - any-glob-to-any-file: 'packages/util/**'
+
+'@oceanbase/codemod':
+  - changed-files:
+    - any-glob-to-any-file: 'packages/codemod/**'
+
+documentation:
+  - changed-files:
+    - any-glob-to-any-file: 'docs/**'
+
+changelog:
+  - changed-files:
+    - any-glob-to-any-file: '**/*CHANGELOG.md'
+
+demo:
+  - changed-files:
+    - any-glob-to-any-file: '**/demos/**'
+
+skills:
+  - changed-files:
+    - any-glob-to-any-file: 'skills/**'
+
+site:
+  - changed-files:
+    - any-glob-to-any-file:
+        - '.dumi/**'
+        - '.dumirc.ts'
+        - '.dumirc.theme.ts'
+        - 'plugin-theme-less.ts'
+        - 'public/**'
+        - 'CNAME'
+
+Test:
+  - changed-files:
+    - any-glob-to-any-file: 'tests/**'
+
+workflow:
+  - changed-files:
+    - any-glob-to-any-file: '.github/**'
+
+CI:
+  - changed-files:
+    - any-glob-to-any-file: '.github/workflows/**'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,11 @@
+# Uses pull_request_target so GITHUB_TOKEN can add labels on PRs from forks.
+# Security: this job only runs actions/labeler (no user-provided run scripts). Checkout
+# uses the base branch ref only—never the PR head—so fork code is not executed here.
+# See: https://github.com/actions/labeler#notes-regarding-pull_request_target-event
 name: PR Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -14,4 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
       - uses: actions/labeler@v6

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,17 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    if: github.repository == 'oceanbase/oceanbase-design'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/labeler@v6

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ doc.zip
 assets.json
 lerna-debug.log
 useless-locale.txt
-.cursor
+.cursor/*
+!.cursor/skills/
+!.cursor/skills/**
 .claude
 AGENTS.md


### PR DESCRIPTION
### 📦 Modified package

- [ ] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [x] Other (`.github` — PR automated labeling)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Add [actions/labeler](https://github.com/actions/labeler) so new/updated pull requests get labels from the repository’s **existing** label set, based on changed file paths (see `.github/labeler.yml`).

| Area | Label(s) |
| :--- | :--- |
| `packages/*` | `@oceanbase/design`, `@oceanbase/ui`, … |
| `docs/**` | `documentation` |
| `**/*CHANGELOG.md` | `changelog` |
| `**/demos/**` | `demo` |
| `skills/**` | `skills` |
| site config / `.dumi` / `public` | `site` |
| `tests/**` | `Test` |
| `.github/**` | `workflow` |
| `.github/workflows/**` | `CI` |

`changed-files-labels-limit: 25` avoids labeling storms on huge diffs.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | CI: auto-label PRs from path rules via `actions/labeler@v6`. |
| 🇨🇳 Chinese | CI：根据变更路径通过 `actions/labeler@v6` 为 PR 自动打上已有标签。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
