### PR TITLE
fix(design): constrain Spin Lottie indicator size to prevent oversized loading

### DIFF
--- a/packages/design/src/spin/style/index.ts
+++ b/packages/design/src/spin/style/index.ts
@@ -18,6 +18,12 @@ const genSizeStyle = (spinDotSize: number, token: SpinToken): CSSObject => {
       [`${componentCls}-dot`]: {
         width: spinDotWidth,
         height: spinDotHight,
+        overflow: 'hidden',
+        lineHeight: 0,
+        [`> div`]: {
+          width: '100%',
+          height: '100%',
+        },
       },
       [`${componentCls}-text`]: {
         width: spinDotWidth,


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Spin default indicator uses a 360×360 Lottie animation. The dot size (56px / 72px) is applied via CSS-in-JS on `.spin-oceanbase .spin-dot`. When CSS-in-JS is not yet injected, or Lottie initializes before layout is ready, the SVG can render at native size and appear as an oversized loading icon in global/page loading states.

This PR constrains the Lottie container chain in `genSizeStyle`:

- `overflow: hidden` and `lineHeight: 0` on `.spin-dot`
- `> div { width: 100%; height: 100% }` so the Lottie wrapper fills the dot

SVG scaling is still handled by lottie-web (`style.width/height = 100%`); no redundant `svg` override is added.

| Before | After |
| :--- | :--- |
| Global/page loading Spin occasionally renders at ~360px | Spin indicator stays within design token size (56px default / 72px large) |

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - 🐞 Fix Spin default Lottie indicator occasionally rendering at native 360px size. |
| 🇨🇳 Chinese | - 🐞 修复 Spin 默认 Lottie 指示器偶发以 360px 原始尺寸渲染的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed