### PR TITLE
feat(design): route message API through notification compat layer

### DIFF
--- a/.dumi/sidebar-locales.ts
+++ b/.dumi/sidebar-locales.ts
@@ -109,10 +109,9 @@ const componentsGroups: BilingualGroup[] = [
     zh: '反馈',
     children: [
       { en: 'Alert', zh: 'Alert 警告提示', link: '/components/alert' },
-      { en: 'Message', zh: 'Message 全局提示', link: '/components/message' },
+      { en: 'Notification', zh: 'Notification 通知提醒框', link: '/components/notification' },
       { en: 'Modal', zh: 'Modal 对话框', link: '/components/modal' },
       { en: 'Drawer', zh: 'Drawer 抽屉', link: '/components/drawer' },
-      { en: 'Notification', zh: 'Notification 通知提醒框', link: '/components/notification' },
       { en: 'Popconfirm', zh: 'Popconfirm 气泡确认框', link: '/components/popconfirm' },
       { en: 'Progress', zh: 'Progress 进度条', link: '/components/progress' },
       { en: 'Result', zh: 'Result 结果', link: '/components/result' },

--- a/packages/design/src/message/__tests__/createMessageCompat.test.ts
+++ b/packages/design/src/message/__tests__/createMessageCompat.test.ts
@@ -1,0 +1,191 @@
+import { createMessageCompat, mapMessageConfigToNotification } from '../createMessageCompat';
+import type { ObNotificationInstance } from '../../notification/interface';
+
+const createMockNotification = () => {
+  const calls: { method: string; args: unknown }[] = [];
+  const api = {
+    success: vi.fn((args: unknown) => calls.push({ method: 'success', args })),
+    error: vi.fn((args: unknown) => calls.push({ method: 'error', args })),
+    info: vi.fn((args: unknown) => calls.push({ method: 'info', args })),
+    warning: vi.fn((args: unknown) => calls.push({ method: 'warning', args })),
+    loading: vi.fn((args: unknown) => calls.push({ method: 'loading', args })),
+    open: vi.fn(),
+    destroy: vi.fn(),
+    config: vi.fn(),
+  } as unknown as ObNotificationInstance & { destroy: ReturnType<typeof vi.fn> };
+
+  return { api, calls };
+};
+
+describe('mapMessageConfigToNotification', () => {
+  it('maps top to notification placement and top offset', () => {
+    expect(mapMessageConfigToNotification({ top: 24 })).toMatchObject({
+      placement: 'top',
+      top: 24,
+    });
+  });
+
+  it('parses string top values', () => {
+    expect(mapMessageConfigToNotification({ top: '32px' })).toMatchObject({
+      placement: 'top',
+      top: 32,
+    });
+  });
+
+  it('forwards prefixCls and getContainer', () => {
+    const getContainer = () => document.body;
+    expect(
+      mapMessageConfigToNotification({
+        prefixCls: 'custom-message',
+        getContainer,
+        duration: 4,
+      })
+    ).toMatchObject({
+      prefixCls: 'custom-message',
+      getContainer,
+      duration: 4,
+    });
+  });
+});
+
+describe('createMessageCompat', () => {
+  it('maps message.success string content to notification.success', () => {
+    const { api, calls } = createMockNotification();
+    const message = createMessageCompat(api);
+
+    message.success('Saved');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('success');
+    expect(calls[0].args).toMatchObject({ message: 'Saved' });
+  });
+
+  it('maps message.loading to notification.loading', () => {
+    const { api, calls } = createMockNotification();
+    const message = createMessageCompat(api);
+
+    message.loading('Loading', 0);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('loading');
+    expect(calls[0].args).toMatchObject({ message: 'Loading', duration: 0 });
+  });
+
+  it('maps message.open args with loading type to notification.loading', () => {
+    const { api, calls } = createMockNotification();
+    const message = createMessageCompat(api);
+
+    message.open({ type: 'loading', content: 'Submitting' });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('loading');
+    expect(calls[0].args).toMatchObject({ message: 'Submitting' });
+  });
+
+  it('forwards open args fields to notification', () => {
+    const { api, calls } = createMockNotification();
+    const message = createMessageCompat(api);
+    const onClose = vi.fn();
+    const onClick = vi.fn();
+    const icon = 'custom-icon';
+
+    message.open({
+      type: 'warning',
+      content: 'Heads up',
+      duration: 6,
+      key: 'warn-1',
+      className: 'custom-message',
+      style: { color: 'red' },
+      icon,
+      onClose,
+      onClick,
+    });
+
+    expect(calls[0].args).toMatchObject({
+      message: 'Heads up',
+      duration: 6,
+      key: 'warn-1',
+      className: 'custom-message',
+      style: { color: 'red' },
+      icon,
+    });
+
+    const args = calls[0].args as { onClick?: () => void; onClose?: () => void };
+    args.onClick?.();
+    expect(onClick).toHaveBeenCalledTimes(1);
+    args.onClose?.();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses explicit key without generating a new one', () => {
+    const { api } = createMockNotification();
+    const message = createMessageCompat(api);
+
+    message.open({ type: 'info', content: 'Hello', key: 'fixed-key' });
+
+    expect((api.info as ReturnType<typeof vi.fn>).mock.calls[0][0].key).toBe('fixed-key');
+  });
+
+  it('returns a close function that destroys by key', () => {
+    const { api } = createMockNotification();
+    const message = createMessageCompat(api);
+
+    const close = message.info('Hello');
+    const key = (api.info as ReturnType<typeof vi.fn>).mock.calls[0][0].key;
+    close();
+
+    expect(api.destroy).toHaveBeenCalledWith(key);
+  });
+
+  it('resolves returned promise when notification closes', async () => {
+    const { api } = createMockNotification();
+    const message = createMessageCompat(api);
+
+    const closeable = message.success('Saved');
+    const onClose = (api.success as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      .onClose as () => void;
+    onClose();
+
+    await expect(closeable.then(Boolean)).resolves.toBe(true);
+  });
+
+  it('forwards message.config to notification.config', () => {
+    const { api } = createMockNotification();
+    const message = createMessageCompat(api);
+    const getContainer = () => document.body;
+
+    message.config({
+      duration: 3,
+      maxCount: 5,
+      rtl: true,
+      top: 16,
+      prefixCls: 'custom-message',
+      getContainer,
+    });
+
+    expect(api.config).toHaveBeenCalledWith({
+      duration: 3,
+      maxCount: 5,
+      rtl: true,
+      top: 16,
+      placement: 'top',
+      prefixCls: 'custom-message',
+      getContainer,
+    });
+  });
+
+  it('maps typed method duration overload to onClose callback', () => {
+    const { api, calls } = createMockNotification();
+    const message = createMessageCompat(api);
+    const onClose = vi.fn();
+
+    message.info('Hello', onClose);
+
+    expect(calls[0].args).toMatchObject({
+      message: 'Hello',
+    });
+
+    (calls[0].args as { onClose?: () => void }).onClose?.();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/design/src/message/createMessageCompat.ts
+++ b/packages/design/src/message/createMessageCompat.ts
@@ -1,0 +1,170 @@
+import type { Key, MouseEvent } from 'react';
+import type {
+  ArgsProps as MessageArgsProps,
+  ConfigOptions,
+  JointContent,
+  MessageInstance,
+  NoticeType,
+} from 'antd/es/message/interface';
+import type { NotificationConfig } from 'antd/es/notification/interface';
+import type {
+  NotificationType,
+  ObNotificationArgs,
+  ObNotificationInstance,
+} from '../notification/interface';
+import { wrapPromiseFn } from './wrapPromiseFn';
+
+let keyIndex = 0;
+
+const warnDeprecated = () => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(
+      '[@oceanbase/design] `message` is deprecated for notification scenarios. Use `notification` instead.'
+    );
+  }
+};
+
+const parseOffset = (value: string | number) => {
+  const parsed = typeof value === 'number' ? value : Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const adaptMessageOnClick = (onClick?: (event: MouseEvent<HTMLDivElement>) => void) => {
+  if (!onClick) {
+    return undefined;
+  }
+  return () => {
+    onClick({} as MouseEvent<HTMLDivElement>);
+  };
+};
+
+const isMessageArgs = (content: JointContent): content is MessageArgsProps =>
+  typeof content === 'object' && content !== null && 'content' in content;
+
+const normalizeMessageArgs = (
+  type: NoticeType | undefined,
+  content: JointContent,
+  duration?: number | VoidFunction,
+  onClose?: VoidFunction
+): { noticeType: NotificationType; args: ObNotificationArgs } => {
+  const config: MessageArgsProps = isMessageArgs(content) ? content : { content };
+
+  let mergedDuration: number | undefined;
+  let mergedOnClose: VoidFunction | undefined;
+  if (typeof duration === 'function') {
+    mergedOnClose = duration;
+  } else {
+    mergedDuration = duration;
+    mergedOnClose = onClose;
+  }
+
+  const noticeType = (config.type ?? type ?? 'info') as NotificationType;
+
+  return {
+    noticeType,
+    args: {
+      message: config.content,
+      duration: config.duration ?? mergedDuration,
+      onClose: config.onClose ?? mergedOnClose,
+      icon: config.icon,
+      key: config.key,
+      style: config.style,
+      className: config.className,
+      onClick: adaptMessageOnClick(config.onClick),
+    },
+  };
+};
+
+const openWithNotification = (
+  notification: ObNotificationInstance,
+  noticeType: NotificationType,
+  args: ObNotificationArgs
+) => {
+  let mergedKey = args.key;
+  if (mergedKey === undefined || mergedKey === null) {
+    keyIndex += 1;
+    mergedKey = `ob-message-compat-${keyIndex}`;
+  }
+
+  return wrapPromiseFn(resolve => {
+    const originalOnClose = args.onClose;
+    const config: ObNotificationArgs = {
+      ...args,
+      key: mergedKey,
+      onClose: () => {
+        originalOnClose?.();
+        resolve();
+      },
+    };
+
+    notification[noticeType](config);
+
+    return () => {
+      notification.destroy(mergedKey);
+    };
+  });
+};
+
+export const mapMessageConfigToNotification = (config?: ConfigOptions): NotificationConfig => {
+  if (!config) {
+    return {};
+  }
+
+  const { top, duration, prefixCls, getContainer, maxCount, rtl, transitionName } = config;
+  const notificationConfig: NotificationConfig = {
+    duration,
+    prefixCls,
+    getContainer,
+    maxCount,
+    rtl,
+  };
+
+  if (top !== undefined) {
+    const parsedTop = parseOffset(top);
+    if (parsedTop !== undefined) {
+      notificationConfig.placement = 'top';
+      notificationConfig.top = parsedTop;
+    }
+  }
+
+  if (process.env.NODE_ENV !== 'production' && transitionName) {
+    console.warn(
+      '[@oceanbase/design] message.config transitionName is not supported by notification and will be ignored.'
+    );
+  }
+
+  return notificationConfig;
+};
+
+export const createMessageCompat = (
+  notification: ObNotificationInstance
+): MessageInstance & {
+  config: (config: ConfigOptions) => void;
+} => {
+  const openMessage = (
+    type: NoticeType | undefined,
+    content: JointContent,
+    duration?: number | VoidFunction,
+    onClose?: VoidFunction
+  ) => {
+    warnDeprecated();
+    const { noticeType, args } = normalizeMessageArgs(type, content, duration, onClose);
+    return openWithNotification(notification, noticeType, args);
+  };
+
+  return {
+    info: (content, duration, onClose) => openMessage('info', content, duration, onClose),
+    success: (content, duration, onClose) => openMessage('success', content, duration, onClose),
+    error: (content, duration, onClose) => openMessage('error', content, duration, onClose),
+    warning: (content, duration, onClose) => openMessage('warning', content, duration, onClose),
+    loading: (content, duration, onClose) => openMessage('loading', content, duration, onClose),
+    open: config => openMessage(config.type, config),
+    destroy: (key?: Key) => {
+      notification.destroy(key);
+    },
+    config: config => {
+      warnDeprecated();
+      notification.config?.(mapMessageConfigToNotification(config));
+    },
+  };
+};

--- a/packages/design/src/message/demo/basic.tsx
+++ b/packages/design/src/message/demo/basic.tsx
@@ -2,42 +2,12 @@ import { Button, Space, message } from '@oceanbase/design';
 
 export default () => {
   return (
-    <Space>
-      <Button
-        onClick={() => {
-          message.info('This is a info message');
-        }}
-      >
-        Info
-      </Button>
-      <Button
-        onClick={() => {
-          message.success('This is a success message');
-        }}
-      >
-        Success
-      </Button>
-      <Button
-        onClick={() => {
-          message.error('This is an error message');
-        }}
-      >
-        Error
-      </Button>
-      <Button
-        onClick={() => {
-          message.warning('This is a warning message');
-        }}
-      >
-        Warning
-      </Button>
-      <Button
-        onClick={() => {
-          message.loading('This is a loading message');
-        }}
-      >
-        Loading
-      </Button>
+    <Space wrap>
+      <Button onClick={() => message.info('This is a info message')}>message.info</Button>
+      <Button onClick={() => message.success('This is a success message')}>message.success</Button>
+      <Button onClick={() => message.error('This is an error message')}>message.error</Button>
+      <Button onClick={() => message.warning('This is a warning message')}>message.warning</Button>
+      <Button onClick={() => message.loading('This is a loading message')}>message.loading</Button>
     </Space>
   );
 };

--- a/packages/design/src/message/demo/deprecated-notice.en-US.tsx
+++ b/packages/design/src/message/demo/deprecated-notice.en-US.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Alert } from '@oceanbase/design';
+
+export default () => (
+  <Alert
+    type="warning"
+    showIcon
+    message="Message is deprecated"
+    description={
+      <>
+        Use <a href="/components/notification">Notification</a> for notification scenarios. message
+        remains as an antd Message-compatible alias and is implemented via Notification.
+      </>
+    }
+  />
+);

--- a/packages/design/src/message/demo/deprecated-notice.tsx
+++ b/packages/design/src/message/demo/deprecated-notice.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Alert } from '@oceanbase/design';
+
+export default () => (
+  <Alert
+    type="warning"
+    showIcon
+    message="Message 已弃用"
+    description={
+      <>
+        通知场景请使用 <a href="/components/notification">Notification 通知提醒框</a>。message
+        仍保留兼容 antd Message API，内部已转发至 Notification 实现。
+      </>
+    }
+  />
+);

--- a/packages/design/src/message/index.en-US.md
+++ b/packages/design/src/message/index.en-US.md
@@ -5,15 +5,23 @@ nav:
   path: /components
 ---
 
-- 🔥 Fully inherits antd [Message](https://ant.design/components/message-cn) capabilities and API, seamless migration.
-- 💄 Custom theme and styles, aligned with OceanBase Design specification.
-- 🆕 `message.method()` static method supports ConfigProvider global config.
+<code src="./demo/deprecated-notice.en-US.tsx" inline></code>
+
+## Overview
+
+- 🔥 Compatible with antd [Message](https://ant.design/components/message) call sites; existing code keeps working.
+- 💄 Internally forwards to [Notification](/components/notification) with OBUI 2.0 styles and behavior.
+- 📌 Prefer `notification` for all new notification scenarios.
 
 ## Code Examples
 
 <!-- prettier-ignore -->
-<code src="./demo/basic.tsx" title="Basic"></code>
+<code src="./demo/basic.tsx" title="Compatibility" description="message methods still work but render as Notification."></code>
 
 ## API
 
-- See antd Message docs: https://ant.design/components/message-cn
+- Compatible with antd Message static methods and `message.useMessage()`; params and return semantics are preserved.
+- `message.*` maps to `notification.*`: `content` → `message`, and forwards `duration`, `key`, `icon`, `style`, `className`, `onClose`, `onClick`, etc.
+- `message.loading()` maps to `notification.loading()`.
+- `message.config()` forwards `duration`, `maxCount`, `rtl`, `getContainer`, `prefixCls`; `top` maps to `placement: 'top'` and `top` offset (`transitionName` has no notification equivalent and is ignored in dev with a warning).
+- For notification scenarios, use the [Notification API](/components/notification#api).

--- a/packages/design/src/message/index.md
+++ b/packages/design/src/message/index.md
@@ -5,15 +5,23 @@ nav:
   path: /components
 ---
 
-- 🔥 完全继承 antd [Message](https://ant.design/components/message-cn) 的能力和 API，可无缝切换。
-- 💄 定制主题和样式，符合 OceanBase Design 设计规范。
-- 🆕 `message.method()` 静态方法，支持消费 `ConfigProvider` 全局配置。
+<code src="./demo/deprecated-notice.tsx" inline></code>
+
+## 组件说明
+
+- 🔥 兼容 antd [Message](https://ant.design/components/message-cn) 调用方式，现有代码无需修改。
+- 💄 内部转发至 [Notification](/zh-CN/components/notification)，统一 OBUI 2.0 通知样式与行为。
+- 📌 新代码请直接使用 `notification`，不再新增 `message` 用法。
 
 ## 代码演示
 
 <!-- prettier-ignore -->
-<code src="./demo/basic.tsx" title="基本"></code>
+<code src="./demo/basic.tsx" title="兼容用法" description="message 方法仍可使用，但会渲染为 Notification。"></code>
 
 ## API
 
-- 详见 antd Message 文档: https://ant.design/components/message-cn
+- 兼容 antd Message 静态方法与 `message.useMessage()`，参数与返回值语义保持一致。
+- `message.*` 会映射为 `notification.*`：`content` → `message`，并转发 `duration`、`key`、`icon`、`style`、`className`、`onClose`、`onClick` 等字段。
+- `message.loading()` 映射为 `notification.loading()`。
+- `message.config()` 会转发 `duration`、`maxCount`、`rtl`、`getContainer`、`prefixCls`；`top` 会映射为 `placement: 'top'` 与 `top` 偏移（`transitionName` 无 notification 等价项，开发环境会提示忽略）。
+- 通知场景请改用 [Notification API](/components/notification#api)。

--- a/packages/design/src/message/index.ts
+++ b/packages/design/src/message/index.ts
@@ -1,1 +1,3 @@
-export * from 'antd/es/message';
+export * from './interface';
+export { createMessageCompat, mapMessageConfigToNotification } from './createMessageCompat';
+export { useMessageCompat } from './useMessageCompat';

--- a/packages/design/src/message/useMessageCompat.ts
+++ b/packages/design/src/message/useMessageCompat.ts
@@ -1,0 +1,12 @@
+import { useMemo } from 'react';
+import type { ConfigOptions } from 'antd/es/message/interface';
+import { useObNotification } from '../notification/useObNotification';
+import { createMessageCompat, mapMessageConfigToNotification } from './createMessageCompat';
+
+export const useMessageCompat = (messageConfig?: ConfigOptions) => {
+  const [notificationApi, holder] = useObNotification(
+    mapMessageConfigToNotification(messageConfig)
+  );
+  const messageApi = useMemo(() => createMessageCompat(notificationApi), [notificationApi]);
+  return [messageApi, holder] as const;
+};

--- a/packages/design/src/message/wrapPromiseFn.ts
+++ b/packages/design/src/message/wrapPromiseFn.ts
@@ -1,0 +1,17 @@
+import type { MessageType } from 'antd/es/message/interface';
+
+/** Wrap message open with promise-like function, aligned with antd message API. */
+export const wrapPromiseFn = (openFn: (resolve: () => void) => () => void): MessageType => {
+  let closeFn: (() => void) | undefined;
+  const closePromise = new Promise<boolean>(resolve => {
+    closeFn = openFn(() => {
+      resolve(true);
+    });
+  });
+  const result = (() => {
+    closeFn?.();
+  }) as MessageType;
+  result.then = (filled, rejected) => closePromise.then(filled, rejected);
+  (result as MessageType & { promise: Promise<boolean> }).promise = closePromise;
+  return result;
+};

--- a/packages/design/src/notification/__tests__/createObNotification.test.ts
+++ b/packages/design/src/notification/__tests__/createObNotification.test.ts
@@ -33,13 +33,30 @@ describe('createObNotification', () => {
     expect(error).toHaveBeenCalledTimes(1);
   });
 
-  it('wraps processing notification with processing class', () => {
+  it('exposes loading method for in-progress notifications', () => {
+    const open = vi.fn();
+    const api = createObNotification({
+      ...antNotification,
+      warning: vi.fn(),
+      error: vi.fn(),
+      open,
+      success: vi.fn(),
+      info: vi.fn(),
+      destroy: vi.fn(),
+    } as typeof antNotification);
+
+    api.loading({ message: 'Loading' });
+
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps loading notification with loading class', () => {
     const wrapped = wrapNotificationArgs({
-      type: 'processing',
-      args: { message: 'Processing' },
+      type: 'loading',
+      args: { message: 'Loading' },
     });
 
-    expect(wrapped.className).toContain('ant-notification-notice-processing');
+    expect(wrapped.className).toContain('ant-notification-notice-loading');
     expect(wrapped.duration).toBe(5);
     expect(wrapped.showProgress).toBe(true);
   });

--- a/packages/design/src/notification/createObNotification.ts
+++ b/packages/design/src/notification/createObNotification.ts
@@ -14,7 +14,7 @@ const openWithType = (
 ) => {
   const wrapped = wrapNotificationArgs({ type, args });
 
-  if (type === 'processing') {
+  if (type === 'loading') {
     base.open(wrapped);
     return;
   }
@@ -77,7 +77,7 @@ export const createObNotification = (base: NotificationInstance): ObNotification
     error: wrap('error'),
     info: wrap('info'),
     warning: wrap('warning'),
-    processing: wrap('processing'),
+    loading: wrap('loading'),
     destroy: (key?: React.Key) => {
       if (key === undefined) {
         activeDedupeKeys.clear();

--- a/packages/design/src/notification/demo/basic.tsx
+++ b/packages/design/src/notification/demo/basic.tsx
@@ -48,13 +48,13 @@ export default () => {
       </Button>
       <Button
         onClick={() => {
-          notification.processing({
+          notification.loading({
             message: 'Exporting report',
             description: 'Estimated time remaining: about 2 minutes.',
           });
         }}
       >
-        Processing
+        Loading
       </Button>
     </Space>
   );

--- a/packages/design/src/notification/demo/update.tsx
+++ b/packages/design/src/notification/demo/update.tsx
@@ -7,14 +7,14 @@ export default () => {
   return (
     <Button
       onClick={() => {
-        notification.processing({
+        notification.loading({
           key: UPDATE_KEY,
           message: 'Exporting report',
           description: 'Progress: 20%',
         });
 
         setTimeout(() => {
-          notification.processing({
+          notification.loading({
             key: UPDATE_KEY,
             message: 'Exporting report',
             description: 'Progress: 60%',

--- a/packages/design/src/notification/icons.tsx
+++ b/packages/design/src/notification/icons.tsx
@@ -13,5 +13,5 @@ export const iconMap: Record<NotificationType, React.ReactNode> = {
   info: <InfoCircleOutlined />,
   error: <CloseCircleOutlined />,
   warning: <ExclamationCircleOutlined />,
-  processing: <LoadingOutlined spin />,
+  loading: <LoadingOutlined spin />,
 };

--- a/packages/design/src/notification/index.en-US.md
+++ b/packages/design/src/notification/index.en-US.md
@@ -9,17 +9,18 @@ Use notifications for non-blocking task results or system feedback that can reac
 
 - 🔥 Extends antd [Notification](https://ant.design/components/notification) with OBUI 2.0 capabilities.
 - 💄 Default placement is bottom left, fixed width 350px, linear icons with auto-close progress bar, and links in title/description automatically use the type color style.
-- 🆕 Add `notification.processing` method to display long-running process status.
+- 🆕 Add `notification.loading` method to display long-running process status.
 - 🆕 Add `errorDetails` property to display error information, supporting copy as Markdown format.
 - 🆕 Add `dedupeKey` property to deduplicate notifications.
+- 📌 **Use `notification` for all notification scenarios**; `message` remains as a compatibility alias implemented via Notification.
 
 ## Examples
 
 <!-- prettier-ignore -->
-<code src="./demo/basic.tsx" title="Basic" description="Five types — info, success, warning, error, and processing — for common scenarios."></code>
+<code src="./demo/basic.tsx" title="Basic" description="Five types — info, success, warning, error, and loading — for common scenarios."></code>
 <code src="./demo/placement.tsx" title="Placement" description="Defaults to `bottomLeft`."></code>
 <code src="./demo/auto-close.tsx" title="Auto close" description="5s for title only, 10s with description; errors do not auto close; pause on hover."></code>
-<code src="./demo/update.tsx" title="Update content" description="Use `key` to update the same notification, e.g. processing progress."></code>
+<code src="./demo/update.tsx" title="Update content" description="Use `key` to update the same notification, e.g. loading progress."></code>
 <code src="./demo/error-details.tsx" title="Error details" description="Structured diagnostics for warning / error with collapse and Markdown copy."></code>
 <code src="./demo/actions.tsx" title="Text link actions" description="Custom `<a>` or `Typography.Link` in `message` / `description`; styles match the notification type."></code>
 <code src="./demo/dedupe.tsx" title="Dedupe" description="`dedupeKey` skips duplicates per type; different from `key`, which replaces in place."></code>
@@ -34,7 +35,7 @@ Use notifications for non-blocking task results or system feedback that can reac
 | success | Write succeeded | Create / save / submit success; 5s when title only |
 | warning | Pay attention | Quota, permission, network issues; use `dedupeKey` for repeated alerts |
 | error | Something went wrong | Does not auto close; include reassurance, cause, and next steps |
-| processing | In progress | Long-running tasks; show ETA or stage, update via `key` |
+| loading | In progress | Long-running tasks; show ETA or stage, update via `key` |
 
 ## API
 
@@ -52,7 +53,7 @@ Use notifications for non-blocking task results or system feedback that can reac
 |  | `key` | `dedupeKey` |
 | --- | --- | --- |
 | Same value called again | **Replaces** the existing notification | **Skips** the new notification |
-| Typical use | Processing progress, export stage updates | Polling alerts, error storm prevention |
+| Typical use | Loading progress, export stage updates | Polling alerts, error storm prevention |
 | After close | Can open a new notification with the same key | Can open again with the same dedupeKey |
 
 ### ErrorDetailItem
@@ -82,5 +83,16 @@ Pass `duration` explicitly to override the auto-close strategy above.
 
 ### Methods
 
-- `notification.processing(config)`: Show in-progress notification.
+- `notification.loading(config)`: Show in-progress notification.
 - `notification.useNotification()`: Returns a Hook API and `contextHolder`; insert `contextHolder` into the tree to consume ConfigProvider context.
+
+### Message compatibility
+
+| Legacy | Recommended |
+| --- | --- |
+| `message.success('Saved')` | `notification.success({ message: 'Saved' })` |
+| `message.error('Failed')` | `notification.error({ message: 'Failed' })` |
+| `message.loading('Processing', 0)` | `notification.loading({ message: 'Processing', duration: 0 })` |
+| `message.useMessage()` | `notification.useNotification()` |
+
+`message` remains as an antd Message-compatible alias implemented via Notification; prefer `notification` for new code.

--- a/packages/design/src/notification/index.md
+++ b/packages/design/src/notification/index.md
@@ -9,17 +9,18 @@ nav:
 
 - 🔥 继承 antd [Notification](https://ant.design/components/notification-cn) 的能力和 API，可无缝切换。
 - 💄 默认左下角展示，固定宽度 350px，线性图标与自动关闭进度条，标题/描述内链接自动应用类型色样式。
-- 🆕 新增 `notification.processing` 方法，用于展示持续时间较长的进程状态。
+- 🆕 新增 `notification.loading` 方法，用于展示持续时间较长的进程状态。
 - 🆕 新增 `errorDetails` 属性，用于展示异常信息，并支持复制为 Markdown 格式。
 - 🆕 新增 `dedupeKey` 属性，用于去除重复弹出。
+- 📌 **通知场景统一使用 `notification`**；`message` 仅作兼容入口，内部转发至 Notification。
 
 ## 代码演示
 
 <!-- prettier-ignore -->
-<code src="./demo/basic.tsx" title="基本" description="五种类型：info、success、warning、error、processing，对应不同业务场景。"></code>
+<code src="./demo/basic.tsx" title="基本" description="五种类型：info、success、warning、error、loading，对应不同业务场景。"></code>
 <code src="./demo/placement.tsx" title="位置" description="默认 `bottomLeft`。"></code>
 <code src="./demo/auto-close.tsx" title="自动关闭" description="仅标题 5s、含描述 10s；error 默认不自动关闭；悬停暂停倒计时。"></code>
-<code src="./demo/update.tsx" title="更新消息内容" description="通过 `key` 更新同一条通知，适用于 processing 等进度场景。"></code>
+<code src="./demo/update.tsx" title="更新消息内容" description="通过 `key` 更新同一条通知，适用于 loading 等进度场景。"></code>
 <code src="./demo/error-details.tsx" title="异常明细" description="warning / error 可附加结构化诊断信息，支持折叠展开与 Markdown 复制。"></code>
 <code src="./demo/actions.tsx" title="文字链操作" description="在 `message` / `description` 中插入 `<a>` 或 `Typography.Link`，样式自动按通知类型着色。"></code>
 <code src="./demo/dedupe.tsx" title="去重" description="`dedupeKey` 在同类型下去除重复弹出；与 `key`（替换）语义不同。"></code>
@@ -28,13 +29,13 @@ nav:
 
 ## 通知类型
 
-| 类型       | 含义             | 推荐用法                                            |
-| ---------- | ---------------- | --------------------------------------------------- |
-| info       | 值得知道的事     | 后台任务结果、跨页面同步提示；默认可自动关闭        |
-| success    | 写入任务成功     | 创建/保存/提交成功；仅标题时 5s 自动关闭            |
-| warning    | 可能重要，请注意 | 配额、权限、网络抖动等；重复告警可用 `dedupeKey`    |
-| error      | 出错了           | 默认不自动关闭；建议包含安抚、原因、解决方案        |
-| processing | 进行中           | 长耗时任务；提供预估时间或阶段，配合 `key` 更新进度 |
+| 类型    | 含义             | 推荐用法                                            |
+| ------- | ---------------- | --------------------------------------------------- |
+| info    | 值得知道的事     | 后台任务结果、跨页面同步提示；默认可自动关闭        |
+| success | 写入任务成功     | 创建/保存/提交成功；仅标题时 5s 自动关闭            |
+| warning | 可能重要，请注意 | 配额、权限、网络抖动等；重复告警可用 `dedupeKey`    |
+| error   | 出错了           | 默认不自动关闭；建议包含安抚、原因、解决方案        |
+| loading | 进行中           | 长耗时任务；提供预估时间或阶段，配合 `key` 更新进度 |
 
 ## API
 
@@ -49,11 +50,11 @@ nav:
 
 ### `key` 与 `dedupeKey`
 
-|              | `key`                             | `dedupeKey`               |
-| ------------ | --------------------------------- | ------------------------- |
-| 同值再次调用 | **替换**原通知内容                | **跳过**新通知            |
-| 典型场景     | processing 进度更新、导出阶段切换 | 轮询告警、接口错误防刷屏  |
-| 关闭后       | 可用同 key 创建新通知             | 可用同 dedupeKey 再次弹出 |
+|              | `key`                          | `dedupeKey`               |
+| ------------ | ------------------------------ | ------------------------- |
+| 同值再次调用 | **替换**原通知内容             | **跳过**新通知            |
+| 典型场景     | loading 进度更新、导出阶段切换 | 轮询告警、接口错误防刷屏  |
+| 关闭后       | 可用同 key 创建新通知          | 可用同 dedupeKey 再次弹出 |
 
 ### ErrorDetailItem
 
@@ -82,5 +83,16 @@ nav:
 
 ### 方法
 
-- `notification.processing(config)`：展示进行中通知。
+- `notification.loading(config)`：展示进行中通知。
 - `notification.useNotification()`：获取 Hook 实例，需将返回的 `contextHolder` 插入组件树以消费 ConfigProvider 上下文。
+
+### 与 Message 的兼容
+
+| 旧用法                         | 推荐用法                                                   |
+| ------------------------------ | ---------------------------------------------------------- |
+| `message.success('已保存')`    | `notification.success({ message: '已保存' })`              |
+| `message.error('失败')`        | `notification.error({ message: '失败' })`                  |
+| `message.loading('处理中', 0)` | `notification.loading({ message: '处理中', duration: 0 })` |
+| `message.useMessage()`         | `notification.useNotification()`                           |
+
+`message` 仍保留兼容 antd Message API，内部转发至 Notification；新代码请直接使用 `notification`。

--- a/packages/design/src/notification/interface.ts
+++ b/packages/design/src/notification/interface.ts
@@ -12,7 +12,7 @@ export type {
   NotificationPlacement,
 } from 'antd/es/notification/interface';
 
-export type NotificationType = 'info' | 'success' | 'warning' | 'error' | 'processing';
+export type NotificationType = 'info' | 'success' | 'warning' | 'error' | 'loading';
 
 export interface ErrorDetailItem {
   label: string;
@@ -34,6 +34,6 @@ export interface ObNotificationInstance extends NotificationInstance {
   info: ObNotificationMethod;
   warning: ObNotificationMethod;
   open: ObNotificationMethod;
-  processing: ObNotificationMethod;
+  loading: ObNotificationMethod;
   config?: (config: NotificationConfig | GlobalConfigProps) => void;
 }

--- a/packages/design/src/notification/style/index.ts
+++ b/packages/design/src/notification/style/index.ts
@@ -18,10 +18,10 @@ const NOTIFICATION_CONTENT_GAP = 4;
 const STACK_GAP = 8;
 const NOTIFICATION_SHADOW = '0 6px 8px rgba(19, 33, 57, 0.1)';
 
-type NotificationVisualType = 'success' | 'info' | 'warning' | 'error' | 'processing';
+type NotificationVisualType = 'success' | 'info' | 'warning' | 'error' | 'loading';
 
 const getNotificationTypeColor = (type: NotificationVisualType, token: NotificationToken) =>
-  type === 'processing' ? token.colorPrimary : token[`color${upperFirst(type)}Text`];
+  type === 'loading' ? token.colorPrimary : token[`color${upperFirst(type)}Text`];
 
 const genNotificationTypeStyle = (
   type: NotificationVisualType,
@@ -30,9 +30,9 @@ const genNotificationTypeStyle = (
 ): CSSObject => {
   const textColor = getNotificationTypeColor(type, token);
   const hoverColor =
-    type === 'processing' ? token.colorPrimaryHover : token[`color${upperFirst(type)}TextHover`];
+    type === 'loading' ? token.colorPrimaryHover : token[`color${upperFirst(type)}TextHover`];
   const activeColor =
-    type === 'processing' ? token.colorPrimaryActive : token[`color${upperFirst(type)}TextActive`];
+    type === 'loading' ? token.colorPrimaryActive : token[`color${upperFirst(type)}TextActive`];
   const typeNoticeSelector = `${noticeCls}-wrapper ${noticeCls}-${type}`;
   const linkStyle = {
     color: textColor,
@@ -79,7 +79,7 @@ export const genNotificationStyle: GenerateStyle<NotificationToken> = (
   const progressBottomRadius = `0 0 ${bottomRadius} ${bottomRadius}`;
 
   const typeStyles = (
-    ['success', 'info', 'warning', 'error', 'processing'] as const
+    ['success', 'info', 'warning', 'error', 'loading'] as const
   ).reduce<CSSObject>((acc, type) => {
     return {
       ...acc,

--- a/packages/design/src/notification/wrapNotificationArgs.tsx
+++ b/packages/design/src/notification/wrapNotificationArgs.tsx
@@ -79,7 +79,7 @@ export const wrapNotificationArgs = ({
   });
 
   const duration = resolveDuration(type, content.description ?? restArgs.description, args);
-  const noticeType = type === 'processing' ? undefined : type;
+  const noticeType = type === 'loading' ? undefined : type;
 
   const defaultIcon = icon ?? iconMap[type];
   let iconNode: React.ReactNode = defaultIcon;

--- a/packages/design/src/static-function/index.tsx
+++ b/packages/design/src/static-function/index.tsx
@@ -1,11 +1,8 @@
 import React, { useContext } from 'react';
-import {
-  App,
-  message as antMessage,
-  Modal as AntModal,
-  notification as antNotification,
-} from 'antd';
+import { App, Modal as AntModal, notification as antNotification } from 'antd';
 import type { MessageInstance } from 'antd/es/message/interface';
+import { createMessageCompat } from '../message/createMessageCompat';
+import { useMessageCompat } from '../message/useMessageCompat';
 import type { ModalStaticFunctions } from 'antd/es/modal/confirm';
 import formatToken from 'antd/lib/theme/util/alias';
 import ConfigProvider from '../config-provider';
@@ -36,14 +33,17 @@ const mapToken = {
 let token = formatToken(mapToken);
 let obToken = genObToken(token as GlobalToken);
 
-let message: MessageInstance & {
-  useMessage: typeof antMessage.useMessage;
-} = antMessage;
 let notification: ObNotificationInstance & {
   useNotification: typeof useObNotification;
 } = {
   ...createObNotification(antNotification),
   useNotification: useObNotification,
+};
+let message: MessageInstance & {
+  useMessage: typeof useMessageCompat;
+} = {
+  ...createMessageCompat(notification),
+  useMessage: useMessageCompat,
 };
 
 ensureNotificationConfig();
@@ -66,13 +66,13 @@ export default () => {
 
   const staticFunction = App.useApp();
   // replace antd's static methods, support consuming ConfigProvider configuration
-  message = {
-    ...staticFunction.message,
-    useMessage: antMessage.useMessage,
-  };
   notification = {
     ...createObNotification(staticFunction.notification),
     useNotification: useObNotification,
+  };
+  message = {
+    ...createMessageCompat(notification),
+    useMessage: useMessageCompat,
   };
   modal = {
     ...staticFunction.modal,


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Notification is now the recommended entry for feedback scenarios. Existing `message` call sites remain compatible: static methods and `message.useMessage()` forward to the OB Notification implementation via a compat layer.

Key changes:
- `message.*` maps to `notification.*` (`content` → `message`, `loading` → `notification.loading`)
- Forwards `duration`, `key`, `icon`, `style`, `className`, `onClose`, `onClick`, and common `message.config` options (`top` → `placement: 'top'`)
- Notification in-progress type/API renamed from `processing` to `loading` (class names updated accordingly)
- Message docs show deprecation Alert; site sidebar promotes Notification over Message

Visual placement and interaction follow Notification OBUI 2.0 defaults (expected behavior).

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Notification<br/>&nbsp;&nbsp;- 🆕 Add `notification.loading` for in-progress feedback; rename in-progress styling from `processing` to `loading`.<br/>&nbsp;&nbsp;- 📌 Recommend Notification as the primary feedback entry in docs and sidebar.<br/>- Message<br/>&nbsp;&nbsp;- 🔄 Keep antd Message-compatible API but forward calls to Notification (including `useMessage`).<br/>&nbsp;&nbsp;- 📌 Mark Message docs as deprecated and link to Notification migration guidance. |
| 🇨🇳 Chinese | - Notification<br/>&nbsp;&nbsp;- 🆕 新增 `notification.loading` 用于进行中反馈；进行中样式类型由 `processing` 更名为 `loading`。<br/>&nbsp;&nbsp;- 📌 文档与侧边栏将 Notification 作为通知场景首选入口。<br/>- Message<br/>&nbsp;&nbsp;- 🔄 保留 antd Message 兼容 API，内部转发至 Notification（含 `useMessage`）。<br/>&nbsp;&nbsp;- 📌 Message 文档标注弃用，并提供迁移至 Notification 的说明。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed


Made with [Cursor](https://cursor.com)