### PR TITLE
fix(ui): restore FullscreenBox class names and header styles after CSS-in-JS migration

### DIFF
--- a/packages/ui/src/FullscreenBox/index.tsx
+++ b/packages/ui/src/FullscreenBox/index.tsx
@@ -173,8 +173,8 @@ const FullscreenBox = React.forwardRef<FullscreenBoxRef, FullscreenBoxProps>(
       <div
         ref={containerRef}
         style={style}
-        className={classnames(`${prefixCls}-box`, className, {
-          [`${prefixCls}-box-fullscreen`]: innerFullscreen,
+        className={classnames(prefixCls, className, {
+          [`${prefixCls}-fullscreen`]: innerFullscreen,
         })}
         aria-live="polite"
       >

--- a/packages/ui/src/FullscreenBox/style/index.ts
+++ b/packages/ui/src/FullscreenBox/style/index.ts
@@ -8,35 +8,38 @@ export type FullscreenBoxToken = OBToken;
 export const genFullscreenBoxStyle: GenerateStyle<FullscreenBoxToken> = (
   token: FullscreenBoxToken
 ): CSSObject => {
-  const { componentCls, fontWeightStrong } = token;
+  const { componentCls, fontWeightStrong, colorText, colorBgContainer, prefixCls } = token;
 
   return {
-    [`${componentCls}-box`]: {
+    [componentCls]: {
       boxSizing: 'border-box',
       margin: 0,
       padding: 0,
-      color: 'rgba(0, 0, 0, 0.88)',
+      color: colorText,
       fontSize: 14,
       lineHeight: 1.5714285714285714,
       listStyle: 'none',
-      [`&.${componentCls}-box-fullscreen`]: {
+      [`&.${prefixCls}-fullscreen`]: {
         position: 'fixed',
         zIndex: 900,
-        background: '#fff',
+        background: colorBgContainer,
         insetBlockStart: 0,
         insetInlineEnd: 0,
         insetBlockEnd: 0,
         insetInlineStart: 0,
       },
-      [`${componentCls}-header`]: {
+      [`& ${componentCls}-header`]: {
         display: 'flex',
+        alignItems: 'center',
         height: 64,
-        [`${componentCls}-header-left`]: {
+        [`& ${componentCls}-header-left`]: {
+          display: 'flex',
           flex: 1,
+          alignItems: 'center',
           paddingBlock: 20,
           paddingInline: 24,
         },
-        [`${componentCls}-header-icon-btn`]: {
+        [`& ${componentCls}-header-icon-btn`]: {
           display: 'inline-flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -46,21 +49,22 @@ export const genFullscreenBoxStyle: GenerateStyle<FullscreenBoxToken> = (
           margin: 0,
           border: 'none',
           background: 'transparent',
+          color: colorText,
           cursor: 'pointer',
           verticalAlign: 'middle',
         },
-        [`${componentCls}-header-icon`]: {
+        [`& ${componentCls}-header-icon`]: {
           display: 'inline-flex',
           fontSize: 16,
           lineHeight: 1,
         },
-        [`${componentCls}-header-title`]: {
+        [`& ${componentCls}-header-title`]: {
           fontWeight: fontWeightStrong,
           fontSize: 16,
           lineHeight: 24,
           marginInlineStart: 24,
         },
-        [`${componentCls}-header-extra`]: {
+        [`& ${componentCls}-header-extra`]: {
           flex: 2,
           lineHeight: 64,
           textAlign: 'end',


### PR DESCRIPTION
### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

After migrating FullscreenBox from Less to CSS-in-JS (#1278), the container used an extra `-box` suffix (`ant-fullscreen-box-box`) and header selectors were nested in a way that did not compile to effective descendant rules in the doc site. The fullscreen toggle and header layout appeared broken compared to the `0.x` branch.

This PR restores the original class naming (`prefixCls` / `${prefixCls}-fullscreen`) and uses `& ${componentCls}-*` descendant selectors so header, icon button, and title styles apply correctly again.

| Before | After |
| :--- | :--- |
| Fullscreen entry and header styles missing | Matches 0.x: visible toggle, 64px header, title and icon layout |

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed FullscreenBox header and fullscreen toggle not rendering correctly after the CSS-in-JS migration. |
| 🇨🇳 Chinese | 修复 FullscreenBox 在 CSS-in-JS 迁移后全屏入口与 header 样式未生效的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [ ] Changelog is provided or not needed


Made with [Cursor](https://cursor.com)