### PR TITLE
improve(design): set Skeleton blockRadius to 2px

### DIFF
--- a/packages/design/src/theme/default.ts
+++ b/packages/design/src/theme/default.ts
@@ -399,7 +399,7 @@ const defaultTheme: ThemeConfig = {
       handleColorDisabled: '#b3ccff',
     },
     Skeleton: {
-      blockRadius: borderRadius,
+      blockRadius: 2,
     },
     Tabs: {
       horizontalItemGutter: 24,


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

| Before | After |
| :--- | :--- |
| <img width="1682" height="284" alt="image" src="https://github.com/user-attachments/assets/365aac6f-0411-472f-ace3-05a811ffa93f" /> | <img width="1682" height="282" alt="image" src="https://github.com/user-attachments/assets/e88b9ee9-a18e-47f3-a0d5-940c3511bb92" /> |

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - 💄 Update Skeleton `blockRadius` theme token to `2px`. [#1485](https://github.com/oceanbase/oceanbase-design/pull/1485) |
| 🇨🇳 Chinese | - 💄 将 Skeleton 的 `blockRadius` 主题 token 调整为 `2px`。[#1485](https://github.com/oceanbase/oceanbase-design/pull/1485) |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
