### PR TITLE
fix(design): disable global focus-visible outline for native elements

### DIFF
--- a/packages/design/src/style/global.tsx
+++ b/packages/design/src/style/global.tsx
@@ -88,17 +88,17 @@ const genGlobalStyle = (
         fontWeight: token.fontWeightWeak,
       },
       // WCAG 2.4.7: native / non-ant focusables still need a visible ring (antd controls use token lineWidthFocus)
-      [[
-        `button:not([class^="${prefixCls}-"]):not([class*=" ${prefixCls}-"]):focus-visible`,
-        `a:not([class^="${prefixCls}-"]):not([class*=" ${prefixCls}-"]):focus-visible`,
-        `textarea:not([class^="${prefixCls}-"]):not([class*=" ${prefixCls}-"]):focus-visible`,
-        `select:not([class^="${prefixCls}-"]):not([class*=" ${prefixCls}-"]):focus-visible`,
-        `input:not([class^="${prefixCls}-"]):not([class*=" ${prefixCls}-"]):focus-visible`,
-        `[role="button"]:not([class^="${prefixCls}-"]):not([class*=" ${prefixCls}-"]):focus-visible`,
-      ].join(', ')]: {
-        outline: `${token.lineWidthFocus ?? 2}px solid ${token.colorPrimary}`,
-        outlineOffset: 2,
-      },
+      // [[
+      //   `button:not([class^="${prefixCls}-"]):not([class*=" ${prefixCls}-"]):focus-visible`,
+      //   `a:not([class^="${prefixCls}-"]):not([class*=" ${prefixCls}-"]):focus-visible`,
+      //   `textarea:not([class^="${prefixCls}-"]):not([class*=" ${prefixCls}-"]):focus-visible`,
+      //   `select:not([class^="${prefixCls}-"]):not([class*=" ${prefixCls}-"]):focus-visible`,
+      //   `input:not([class^="${prefixCls}-"]):not([class*=" ${prefixCls}-"]):focus-visible`,
+      //   `[role="button"]:not([class^="${prefixCls}-"]):not([class*=" ${prefixCls}-"]):focus-visible`,
+      // ].join(', ')]: {
+      //   outline: `${token.lineWidthFocus ?? 2}px solid ${token.colorPrimary}`,
+      //   outlineOffset: 2,
+      // },
       '*': {
         scrollbarColor: `${token.colorFillSecondary} transparent`,
       },


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Global focus-visible outline styles for native (non-ant) elements were introduced in #1483 for WCAG 2.4.7 compliance. In practice they caused unwanted focus rings on native `button`, `a`, `input`, `textarea`, `select`, and `[role="button"]` elements that are not styled by antd, conflicting with page-level or browser-default focus styles.

This PR disables those global rules by commenting them out. Ant Design controls continue to use `lineWidthFocus` via theme tokens.

| Before | After |
| :--- | :--- |
| Native focusables get a primary-color outline globally | Native focusables rely on browser / page-level focus styles; antd controls unchanged |

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix unwanted global focus-visible outline on native HTML elements |
| 🇨🇳 Chinese | 修复原生 HTML 元素出现多余全局 focus-visible 描边的问题 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [ ] Changelog is provided or not needed
