### PR TITLE
feat(design): add column.tooltip for Table and ProTable header help

### DIFF
--- a/packages/design/src/table/ColumnTitleWithTooltip.tsx
+++ b/packages/design/src/table/ColumnTitleWithTooltip.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import { QuestionCircleOutlined } from '@oceanbase/icons';
+import Space from '../space';
+import Tooltip from '../tooltip';
+import type { TooltipProps } from '../tooltip';
+import type { WrapperTooltipProps } from '../form/FormItem';
+import { useTooltipTypeList } from '../tooltip/hooks/useTooltipTypeList';
+
+export type ColumnTooltipType = WrapperTooltipProps | ReactNode;
+
+export function getColumnTooltip(column: Record<string, any>): ColumnTooltipType | undefined {
+  return column.tooltip ?? column.tip;
+}
+
+export function isValidColumnTooltip(
+  tooltip: ColumnTooltipType | undefined
+): tooltip is ColumnTooltipType {
+  if (tooltip == null || tooltip === '') {
+    return false;
+  }
+  if (React.isValidElement(tooltip)) {
+    return true;
+  }
+  if (typeof tooltip === 'object') {
+    const { title, icon } = tooltip as WrapperTooltipProps;
+    if (icon) {
+      return true;
+    }
+    if (title != null && title !== '') {
+      return true;
+    }
+    return false;
+  }
+  return true;
+}
+
+export interface ColumnTitleWithTooltipProps {
+  title?: ReactNode;
+  tooltip: ColumnTooltipType;
+  prefixCls: string;
+}
+
+export const ColumnTitleWithTooltip: React.FC<ColumnTitleWithTooltipProps> = ({
+  title,
+  tooltip,
+  prefixCls,
+}) => {
+  const typeList = useTooltipTypeList();
+  const iconCls = `${prefixCls}-column-title-tooltip-icon`;
+
+  const renderTooltipTrigger = () => {
+    if (React.isValidElement(tooltip)) {
+      return tooltip;
+    }
+
+    let tooltipProps: TooltipProps = { placement: 'top', title: '' };
+    let icon: ReactNode = <QuestionCircleOutlined className={iconCls} />;
+
+    if (typeof tooltip === 'object') {
+      const {
+        icon: customIcon,
+        type,
+        overlayInnerStyle,
+        ...restTooltipProps
+      } = tooltip as WrapperTooltipProps;
+      const typeItem = typeList.find(item => item.type === type);
+      tooltipProps = {
+        placement: 'top',
+        color: typeItem?.backgroundColor,
+        overlayInnerStyle: {
+          color: typeItem?.color,
+          ...overlayInnerStyle,
+        },
+        ...restTooltipProps,
+      };
+      if (customIcon) {
+        icon = customIcon;
+      }
+    } else {
+      tooltipProps = { placement: 'top', title: tooltip };
+    }
+
+    return <Tooltip {...tooltipProps}>{icon}</Tooltip>;
+  };
+
+  const hasTitle = title != null && title !== '';
+
+  if (!hasTitle) {
+    return <>{renderTooltipTrigger()}</>;
+  }
+
+  return (
+    <Space size={4}>
+      {title}
+      {renderTooltipTrigger()}
+    </Space>
+  );
+};
+
+export function injectColumnTitleTooltip<T extends Record<string, any>>(
+  column: T,
+  prefixCls: string
+): T {
+  const tooltip = getColumnTooltip(column);
+  if (!isValidColumnTooltip(tooltip)) {
+    return column;
+  }
+
+  const {
+    tooltip: _tooltip,
+    tip: _tip,
+    title: originalTitle,
+    ...rest
+  } = column as T & {
+    tooltip?: ColumnTooltipType;
+    tip?: ColumnTooltipType;
+    title?: ReactNode | ((...args: any[]) => ReactNode);
+  };
+
+  return {
+    ...rest,
+    title: ((...titleProps: any[]) => (
+      <ColumnTitleWithTooltip
+        prefixCls={prefixCls}
+        tooltip={tooltip}
+        title={typeof originalTitle === 'function' ? originalTitle(...titleProps) : originalTitle}
+      />
+    )) as T['title'],
+  } as unknown as T;
+}

--- a/packages/design/src/table/__tests__/column-tooltip.test.tsx
+++ b/packages/design/src/table/__tests__/column-tooltip.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ConfigProvider, Table } from '@oceanbase/design';
+import {
+  ColumnTitleWithTooltip,
+  isValidColumnTooltip,
+  injectColumnTitleTooltip,
+} from '../ColumnTitleWithTooltip';
+
+const prefixCls = 'ant-table';
+
+describe('ColumnTitleWithTooltip', () => {
+  it('isValidColumnTooltip should validate tooltip content', () => {
+    expect(isValidColumnTooltip(undefined)).toBe(false);
+    expect(isValidColumnTooltip('')).toBe(false);
+    expect(isValidColumnTooltip({})).toBe(false);
+    expect(isValidColumnTooltip({ title: '' })).toBe(false);
+    expect(isValidColumnTooltip('help')).toBe(true);
+    expect(isValidColumnTooltip({ title: 'help' })).toBe(true);
+    expect(isValidColumnTooltip({ icon: <span data-testid="custom-icon" /> })).toBe(true);
+  });
+
+  it('should render title with tooltip icon', () => {
+    const { container } = render(
+      <ConfigProvider>
+        <ColumnTitleWithTooltip prefixCls={prefixCls} title="Name" tooltip="help text" />
+      </ConfigProvider>
+    );
+    expect(container.textContent).toContain('Name');
+    expect(container.querySelector(`.${prefixCls}-column-title-tooltip-icon`)).toBeTruthy();
+  });
+
+  it('should render only tooltip icon when title is empty', () => {
+    const { container } = render(
+      <ConfigProvider>
+        <ColumnTitleWithTooltip prefixCls={prefixCls} tooltip="help text" />
+      </ConfigProvider>
+    );
+    expect(container.querySelector(`.${prefixCls}-column-title-tooltip-icon`)).toBeTruthy();
+  });
+});
+
+describe('Table column tooltip', () => {
+  const dataSource = [{ key: '1', name: 'Mike', age: 32 }];
+
+  it('should render tooltip icon in column header', () => {
+    const { container } = render(
+      <ConfigProvider>
+        <Table
+          pagination={false}
+          dataSource={dataSource}
+          columns={[
+            { title: 'Name', dataIndex: 'name', tooltip: 'User name' },
+            { title: 'Age', dataIndex: 'age' },
+          ]}
+        />
+      </ConfigProvider>
+    );
+    const nameHeader = container.querySelector('.ant-table-thead tr th:first-child');
+    const ageHeader = container.querySelector('.ant-table-thead tr th:last-child');
+    expect(nameHeader?.querySelector(`.${prefixCls}-column-title-tooltip-icon`)).toBeTruthy();
+    expect(ageHeader?.querySelector(`.${prefixCls}-column-title-tooltip-icon`)).toBeFalsy();
+  });
+
+  it('should not render tooltip icon when tooltip is empty', () => {
+    const { container } = render(
+      <ConfigProvider>
+        <Table
+          pagination={false}
+          dataSource={dataSource}
+          columns={[
+            { title: 'Name', dataIndex: 'name', tooltip: '' },
+            { title: 'Age', dataIndex: 'age', tooltip: {} },
+          ]}
+        />
+      </ConfigProvider>
+    );
+    expect(container.querySelector(`.${prefixCls}-column-title-tooltip-icon`)).toBeFalsy();
+  });
+
+  it('should render tooltip icon without title text', () => {
+    const { container } = render(
+      <ConfigProvider>
+        <Table
+          pagination={false}
+          dataSource={dataSource}
+          columns={[{ dataIndex: 'name', tooltip: 'User name' }]}
+        />
+      </ConfigProvider>
+    );
+    const headerCell = container.querySelector('.ant-table-thead .ant-table-cell');
+    expect(headerCell?.textContent).toBe('');
+    expect(container.querySelector(`.${prefixCls}-column-title-tooltip-icon`)).toBeTruthy();
+  });
+
+  it('should keep sorter icon when tooltip exists', () => {
+    const { container } = render(
+      <ConfigProvider>
+        <Table
+          pagination={false}
+          dataSource={dataSource}
+          columns={[
+            {
+              title: 'Age',
+              dataIndex: 'age',
+              sorter: (a, b) => a.age - b.age,
+              tooltip: 'Age in years',
+            },
+          ]}
+        />
+      </ConfigProvider>
+    );
+    expect(container.querySelector(`.${prefixCls}-column-title-tooltip-icon`)).toBeTruthy();
+    expect(container.querySelector(`.${prefixCls}-column-sorter`)).toBeTruthy();
+  });
+
+  it('injectColumnTitleTooltip should wrap function title', () => {
+    const column = injectColumnTitleTooltip(
+      {
+        title: ({ sortOrder }: { sortOrder?: string }) => `Age${sortOrder ? `-${sortOrder}` : ''}`,
+        tooltip: 'help',
+      },
+      prefixCls
+    );
+    const { container } = render(
+      <ConfigProvider>{column.title?.({ sortOrder: 'ascend' })}</ConfigProvider>
+    );
+    expect(container.textContent).toContain('Age-ascend');
+    expect(container.querySelector(`.${prefixCls}-column-title-tooltip-icon`)).toBeTruthy();
+  });
+});

--- a/packages/design/src/table/demo/column-tooltip.tsx
+++ b/packages/design/src/table/demo/column-tooltip.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Table } from '@oceanbase/design';
+import type { OBTableColumnsType } from '@oceanbase/design/es/table';
+
+interface DataType {
+  key: React.Key;
+  name: string;
+  age: number;
+  amount: number;
+  address: string;
+}
+
+const dataSource: DataType[] = [
+  { key: '1', name: 'Mike', age: 32, amount: 1200, address: '10 Downing Street' },
+  { key: '2', name: 'John', age: 42, amount: 2400, address: '20 Oxford Street' },
+  { key: '3', name: 'Jane', age: 28, amount: 800, address: '30 Baker Street' },
+];
+
+const columns: OBTableColumnsType<DataType> = [
+  {
+    title: 'Name',
+    dataIndex: 'name',
+    tooltip: 'User display name',
+  },
+  {
+    title: 'Age',
+    dataIndex: 'age',
+    sorter: (a, b) => a.age - b.age,
+    tooltip: { title: 'Age in years', type: 'info' },
+  },
+  {
+    title: 'Amount',
+    dataIndex: 'amount',
+    sorter: (a, b) => a.amount - b.amount,
+    filters: [
+      { text: '>= 1000', value: 'high' },
+      { text: '< 1000', value: 'low' },
+    ],
+    onFilter: (value, record) => (value === 'high' ? record.amount >= 1000 : record.amount < 1000),
+    tooltip: 'Amount before tax',
+  },
+  {
+    title: 'Address',
+    dataIndex: 'address',
+  },
+];
+
+const App: React.FC = () => <Table columns={columns} dataSource={dataSource} pagination={false} />;
+
+export default App;

--- a/packages/design/src/table/index.en-US.md
+++ b/packages/design/src/table/index.en-US.md
@@ -14,6 +14,7 @@ markdown: |
 - 🔥 Fully inherits antd [Table](https://ant.design/components/table-cn) capabilities and API, seamless migration.
 - 💄 Custom theme and styles, aligned with OceanBase Design specification.
 - 🆕 Set `column.ellipsis` for auto-ellipsis with Tooltip.
+- 🆕 Set `column.tooltip` for column header help.
 - 🆕 New batch action bar for selected items and batch actions, see [API](#api).
 
 ## Code Examples
@@ -23,6 +24,7 @@ markdown: |
 <code src="./demo/bordered.tsx" title="Bordered" description="Add table borders."></code>
 <code src="./demo/inner-bordered.tsx" title="Inner Bordered" description="Borders only inside table, often with bordered Card."></code>
 <code src="./demo/ellipsis.tsx" title="Cell Ellipsis" description="`column.ellipsis` enables auto-ellipsis with Tooltip. Note: column header ellipsis does not support sort/filter yet."></code>
+<code src="./demo/column-tooltip.tsx" title="Column Header Tooltip" description="Use `column.tooltip` for column header help. Works with sort and filter."></code>
 <code src="./demo/fixed-columns-header-tables.tsx" title="Fixed Header and Columns"></code>
 <code src="./demo/filter-and-sorter.tsx" title="Filter and Sort"></code>
 <code src="./demo/row-selection.tsx" title="Selection and Actions"></code>
@@ -55,5 +57,11 @@ markdown: |
 | toolOptionsRender | Render toolbar, returns dom array with auto margin | (selectedRowKeys, selectedRows) => ReactNode[] | - | - |
 | toolAlertRender | Render alert | ((selectedRowKeys, selectedRows) => ReactNode) \| false | - | - |
 | toolSelectedContent | Render expanded content | (selectedRowKeys, selectedRows) => ReactNode | - | - |
+
+### Column
+
+| Property | Description                | Type                | Default | Version |
+| :------- | :------------------------- | :------------------ | :------ | :------ |
+| tooltip  | Column header help tooltip | `ColumnTooltipType` | -       | -       |
 
 - See antd Table docs: https://ant.design/components/table-cn

--- a/packages/design/src/table/index.md
+++ b/packages/design/src/table/index.md
@@ -14,6 +14,7 @@ markdown: |
 - 🔥 完全继承 antd [Alert](https://ant.design/components/alert-cn) 的能力和 API，可无缝切换。
 - 💄 定制主题和样式，符合 OceanBase Design 设计规范。
 - 🆕 设置 `column.ellipsis`，开启自动省略，并使用 Tooltip 展示全部内容。
+- 🆕 设置 `column.tooltip`，在列头展示帮助说明。
 - 🆕 新增 `批量操作栏`，可配置选中对象、批量操作项等，详见 [API](#api)。
 
 ## 代码演示
@@ -23,6 +24,7 @@ markdown: |
 <code src="./demo/bordered.tsx" title="带边框" description="添加表格边框线。"></code>
 <code src="./demo/inner-bordered.tsx" title="带内部边框" description="仅表格内部添加边框线，常和带边框的 Card 一起使用，以避免外部边框重复。"></code>
 <code src="./demo/ellipsis.tsx" title="单元格自动省略" description="设置 `column.ellipsis` 可以让单元格内容根据宽度自动省略，并使用 Tooltip 展示全部内容。`说明`: 列头缩略暂不支持和排序筛选一起使用。"></code>
+<code src="./demo/column-tooltip.tsx" title="列头帮助提示" description="通过 `column.tooltip` 在列头展示帮助说明，可与排序、筛选一起使用。"></code>
 <code src="./demo/fixed-columns-header-tables.tsx" title="固定头和列"></code>
 <code src="./demo/filter-and-sorter.tsx" title="筛选和排序"></code>
 <code src="./demo/row-selection.tsx" title="选择和操作"></code>
@@ -55,5 +57,11 @@ markdown: |
 | toolOptionsRender | 渲染工具栏，支持返回一个 dom 数组，会自动增加 margin | (selectedRowKeys, selectedRows) => ReactNode[] | - | - |
 | toolAlertRender | 渲染 alert 提示信息 | ((selectedRowKeys, selectedRows) => ReactNode) \| false，设置 false 取消 alert 提示 | - | - |
 | toolSelectedContent | 渲染展开内容 | (selectedRowKeys, selectedRows) => ReactNode | - | - |
+
+### Column
+
+| 参数    | 说明         | 类型                | 默认值 | 版本 |
+| :------ | :----------- | :------------------ | :----- | :--- |
+| tooltip | 列头帮助提示 | `ColumnTooltipType` | -      | -    |
 
 - 详见 antd Table 文档: https://ant.design/components/table-cn

--- a/packages/design/src/table/index.tsx
+++ b/packages/design/src/table/index.tsx
@@ -1,6 +1,6 @@
 import { Popover, Space, Table as AntTable, theme } from 'antd';
 import type { TableProps as AntTableProps } from 'antd';
-import type { ColumnsType } from 'antd/es/table';
+import type { ColumnsType, ColumnType } from 'antd/es/table';
 import type { RowSelectMethod, TableLocale as AntTableLocale } from 'antd/es/table/interface';
 import type { Reference } from 'rc-table';
 import type Summary from 'rc-table/es/Footer/Summary';
@@ -17,6 +17,12 @@ import type { AnyObject } from '../_util/type';
 import useDefaultPagination from './hooks/useDefaultPagination';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import enUS from '../locale/en-US';
+import { injectColumnTitleTooltip } from './ColumnTitleWithTooltip';
+import type { ColumnTooltipType } from './ColumnTitleWithTooltip';
+
+export type { ColumnTooltipType } from './ColumnTitleWithTooltip';
+export type OBColumnType<T> = ColumnType<T> & { tooltip?: ColumnTooltipType };
+export type OBTableColumnsType<T> = OBColumnType<T>[];
 
 export * from 'antd/es/table';
 
@@ -287,7 +293,7 @@ function Table<T extends Record<string, any>>(props: TableProps<T>, ref: React.R
   // 递归处理嵌套的 columns，为所有层级的列添加排序和筛选图标
   const processColumn = React.useCallback(
     (item: any): any => {
-      const newItem = { ...item };
+      const newItem = injectColumnTitleTooltip(item, prefixCls);
       // 自定义排序图标，根据排序状态高亮不同的图标
       if (item.sorter && !item.sortIcon) {
         newItem.sortIcon = ({ sortOrder }: { sortOrder?: 'ascend' | 'descend' }) => (

--- a/packages/design/src/table/style/index.ts
+++ b/packages/design/src/table/style/index.ts
@@ -131,6 +131,13 @@ export const genTableStyle = (token: TableToken): CSSObject => {
         [`${componentCls}-column-title`]: {
           flex: 'initial',
         },
+        [`${componentCls}-column-title-tooltip-icon`]: {
+          cursor: 'help',
+          color: token.colorIcon,
+          ['&:hover']: {
+            color: token.colorIconHover,
+          },
+        },
         [`${componentCls}-filter-column`]: {
           justifyContent: 'flex-start',
         },

--- a/packages/ui/src/ProTable/__tests__/column-tooltip.test.tsx
+++ b/packages/ui/src/ProTable/__tests__/column-tooltip.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ConfigProvider } from '@oceanbase/design';
+import { ProTable } from '@oceanbase/ui';
+
+const columns = [
+  {
+    title: 'Name',
+    dataIndex: 'name',
+    tooltip: 'User display name',
+  },
+  {
+    title: 'Age',
+    dataIndex: 'age',
+    sorter: (a: { age: number }, b: { age: number }) => a.age - b.age,
+    tooltip: { title: 'Age in years', type: 'info' },
+  },
+  {
+    title: 'Amount',
+    dataIndex: 'amount',
+    sorter: (a: { amount: number }, b: { amount: number }) => a.amount - b.amount,
+    filters: [
+      { text: '>= 1000', value: 'high' },
+      { text: '< 1000', value: 'low' },
+    ],
+    onFilter: (value: string | number | boolean, record: { amount: number }) =>
+      value === 'high' ? record.amount >= 1000 : record.amount < 1000,
+    tooltip: 'Amount before tax',
+  },
+  {
+    title: 'Address',
+    dataIndex: 'address',
+  },
+];
+
+const dataSource = [
+  { key: '1', name: 'Mike', age: 32, amount: 1200, address: '10 Downing Street' },
+  { key: '2', name: 'John', age: 42, amount: 2400, address: '20 Oxford Street' },
+];
+
+describe('ProTable column tooltip', () => {
+  it('should render OB Table tooltip icons consistently', () => {
+    const { container } = render(
+      <ConfigProvider>
+        <ProTable
+          search={false}
+          options={false}
+          pagination={false}
+          columns={columns}
+          dataSource={dataSource}
+        />
+      </ConfigProvider>
+    );
+    const nameHeader = container.querySelector('.ant-table-thead tr th:nth-child(1)');
+    const ageHeader = container.querySelector('.ant-table-thead tr th:nth-child(2)');
+    const amountHeader = container.querySelector('.ant-table-thead tr th:nth-child(3)');
+    expect(nameHeader?.querySelector('.ant-table-column-title-tooltip-icon')).toBeTruthy();
+    expect(ageHeader?.querySelector('.ant-table-column-title-tooltip-icon')).toBeTruthy();
+    expect(amountHeader?.querySelector('.ant-table-column-title-tooltip-icon')).toBeTruthy();
+    expect(container.querySelector('.ant-pro-core-label-tip-icon')).toBeFalsy();
+  });
+});

--- a/packages/ui/src/ProTable/__tests__/columnTooltip.test.ts
+++ b/packages/ui/src/ProTable/__tests__/columnTooltip.test.ts
@@ -1,0 +1,46 @@
+import { columnsHaveTooltip, mergeColumnTooltip, stripColumnTooltip } from '../columnTooltip';
+
+describe('ProTable columnTooltip utils', () => {
+  it('columnsHaveTooltip should detect tooltip in nested columns', () => {
+    expect(columnsHaveTooltip([{ title: 'Name', dataIndex: 'name' }])).toBe(false);
+    expect(columnsHaveTooltip([{ title: 'Name', dataIndex: 'name', tooltip: 'help' }])).toBe(true);
+    expect(
+      columnsHaveTooltip([
+        {
+          title: 'Group',
+          children: [{ title: 'Age', dataIndex: 'age', tip: 'tip' }],
+        },
+      ])
+    ).toBe(true);
+  });
+
+  it('stripColumnTooltip should remove tooltip and tip', () => {
+    expect(
+      stripColumnTooltip([
+        { title: 'Name', dataIndex: 'name', tooltip: 'help' },
+        { title: 'Age', dataIndex: 'age', tip: 'tip' },
+      ])
+    ).toEqual([
+      { title: 'Name', dataIndex: 'name' },
+      { title: 'Age', dataIndex: 'age' },
+    ]);
+  });
+
+  it('mergeColumnTooltip should restore tooltip by dataIndex', () => {
+    expect(
+      mergeColumnTooltip(
+        [
+          { title: 'Name', dataIndex: 'name', index: 0 },
+          { title: 'Age', dataIndex: 'age', index: 1 },
+        ],
+        [
+          { title: 'Name', dataIndex: 'name', tooltip: 'help' },
+          { title: 'Age', dataIndex: 'age', tip: 'tip' },
+        ]
+      )
+    ).toEqual([
+      { title: 'Name', dataIndex: 'name', index: 0, tooltip: 'help' },
+      { title: 'Age', dataIndex: 'age', index: 1, tooltip: 'tip' },
+    ]);
+  });
+});

--- a/packages/ui/src/ProTable/columnTooltip.ts
+++ b/packages/ui/src/ProTable/columnTooltip.ts
@@ -1,0 +1,90 @@
+type ColumnLike = Record<string, any>;
+
+function getColumnTooltip(column: ColumnLike) {
+  return column.tooltip ?? column.tip;
+}
+
+function isValidColumnTooltip(tooltip: unknown): boolean {
+  if (tooltip == null || tooltip === '') {
+    return false;
+  }
+  if (typeof tooltip === 'object' && tooltip !== null && !Array.isArray(tooltip)) {
+    const { title, icon } = tooltip as { title?: unknown; icon?: unknown };
+    if (icon) {
+      return true;
+    }
+    return title != null && title !== '';
+  }
+  return true;
+}
+
+export function columnsHaveTooltip(columns?: ColumnLike[]): boolean {
+  if (!columns?.length) {
+    return false;
+  }
+  return columns.some(column => {
+    if (isValidColumnTooltip(getColumnTooltip(column))) {
+      return true;
+    }
+    return column.children?.length ? columnsHaveTooltip(column.children) : false;
+  });
+}
+
+/** 阻止 pro-components 用 LabelIconTip 渲染列头 tooltip，改由 OB Table 统一处理 */
+export function stripColumnTooltip(columns?: ColumnLike[]): ColumnLike[] | undefined {
+  if (!columns?.length) {
+    return columns;
+  }
+  return columns.map(({ tooltip: _tooltip, tip: _tip, children, ...rest }) => ({
+    ...rest,
+    children: children ? stripColumnTooltip(children) : children,
+  }));
+}
+
+function findSourceColumn(
+  column: ColumnLike,
+  sourceColumns: ColumnLike[] | undefined,
+  index: number
+): ColumnLike | undefined {
+  if (!sourceColumns?.length) {
+    return undefined;
+  }
+  if (column.key != null) {
+    const byKey = sourceColumns.find(item => item.key === column.key);
+    if (byKey) {
+      return byKey;
+    }
+  }
+  if (column.dataIndex != null) {
+    const byDataIndex = sourceColumns.find(
+      item =>
+        item.dataIndex === column.dataIndex ||
+        item.dataIndex?.toString() === column.dataIndex?.toString()
+    );
+    if (byDataIndex) {
+      return byDataIndex;
+    }
+  }
+  return sourceColumns[index];
+}
+
+/** 将用户 columns 上的 tooltip 合并回 pro-components 处理后的 columns */
+export function mergeColumnTooltip(
+  processedColumns?: ColumnLike[],
+  sourceColumns?: ColumnLike[]
+): ColumnLike[] | undefined {
+  if (!processedColumns?.length) {
+    return processedColumns;
+  }
+  return processedColumns.map((column, index) => {
+    const source = findSourceColumn(column, sourceColumns, index);
+    const tooltip = source ? getColumnTooltip(source) : undefined;
+    return {
+      ...column,
+      ...(tooltip !== undefined ? { tooltip } : {}),
+      children: column.children?.length
+        ? mergeColumnTooltip(column.children, source?.children)
+        : column.children,
+    };
+  });
+}

--- a/packages/ui/src/ProTable/demo/column-tooltip.tsx
+++ b/packages/ui/src/ProTable/demo/column-tooltip.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { ProTable } from '@oceanbase/ui';
+import type { OBTableColumnsType } from '@oceanbase/design/es/table';
+
+interface DataType {
+  key: React.Key;
+  name: string;
+  age: number;
+  amount: number;
+  address: string;
+}
+
+const dataSource: DataType[] = [
+  { key: '1', name: 'Mike', age: 32, amount: 1200, address: '10 Downing Street' },
+  { key: '2', name: 'John', age: 42, amount: 2400, address: '20 Oxford Street' },
+  { key: '3', name: 'Jane', age: 28, amount: 800, address: '30 Baker Street' },
+];
+
+const columns: OBTableColumnsType<DataType> = [
+  {
+    title: 'Name',
+    dataIndex: 'name',
+    tooltip: 'User display name',
+  },
+  {
+    title: 'Age',
+    dataIndex: 'age',
+    sorter: (a, b) => a.age - b.age,
+    tooltip: { title: 'Age in years', type: 'info' },
+  },
+  {
+    title: 'Amount',
+    dataIndex: 'amount',
+    sorter: (a, b) => a.amount - b.amount,
+    filters: [
+      { text: '>= 1000', value: 'high' },
+      { text: '< 1000', value: 'low' },
+    ],
+    onFilter: (value, record) => (value === 'high' ? record.amount >= 1000 : record.amount < 1000),
+    tooltip: 'Amount before tax',
+  },
+  {
+    title: 'Address',
+    dataIndex: 'address',
+  },
+];
+
+const App: React.FC = () => (
+  <ProTable
+    headerTitle="Advanced Table"
+    cardBordered
+    columns={columns}
+    dataSource={dataSource}
+    search={false}
+    options={false}
+    pagination={false}
+  />
+);
+
+export default App;

--- a/packages/ui/src/ProTable/index.en-US.md
+++ b/packages/ui/src/ProTable/index.en-US.md
@@ -8,6 +8,7 @@ nav:
 - 🔥 Fully inherits pro-components [ProTable](https://procomponents.ant.design/components/table) capabilities and API, seamless migration.
 - 💄 Custom theme and styles, aligned with OceanBase Design.
 - 📢 Default size is `large`.
+- 🆕 Supports [Table](/components/table) `column.tooltip`.
 
 ## Code Examples
 
@@ -17,6 +18,7 @@ nav:
 <code src="./demo/light-filter.tsx" title="Light filter"></code>
 <code src="./demo/expandable.tsx" title="Expandable table"></code>
 <code src="./demo/bordered.tsx" title="Card without border, table with border"></code>
+<code src="./demo/column-tooltip.tsx" title="Column Header Tooltip" description="Use `column.tooltip` for column header help. Works with sort and filter."></code>
 <code src="./demo/empty.tsx" title="Empty"></code>
 <code src="./demo/link.tsx" title="With link" debug></code>
 

--- a/packages/ui/src/ProTable/index.md
+++ b/packages/ui/src/ProTable/index.md
@@ -8,6 +8,7 @@ nav:
 - 🔥 完全继承 pro-components [ProTable](https://procomponents.ant.design/components/table) 的能力和 API，可无缝切换。
 - 💄 定制主题和样式，符合 OceanBase Design 设计规范。
 - 📢 ProTable 的默认尺寸改为 `large`。
+- 🆕 支持 [Table](/components/table) 的 `column.tooltip` 列头帮助提示。
 
 ## 代码演示
 
@@ -18,6 +19,7 @@ nav:
 <code src="./demo/expandable.tsx" title="可展开表格"></code>
 <code src="./demo/bordered.tsx" title="卡片不带边框、表格带边框"></code>
 <code src="./demo/empty.tsx" title="空状态"></code>
+<code src="./demo/column-tooltip.tsx" title="列头帮助提示" description="通过 `column.tooltip` 在列头展示帮助说明，可与排序、筛选一起使用。"></code>
 <code src="./demo/link.tsx" title="带链接" debug></code>
 
 ## API

--- a/packages/ui/src/ProTable/index.tsx
+++ b/packages/ui/src/ProTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import { ProTable as AntProTable } from '@ant-design/pro-components';
 import type { ProTableProps as AntProTableProps } from '@ant-design/pro-components';
 import { ConfigProvider, Empty, Table } from '@oceanbase/design';
@@ -6,6 +6,8 @@ import classNames from 'classnames';
 import { isEmpty, merge } from 'lodash';
 import useLightFilterStyle from '../LightFilter/style';
 import useStyle from './style';
+import { columnsHaveTooltip, stripColumnTooltip } from './columnTooltip';
+import { createObTableViewRender } from './obTableViewRender';
 
 export interface ProTableProps<T, U, ValueType> extends AntProTableProps<T, U, ValueType> {
   innerBordered?: boolean;
@@ -33,6 +35,8 @@ function ProTable<T, U, ValueType>({
   prefixCls: customizePrefixCls,
   tableClassName,
   className,
+  tableViewRender: userTableViewRender,
+  columns,
   ...restProps
 }: ProTableProps<T, U, ValueType>) {
   const { getPrefixCls, card: contextCard } = useContext(ConfigProvider.ConfigContext);
@@ -68,6 +72,44 @@ function ProTable<T, U, ValueType>({
     typeof outerCardProps === 'boolean' ? {} : outerCardProps
   );
   const proCardCls = getPrefixCls('pro-card', customizePrefixCls);
+
+  const emptyTextNode = (
+    <div className={`${tablePrefixCls}-empty-wrapper`}>
+      {typeof emptyText === 'function' ? emptyText() : emptyText}
+    </div>
+  );
+
+  const hasColumnTooltip = useMemo(() => columnsHaveTooltip(columns), [columns]);
+
+  const columnsWithoutTooltip = useMemo(
+    () => (hasColumnTooltip ? stripColumnTooltip(columns) : columns),
+    [columns, hasColumnTooltip]
+  );
+
+  const tableViewRender = useMemo(() => {
+    if (!hasColumnTooltip && !userTableViewRender) {
+      return undefined;
+    }
+    return createObTableViewRender({
+      columns,
+      mergeTooltip: hasColumnTooltip,
+      innerBordered,
+      tableCls,
+      pagination,
+      restLocale,
+      emptyTextNode,
+      userTableViewRender,
+    });
+  }, [
+    columns,
+    hasColumnTooltip,
+    userTableViewRender,
+    innerBordered,
+    tableCls,
+    pagination,
+    restLocale,
+    emptyTextNode,
+  ]);
 
   return tableWrapCSSVar(
     lightFilterWrapSSR(
@@ -125,15 +167,13 @@ function ProTable<T, U, ValueType>({
           footer={footer}
           locale={{
             ...restLocale,
-            emptyText: (
-              <div className={`${tablePrefixCls}-empty-wrapper`}>
-                {typeof emptyText === 'function' ? emptyText() : emptyText}
-              </div>
-            ),
+            emptyText: emptyTextNode,
           }}
+          tableViewRender={tableViewRender}
           prefixCls={customizePrefixCls}
           tableClassName={tableCls}
           className={proTableCls}
+          columns={columnsWithoutTooltip}
           {...restProps}
         />
       )

--- a/packages/ui/src/ProTable/obTableViewRender.tsx
+++ b/packages/ui/src/ProTable/obTableViewRender.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import type { ProTableProps as AntProTableProps } from '@ant-design/pro-components';
+import { Table } from '@oceanbase/design';
+import classNames from 'classnames';
+import { mergeColumnTooltip } from './columnTooltip';
+
+interface CreateObTableViewRenderOptions<T, U, ValueType> {
+  columns?: AntProTableProps<T, U, ValueType>['columns'];
+  mergeTooltip: boolean;
+  innerBordered?: boolean;
+  tableCls: string;
+  pagination: AntProTableProps<T, U, ValueType>['pagination'];
+  restLocale: Record<string, any>;
+  emptyTextNode: React.ReactNode;
+  userTableViewRender?: AntProTableProps<T, U, ValueType>['tableViewRender'];
+}
+
+export function createObTableViewRender<T, U, ValueType>({
+  columns,
+  mergeTooltip,
+  innerBordered,
+  tableCls,
+  pagination,
+  restLocale,
+  emptyTextNode,
+  userTableViewRender,
+}: CreateObTableViewRenderOptions<T, U, ValueType>): NonNullable<
+  AntProTableProps<T, U, ValueType>['tableViewRender']
+> {
+  return (props, _defaultDom) => {
+    const obTable = (
+      <Table
+        {...props}
+        columns={mergeTooltip ? mergeColumnTooltip(props.columns, columns) : props.columns}
+        innerBordered={innerBordered}
+        className={classNames(tableCls, props.className)}
+        pagination={pagination}
+        locale={{
+          ...restLocale,
+          emptyText: emptyTextNode,
+        }}
+      />
+    );
+    return userTableViewRender ? userTableViewRender(props, obTable) : obTable;
+  };
+}


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Table column headers previously had no built-in API for help tooltips; users had to customize `title` manually. This change adds `column.tooltip` aligned with `Form.Item tooltip` semantics.

- **Table**: injects a `QuestionCircleOutlined` icon next to the column title via `processColumn`; supports string, object config, and custom icon; works alongside sort and filter.
- **ProTable**: strips `tooltip`/`tip` before pro-components processing to avoid duplicate `LabelIconTip` icons, then merges tooltip back when rendering OB Table so icons stay consistent with Table.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Table<br/>&nbsp;&nbsp;- 🆕 Added `column.tooltip` for column header help, compatible with sort and filter.<br/>- ProTable<br/>&nbsp;&nbsp;- 🆕 Supports `column.tooltip` with the same header help icon as Table. |
| 🇨🇳 Chinese | - Table<br/>&nbsp;&nbsp;- 🆕 新增 `column.tooltip`，在列头展示帮助说明，可与排序、筛选一起使用。<br/>- ProTable<br/>&nbsp;&nbsp;- 🆕 支持 `column.tooltip`，列头帮助图标与 Table 一致。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed

Made with [Cursor](https://cursor.com)