### PR TITLE
[v0] chore(docs): Add changelog for @oceanbase/design@0.4.21 and @oceanbase/ui@0.4.25

### DIFF
--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,14 @@ group: 基础组件
 
 ---
 
+## 0.4.21
+
+`2026-06-14`
+
+- Spin
+  - 💄 更新 Spin 的加载动画（灰色/彩色）。[#1484](https://github.com/oceanbase/oceanbase-design/pull/1484)
+  - 🐞 修复 Spin 在暗色主题下背景不透明的问题。[#1484](https://github.com/oceanbase/oceanbase-design/pull/1484)
+
 ## 0.4.20
 
 `2026-01-05`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,13 @@ group: 业务组件
 
 ---
 
+## 0.4.25
+
+`2026-06-14`
+
+- 💄 替换默认品牌 logo 资产（`oceanbase_logo`、`oceanbase_logo_dark`、`oceanbase_watermark`），采用新蓝紫渐变品牌标识。[#1486](https://github.com/oceanbase/oceanbase-design/pull/1486)
+- 💄 更新 Highlight demo 中的 logo CDN 链接。[#1486](https://github.com/oceanbase/oceanbase-design/pull/1486)
+
 ## 0.4.24
 
 `2026-01-05`


### PR DESCRIPTION
## @oceanbase/design@0.4.21

`2026-06-14`

- Spin
  - 💄 更新 Spin 的加载动画（灰色/彩色）。[#1484](https://github.com/oceanbase/oceanbase-design/pull/1484)
  - 🐞 修复 Spin 在暗色主题下背景不透明的问题。[#1484](https://github.com/oceanbase/oceanbase-design/pull/1484)

---

## @oceanbase/ui@0.4.25

`2026-06-14`

- 💄 替换默认品牌 logo 资产（`oceanbase_logo`、`oceanbase_logo_dark`、`oceanbase_watermark`），采用新蓝紫渐变品牌标识。[#1486](https://github.com/oceanbase/oceanbase-design/pull/1486)
- 💄 更新 Highlight demo 中的 logo CDN 链接。[#1486](https://github.com/oceanbase/oceanbase-design/pull/1486)

Made with [Cursor](https://cursor.com)