### PR TITLE
improve(design): update Input.Search styling and interaction design

### DIFF
--- a/packages/design/src/input/Search.tsx
+++ b/packages/design/src/input/Search.tsx
@@ -1,11 +1,14 @@
-import React, { forwardRef, useContext } from 'react';
+import React, { forwardRef, useContext, useRef } from 'react';
+import classNames from 'classnames';
 import { Input as AntInput } from 'antd';
+import { SearchOutlined } from '@oceanbase/icons';
+import { composeRef } from 'rc-util/lib/ref';
 import type { SearchProps as AntSearchProps } from 'antd/es/input/Search';
-import type { InputLocale, InputRef } from './Input';
 import ConfigProvider from '../config-provider';
 import type { ConfigConsumerProps } from '../config-provider';
 import defaultLocale from '../locale/en-US';
-import { showCountFormatter } from './Input';
+import InternalInput, { showCountFormatter } from './Input';
+import type { InputLocale, InputRef } from './Input';
 import useStyle from './style';
 
 export * from 'antd/es/input/Search';
@@ -14,32 +17,106 @@ export interface SearchProps extends AntSearchProps {
   locale?: InputLocale;
 }
 
-const Search = forwardRef<InputRef, SearchProps>(
-  ({ prefixCls: customizePrefixCls, locale: customLocale, showCount, ...restProps }, ref) => {
-    const { getPrefixCls, locale: contextLocale } = useContext<ConfigConsumerProps>(
-      ConfigProvider.ConfigContext
-    );
-    const prefixCls = getPrefixCls('input', customizePrefixCls);
-    const [wrapCSSVar] = useStyle(prefixCls);
-    const inputLocale: InputLocale = {
-      placeholder:
-        contextLocale?.global?.inputPlaceholder || defaultLocale.global?.inputPlaceholder,
-      ...defaultLocale.Input,
-      ...contextLocale?.Input,
-      ...customLocale,
+const Search = forwardRef<InputRef, SearchProps>((props, ref) => {
+  const {
+    prefixCls: customizePrefixCls,
+    inputPrefixCls: customizeInputPrefixCls,
+    className,
+    enterButton = false,
+    addonAfter,
+    prefix,
+    locale: customLocale,
+    showCount,
+    onSearch,
+    onChange: onChangeProp,
+    onPressEnter: onPressEnterProp,
+    onCompositionStart,
+    onCompositionEnd,
+    loading,
+    ...restProps
+  } = props;
+
+  const {
+    getPrefixCls,
+    locale: contextLocale,
+    direction,
+  } = useContext<ConfigConsumerProps>(ConfigProvider.ConfigContext);
+  const prefixCls = getPrefixCls('input-search', customizePrefixCls);
+  const inputPrefixCls = getPrefixCls('input', customizeInputPrefixCls);
+  const [wrapCSSVar] = useStyle(inputPrefixCls);
+  const searchPrefix = prefix ?? <SearchOutlined />;
+  const inputRef = useRef<InputRef>(null);
+  const composedRef = useRef(false);
+
+  const inputLocale: InputLocale = {
+    placeholder: contextLocale?.global?.inputPlaceholder || defaultLocale.global?.inputPlaceholder,
+    ...defaultLocale.Input,
+    ...contextLocale?.Input,
+    ...customLocale,
+  };
+
+  if (!enterButton && !addonAfter) {
+    const handleChange: AntSearchProps['onChange'] = e => {
+      if (e?.target && e.type === 'click' && onSearch) {
+        onSearch(e.target.value, e, { source: 'clear' });
+      }
+      onChangeProp?.(e);
     };
 
-    return wrapCSSVar(
-      <AntInput.Search
-        ref={ref}
-        prefixCls={customizePrefixCls}
-        placeholder={inputLocale.placeholder}
-        showCount={showCount === true ? { formatter: showCountFormatter } : showCount}
+    const handlePressEnter: AntSearchProps['onPressEnter'] = e => {
+      if (composedRef.current || loading) {
+        return;
+      }
+      onPressEnterProp?.(e);
+      onSearch?.(inputRef.current?.input?.value ?? '', e, { source: 'input' });
+    };
+
+    const cls = classNames(prefixCls, { [`${prefixCls}-rtl`]: direction === 'rtl' }, className);
+
+    return (
+      <InternalInput
+        ref={composeRef(inputRef, ref)}
+        prefixCls={customizeInputPrefixCls}
+        locale={customLocale}
+        showCount={showCount}
         {...restProps}
+        className={cls}
+        type="search"
+        prefix={searchPrefix}
+        onChange={handleChange}
+        onPressEnter={handlePressEnter}
+        onCompositionStart={e => {
+          composedRef.current = true;
+          onCompositionStart?.(e);
+        }}
+        onCompositionEnd={e => {
+          composedRef.current = false;
+          onCompositionEnd?.(e);
+        }}
       />
     );
   }
-);
+
+  return wrapCSSVar(
+    <AntInput.Search
+      ref={ref}
+      prefixCls={customizeInputPrefixCls}
+      className={classNames(prefixCls, className)}
+      placeholder={inputLocale.placeholder}
+      showCount={showCount === true ? { formatter: showCountFormatter } : showCount}
+      prefix={searchPrefix}
+      enterButton={enterButton}
+      addonAfter={addonAfter}
+      loading={loading}
+      onSearch={onSearch}
+      onChange={onChangeProp}
+      onPressEnter={onPressEnterProp}
+      onCompositionStart={onCompositionStart}
+      onCompositionEnd={onCompositionEnd}
+      {...restProps}
+    />
+  );
+});
 
 if (process.env.NODE_ENV !== 'production') {
   Search.displayName = 'Search';

--- a/packages/design/src/input/__tests__/search.test.tsx
+++ b/packages/design/src/input/__tests__/search.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { Input } from '@oceanbase/design';
+
+const { Search } = Input;
+
+describe('Input.Search', () => {
+  it('should render search icon in prefix by default', () => {
+    const { container } = render(<Search />);
+    expect(container.querySelector('.ant-input-prefix .anticon-search')).toBeTruthy();
+  });
+
+  it('should allow custom prefix', () => {
+    const { container } = render(<Search prefix={<span data-testid="custom-prefix" />} />);
+    expect(container.querySelector('[data-testid="custom-prefix"]')).toBeTruthy();
+    expect(container.querySelector('.ant-input-prefix .anticon-search')).toBeFalsy();
+  });
+
+  it('should trigger onSearch when pressing Enter', () => {
+    const onSearch = vi.fn();
+    const { container } = render(<Search onSearch={onSearch} defaultValue="hello" />);
+    const input = container.querySelector('.ant-input-search input') as HTMLInputElement;
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    expect(onSearch).toHaveBeenCalledWith('hello', expect.any(Object), { source: 'input' });
+  });
+
+  it('should trigger onSearch when clicking enter button', () => {
+    const onSearch = vi.fn();
+    const { container } = render(<Search enterButton onSearch={onSearch} defaultValue="world" />);
+    fireEvent.click(container.querySelector('.ant-input-search-button')!);
+    expect(onSearch).toHaveBeenCalledWith('world', expect.any(Object), { source: 'input' });
+  });
+
+  it('should not render enter button when enterButton is false', () => {
+    const { container } = render(<Search />);
+    expect(container.querySelector('.ant-input-search-button')).toBeFalsy();
+  });
+});


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

更新 `Input.Search` 样式和交互设计：默认使用内部 `Input` 组件并展示左侧搜索图标；未设置 `enterButton` 时不显示右侧搜索按钮；设置 `enterButton` 时保持原有 API 与交互能力。

| Before | After |
| :--- | :--- |
| <img width="774" height="82" alt="image" src="https://github.com/user-attachments/assets/50d15aa9-d000-4a42-8f63-9499a46372f0" /> | <img width="772" height="82" alt="image" src="https://github.com/user-attachments/assets/5754e4f7-f3a6-4b5d-82bc-0d23bd39c0ba" /> |

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - 💄 Update Input.Search styling and interaction design. |
| 🇨🇳 Chinese | - 💄 更新 Input.Search 样式和交互设计。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed