### PR TITLE
feat(design): add Form validateMode and reValidateMode aligned with react-hook-form

### DIFF
--- a/packages/design/src/config-provider/index.tsx
+++ b/packages/design/src/config-provider/index.tsx
@@ -44,6 +44,8 @@ import type { NavigateFunction } from './navigate';
 import type { Locale } from '../locale';
 import GlobalStyle from '../style/global';
 import CssVariablesStyle from '../theme/obToken';
+import type { OBFormConfig } from '../form/validateMode';
+import { DEFAULT_REVALIDATE_MODE, DEFAULT_VALIDATE_MODE } from '../form/validateMode';
 
 export * from './navigate';
 export * from 'antd/es/config-provider/context';
@@ -80,6 +82,9 @@ export interface ConfigConsumerProps extends AntConfigConsumerProps {
   locale?: Locale;
 }
 
+export type { OBFormConfig } from '../form/validateMode';
+export type { FormReValidateMode, FormValidateMode } from '../form/validateMode';
+
 export interface ConfigProviderProps extends AntConfigProviderProps {
   theme?: ThemeConfig;
   locale?: Locale;
@@ -92,6 +97,7 @@ export interface ConfigProviderProps extends AntConfigProviderProps {
   pagination?: PaginationConfig;
   spin?: SpinConfig;
   table?: TableConfig;
+  form?: AntConfigProviderProps['form'] & OBFormConfig;
   // StyleProvider props
   styleProviderProps?: StyleProviderProps;
   appProps?: AppProps;
@@ -347,6 +353,8 @@ const ConfigProvider: ConfigProviderType = ({
         {},
         {
           requiredMark: 'optional',
+          validateMode: DEFAULT_VALIDATE_MODE,
+          reValidateMode: DEFAULT_REVALIDATE_MODE,
         } as ConfigProviderProps['form'],
         parentContext.form,
         form

--- a/packages/design/src/form/__tests__/validateMode.rhf.test.ts
+++ b/packages/design/src/form/__tests__/validateMode.rhf.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getFieldsToRevalidateOnChange,
+  serializeNamePath,
+  shouldSkipValidationOnChange,
+  shouldTrackSubmitAttempt,
+} from '../validateMode';
+
+/**
+ * Mirrors react-hook-form default: mode onSubmit + reValidateMode onChange.
+ * @see https://react-hook-form.com/docs/useform
+ */
+describe('validateMode RHF alignment (shouldSkipValidationOnChange)', () => {
+  const defaults = { validateMode: 'onSubmit' as const, reValidateMode: 'onChange' as const };
+
+  it('onSubmit default: skip change before submit', () => {
+    expect(
+      shouldSkipValidationOnChange(defaults.validateMode, defaults.reValidateMode, {
+        isSubmitted: false,
+        isFieldTouched: true,
+      })
+    ).toBe(true);
+  });
+
+  it('onSubmit default: validate on change after submit', () => {
+    expect(
+      shouldSkipValidationOnChange(defaults.validateMode, defaults.reValidateMode, {
+        isSubmitted: true,
+        isFieldTouched: true,
+      })
+    ).toBe(false);
+  });
+
+  it('onTouched: skip change before field is touched', () => {
+    expect(
+      shouldSkipValidationOnChange('onTouched', 'onChange', {
+        isSubmitted: false,
+        isFieldTouched: false,
+      })
+    ).toBe(true);
+  });
+
+  it('onTouched: validate on change after field is touched', () => {
+    expect(
+      shouldSkipValidationOnChange('onTouched', 'onChange', {
+        isSubmitted: false,
+        isFieldTouched: true,
+      })
+    ).toBe(false);
+  });
+
+  it('onChange mode: always validate on change', () => {
+    expect(
+      shouldSkipValidationOnChange('onChange', 'onChange', {
+        isSubmitted: false,
+        isFieldTouched: false,
+      })
+    ).toBe(false);
+  });
+
+  it('all mode: never skip on change', () => {
+    expect(
+      shouldSkipValidationOnChange('all', 'onChange', {
+        isSubmitted: false,
+        isFieldTouched: false,
+      })
+    ).toBe(false);
+  });
+
+  it('onBlur mode before submit: skip on change', () => {
+    expect(
+      shouldSkipValidationOnChange('onBlur', 'onChange', {
+        isSubmitted: false,
+        isFieldTouched: true,
+      })
+    ).toBe(true);
+  });
+
+  it('reValidateMode onSubmit after submit: skip on change', () => {
+    expect(
+      shouldSkipValidationOnChange('onSubmit', 'onSubmit', {
+        isSubmitted: true,
+        isFieldTouched: true,
+      })
+    ).toBe(true);
+  });
+
+  it('reValidateMode onBlur after submit: skip on change', () => {
+    expect(
+      shouldSkipValidationOnChange('onSubmit', 'onBlur', {
+        isSubmitted: true,
+        isFieldTouched: true,
+      })
+    ).toBe(true);
+  });
+});
+
+describe('validateMode RHF alignment (field selection)', () => {
+  const formWithErrors = (names: string[]) =>
+    ({
+      getFieldsError: () => names.map(name => ({ name: [name], errors: ['err'] })),
+    }) as never;
+
+  it('after submit: only changed fields are revalidated (per-field)', () => {
+    expect(
+      getFieldsToRevalidateOnChange(formWithErrors(['name', 'email']), 'onSubmit', new Set(), {
+        submitted: true,
+        changedValues: { name: 'new' },
+      })
+    ).toEqual([['name']]);
+  });
+
+  it('onTouched: revalidate touched changed fields even without current errors', () => {
+    const blurred = new Set([serializeNamePath(['name'])]);
+    expect(
+      getFieldsToRevalidateOnChange({ getFieldsError: () => [] } as never, 'onTouched', blurred, {
+        submitted: false,
+        changedValues: { name: '' },
+      })
+    ).toEqual([['name']]);
+  });
+
+  it('onTouched: revalidate errored changed fields even when not in blurred set', () => {
+    expect(
+      getFieldsToRevalidateOnChange(formWithErrors(['name']), 'onTouched', new Set(), {
+        submitted: false,
+        changedValues: { name: 'valid' },
+      })
+    ).toEqual([['name']]);
+  });
+
+  it('shouldTrackSubmitAttempt for default onSubmit', () => {
+    expect(shouldTrackSubmitAttempt('onSubmit', 'onChange')).toBe(true);
+  });
+});

--- a/packages/design/src/form/__tests__/validateMode.test.tsx
+++ b/packages/design/src/form/__tests__/validateMode.test.tsx
@@ -1,0 +1,538 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { Button, ConfigProvider, Form, Input } from '@oceanbase/design';
+
+const requiredRule = { required: true, message: 'Name is required' };
+const minLengthRule = { min: 5, message: 'Name must be at least 5 characters' };
+
+const getNameInput = (container: HTMLElement) =>
+  container.querySelector('#name') as HTMLInputElement;
+
+const getSubmitButton = (container: HTMLElement) =>
+  container.querySelector('button[type="submit"]') as HTMLButtonElement;
+
+const hasFieldError = (container: HTMLElement) =>
+  Boolean(container.querySelector('.ant-form-item-explain-error'));
+
+const FormWithName: React.FC<React.ComponentProps<typeof Form>> = props => (
+  <Form {...props}>
+    <Form.Item label="Name" name="name" rules={[requiredRule]}>
+      <Input id="name" />
+    </Form.Item>
+    <Button type="primary" htmlType="submit">
+      Submit
+    </Button>
+  </Form>
+);
+
+describe('Form validateMode', () => {
+  it('default onSubmit should not show error while typing', async () => {
+    const { container } = render(<FormWithName />);
+    const input = getNameInput(container);
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    expect(hasFieldError(container)).toBe(false);
+
+    fireEvent.blur(input);
+    expect(hasFieldError(container)).toBe(false);
+  });
+
+  it('default onSubmit should not show error when clearing value before submit', async () => {
+    const { container } = render(<FormWithName />);
+    const input = getNameInput(container);
+
+    fireEvent.change(input, { target: { value: 'valid name' } });
+    expect(hasFieldError(container)).toBe(false);
+
+    fireEvent.change(input, { target: { value: '' } });
+    expect(hasFieldError(container)).toBe(false);
+  });
+
+  it('default onSubmit should show error after submit', async () => {
+    const { container } = render(<FormWithName />);
+    fireEvent.click(getSubmitButton(container));
+
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+  });
+
+  it('onSubmit + reValidateMode onChange should clear error when fixed without re-submit', async () => {
+    const { container } = render(<FormWithName />);
+    const input = getNameInput(container);
+
+    fireEvent.click(getSubmitButton(container));
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+
+    fireEvent.change(input, { target: { value: 'valid name' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(false);
+    });
+  });
+
+  it('onSubmit + reValidateMode onChange should show error again when value cleared after fix', async () => {
+    const { container } = render(<FormWithName />);
+    const input = getNameInput(container);
+
+    fireEvent.click(getSubmitButton(container));
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+
+    fireEvent.change(input, { target: { value: 'valid name' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(false);
+    });
+
+    fireEvent.change(input, { target: { value: '' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+  });
+
+  it('onSubmit should revalidate on change after successful submit', async () => {
+    const { container } = render(<FormWithName />);
+    const input = getNameInput(container);
+
+    fireEvent.change(input, { target: { value: 'valid name' } });
+    fireEvent.click(getSubmitButton(container));
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(false);
+    });
+
+    fireEvent.change(input, { target: { value: '' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+  });
+
+  it('validateMode onChange should show error while typing', async () => {
+    const { container } = render(
+      <Form validateMode="onChange">
+        <Form.Item label="Name" name="name" rules={[minLengthRule]}>
+          <Input id="name" />
+        </Form.Item>
+      </Form>
+    );
+    const input = getNameInput(container);
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+  });
+
+  it('validateMode onBlur should show error on blur', async () => {
+    const { container } = render(<FormWithName validateMode="onBlur" reValidateMode="onBlur" />);
+    const input = getNameInput(container);
+
+    fireEvent.change(input, { target: { value: '' } });
+    expect(hasFieldError(container)).toBe(false);
+
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+
+    fireEvent.change(input, { target: { value: 'valid name' } });
+    expect(hasFieldError(container)).toBe(true);
+
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(false);
+    });
+  });
+
+  it('validateMode onTouched should not validate on change before blur', async () => {
+    const { container } = render(
+      <Form validateMode="onTouched">
+        <Form.Item label="Name" name="name" rules={[minLengthRule]}>
+          <Input id="name" />
+        </Form.Item>
+      </Form>
+    );
+    const input = getNameInput(container);
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    expect(hasFieldError(container)).toBe(false);
+  });
+
+  it('validateMode onTouched should validate on change after blur', async () => {
+    const { container } = render(
+      <Form validateMode="onTouched">
+        <Form.Item label="Name" name="name" rules={[minLengthRule]}>
+          <Input id="name" />
+        </Form.Item>
+      </Form>
+    );
+    const input = getNameInput(container);
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    expect(hasFieldError(container)).toBe(false);
+
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+
+    fireEvent.change(input, { target: { value: 'valid name' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(false);
+    });
+  });
+
+  it('validateMode onTouched should validate on change after blur even when blur passed', async () => {
+    const { container } = render(
+      <Form validateMode="onTouched">
+        <Form.Item label="Name" name="name" rules={[minLengthRule]}>
+          <Input id="name" />
+        </Form.Item>
+      </Form>
+    );
+    const input = getNameInput(container);
+
+    fireEvent.change(input, { target: { value: 'valid name' } });
+    fireEvent.blur(input);
+    expect(hasFieldError(container)).toBe(false);
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+  });
+
+  it('validateMode onTouched should show error when clearing value after blur error', async () => {
+    const { container } = render(
+      <Form validateMode="onTouched">
+        <Form.Item label="Name" name="name" rules={[requiredRule]}>
+          <Input id="name" />
+        </Form.Item>
+      </Form>
+    );
+    const input = getNameInput(container);
+
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+
+    fireEvent.change(input, { target: { value: 'valid name' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(false);
+    });
+
+    fireEvent.change(input, { target: { value: '' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+  });
+
+  it('explicit validateTrigger should bypass validateMode injection', async () => {
+    const { container } = render(
+      <Form validateTrigger="onChange">
+        <Form.Item label="Name" name="name" rules={[minLengthRule]}>
+          <Input id="name" />
+        </Form.Item>
+      </Form>
+    );
+    const input = getNameInput(container);
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+  });
+
+  it('Form validateMode should override ConfigProvider', async () => {
+    const { container } = render(
+      <ConfigProvider form={{ validateMode: 'onSubmit' }}>
+        <Form validateMode="onChange">
+          <Form.Item label="Name" name="name" rules={[minLengthRule]}>
+            <Input id="name" />
+          </Form.Item>
+        </Form>
+      </ConfigProvider>
+    );
+    const input = getNameInput(container);
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+  });
+
+  it('ConfigProvider should apply default validateMode onSubmit', async () => {
+    const { container } = render(
+      <ConfigProvider>
+        <FormWithName />
+      </ConfigProvider>
+    );
+
+    fireEvent.click(getSubmitButton(container));
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+  });
+
+  it('ConfigProvider form.validateMode onChange should apply globally', async () => {
+    const { container } = render(
+      <ConfigProvider form={{ validateMode: 'onChange' }}>
+        <Form>
+          <Form.Item label="Name" name="name" rules={[minLengthRule]}>
+            <Input id="name" />
+          </Form.Item>
+        </Form>
+      </ConfigProvider>
+    );
+    const input = getNameInput(container);
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+  });
+
+  it('validateMode all should validate on change and blur', async () => {
+    const { container } = render(
+      <Form validateMode="all">
+        <Form.Item label="Name" name="name" rules={[minLengthRule]}>
+          <Input id="name" />
+        </Form.Item>
+      </Form>
+    );
+    const input = getNameInput(container);
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+
+    fireEvent.change(input, { target: { value: 'valid name' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(false);
+    });
+  });
+
+  it('validateMode onBlur + reValidateMode onChange should clear error on change after blur', async () => {
+    const { container } = render(
+      <Form validateMode="onBlur" reValidateMode="onChange">
+        <Form.Item label="Name" name="name" rules={[requiredRule]}>
+          <Input id="name" />
+        </Form.Item>
+      </Form>
+    );
+    const input = getNameInput(container);
+
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+
+    fireEvent.change(input, { target: { value: 'valid name' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(false);
+    });
+
+    fireEvent.change(input, { target: { value: '' } });
+    expect(hasFieldError(container)).toBe(false);
+  });
+
+  it('reValidateMode onSubmit should keep error until next submit', async () => {
+    const { container } = render(<FormWithName reValidateMode="onSubmit" />);
+    const input = getNameInput(container);
+
+    fireEvent.click(getSubmitButton(container));
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+
+    fireEvent.change(input, { target: { value: 'valid name' } });
+    expect(hasFieldError(container)).toBe(true);
+
+    fireEvent.click(getSubmitButton(container));
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(false);
+    });
+  });
+
+  it('after submit should only revalidate the changed field', async () => {
+    const { container } = render(
+      <Form>
+        <Form.Item label="Name" name="name" rules={[requiredRule]}>
+          <Input id="name" />
+        </Form.Item>
+        <Form.Item label="Email" name="email" rules={[requiredRule]}>
+          <Input id="email" />
+        </Form.Item>
+        <Button type="primary" htmlType="submit">
+          Submit
+        </Button>
+      </Form>
+    );
+    const nameInput = getNameInput(container);
+    const emailInput = container.querySelector('#email') as HTMLInputElement;
+
+    fireEvent.click(getSubmitButton(container));
+    await waitFor(() => {
+      expect(container.querySelectorAll('.ant-form-item-explain-error').length).toBe(2);
+    });
+
+    fireEvent.change(nameInput, { target: { value: 'valid name' } });
+    await waitFor(() => {
+      const errors = container.querySelectorAll('.ant-form-item-explain-error');
+      expect(errors.length).toBe(1);
+      expect(
+        emailInput.closest('.ant-form-item')?.querySelector('.ant-form-item-explain-error')
+      ).toBeTruthy();
+    });
+  });
+
+  it('validateMode onTouched + reValidateMode onSubmit should validate on change before submit', async () => {
+    const { container } = render(
+      <Form validateMode="onTouched" reValidateMode="onSubmit">
+        <Form.Item label="Name" name="name" rules={[minLengthRule]}>
+          <Input id="name" />
+        </Form.Item>
+      </Form>
+    );
+    const input = getNameInput(container);
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+
+    fireEvent.change(input, { target: { value: 'valid name' } });
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(false);
+    });
+  });
+
+  it('validateMode onTouched + reValidateMode onSubmit should not revalidate on change after submit', async () => {
+    const { container } = render(
+      <Form validateMode="onTouched" reValidateMode="onSubmit">
+        <Form.Item label="Name" name="name" rules={[requiredRule]}>
+          <Input id="name" />
+        </Form.Item>
+        <Button type="primary" htmlType="submit">
+          Submit
+        </Button>
+      </Form>
+    );
+    const input = getNameInput(container);
+
+    fireEvent.click(getSubmitButton(container));
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+
+    fireEvent.change(input, { target: { value: 'valid name' } });
+    expect(hasFieldError(container)).toBe(true);
+  });
+
+  it('ConfigProvider form.reValidateMode onSubmit should apply globally', async () => {
+    const { container } = render(
+      <ConfigProvider form={{ reValidateMode: 'onSubmit' }}>
+        <FormWithName />
+      </ConfigProvider>
+    );
+    const input = getNameInput(container);
+
+    fireEvent.click(getSubmitButton(container));
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+
+    fireEvent.change(input, { target: { value: 'valid name' } });
+    expect(hasFieldError(container)).toBe(true);
+  });
+
+  it('partial resetFields after submit should keep submitted state', async () => {
+    const Demo: React.FC = () => {
+      const [form] = Form.useForm();
+      return (
+        <Form form={form}>
+          <Form.Item label="Name" name="name" rules={[requiredRule]}>
+            <Input id="name" />
+          </Form.Item>
+          <Form.Item label="Email" name="email" rules={[requiredRule]}>
+            <Input id="email" />
+          </Form.Item>
+          <Button type="primary" htmlType="submit">
+            Submit
+          </Button>
+          <Button type="default" onClick={() => form.resetFields(['name'])}>
+            Reset name
+          </Button>
+        </Form>
+      );
+    };
+
+    const { container } = render(<Demo />);
+
+    fireEvent.click(getSubmitButton(container));
+    await waitFor(() => {
+      expect(container.querySelectorAll('.ant-form-item-explain-error').length).toBe(2);
+    });
+
+    fireEvent.click(container.querySelectorAll('button')[1] as HTMLButtonElement);
+    await waitFor(() => {
+      expect(
+        getNameInput(container)
+          .closest('.ant-form-item')
+          ?.classList.contains('ant-form-item-has-error')
+      ).toBe(false);
+    });
+
+    const nameInputAfterReset = getNameInput(container);
+    fireEvent.change(nameInputAfterReset, { target: { value: 'valid name' } });
+    await waitFor(() => {
+      expect(
+        nameInputAfterReset.closest('.ant-form-item')?.classList.contains('ant-form-item-has-error')
+      ).toBe(false);
+    });
+
+    fireEvent.change(nameInputAfterReset, { target: { value: '' } });
+    await waitFor(() => {
+      expect(
+        nameInputAfterReset.closest('.ant-form-item')?.classList.contains('ant-form-item-has-error')
+      ).toBe(true);
+    });
+  });
+
+  it('validateMode onTouched should not revalidate on change after resetFields', async () => {
+    const Demo: React.FC = () => {
+      const [form] = Form.useForm();
+      return (
+        <Form form={form} validateMode="onTouched">
+          <Form.Item label="Name" name="name" rules={[minLengthRule]}>
+            <Input id="name" />
+          </Form.Item>
+          <Button type="default" onClick={() => form.resetFields()}>
+            Reset
+          </Button>
+        </Form>
+      );
+    };
+
+    const { container } = render(<Demo />);
+    const input = getNameInput(container);
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(true);
+    });
+
+    fireEvent.click(container.querySelector('button') as HTMLButtonElement);
+    await waitFor(() => {
+      expect(hasFieldError(container)).toBe(false);
+    });
+
+    fireEvent.change(input, { target: { value: 'b' } });
+    expect(hasFieldError(container)).toBe(false);
+  });
+});

--- a/packages/design/src/form/__tests__/validateMode.util.test.ts
+++ b/packages/design/src/form/__tests__/validateMode.util.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_REVALIDATE_MODE,
+  DEFAULT_VALIDATE_MODE,
+  deserializeNamePath,
+  getChangedNamePaths,
+  getFieldsToRevalidateOnChange,
+  resolveReValidateMode,
+  resolveValidateMode,
+  resolveValidateTrigger,
+  serializeNamePath,
+  shouldInjectRevalidateOnChange,
+  syncBlurredFieldsFromFieldsChange,
+  syncSubmittedFromFieldsChange,
+} from '../validateMode';
+
+describe('validateMode utils', () => {
+  it('resolveValidateMode should fall back to defaults', () => {
+    expect(resolveValidateMode()).toBe(DEFAULT_VALIDATE_MODE);
+    expect(resolveValidateMode('onChange')).toBe('onChange');
+    expect(resolveValidateMode(undefined, 'onBlur')).toBe('onBlur');
+  });
+
+  it('resolveReValidateMode should fall back to defaults', () => {
+    expect(resolveReValidateMode()).toBe(DEFAULT_REVALIDATE_MODE);
+    expect(resolveReValidateMode('onSubmit')).toBe('onSubmit');
+  });
+
+  it('resolveValidateTrigger should map modes and respect explicit trigger', () => {
+    expect(resolveValidateTrigger('onSubmit')).toEqual([]);
+    expect(resolveValidateTrigger('onBlur')).toBe('onBlur');
+    expect(resolveValidateTrigger('onTouched')).toBe('onBlur');
+    expect(resolveValidateTrigger('onChange')).toBe('onChange');
+    expect(resolveValidateTrigger('all')).toEqual(['onBlur', 'onChange']);
+    expect(resolveValidateTrigger('onSubmit', 'onChange')).toBe('onChange');
+  });
+
+  it('shouldInjectRevalidateOnChange should follow mode matrix', () => {
+    expect(shouldInjectRevalidateOnChange('onSubmit', 'onChange')).toBe(true);
+    expect(shouldInjectRevalidateOnChange('onSubmit', 'onSubmit')).toBe(false);
+    expect(shouldInjectRevalidateOnChange('onChange', 'onChange')).toBe(false);
+    expect(shouldInjectRevalidateOnChange('all', 'onChange')).toBe(false);
+    expect(shouldInjectRevalidateOnChange('onTouched', 'onSubmit')).toBe(true);
+    expect(shouldInjectRevalidateOnChange('onSubmit', 'onChange', 'onBlur')).toBe(false);
+  });
+
+  it('serializeNamePath should normalize string and array name paths', () => {
+    expect(serializeNamePath('name')).toBe(serializeNamePath(['name']));
+  });
+
+  it('serializeNamePath roundtrip', () => {
+    const name = ['user', 'name'];
+    expect(deserializeNamePath(serializeNamePath(name))).toEqual(name);
+  });
+
+  it('syncBlurredFieldsFromFieldsChange should track touched fields and clear on reset', () => {
+    const blurred = new Set<string>();
+
+    syncBlurredFieldsFromFieldsChange(blurred, [{ name: 'name', touched: true }], 'onTouched');
+    expect(blurred.has(serializeNamePath('name'))).toBe(true);
+
+    syncBlurredFieldsFromFieldsChange(blurred, [{ name: 'name', touched: false }], 'onTouched');
+    expect(blurred.size).toBe(0);
+  });
+
+  it('syncBlurredFieldsFromFieldsChange should track blur errors without touched flag', () => {
+    const blurred = new Set<string>();
+
+    syncBlurredFieldsFromFieldsChange(
+      blurred,
+      [{ name: 'name', errors: ['Name is required'] }],
+      'onTouched'
+    );
+    expect(blurred.has(serializeNamePath('name'))).toBe(true);
+  });
+
+  it('syncSubmittedFromFieldsChange should clear submitted on full reset only', () => {
+    const submitted = { current: true };
+    const allFields = [
+      { name: 'name', touched: false },
+      { name: 'email', touched: false },
+    ];
+
+    syncSubmittedFromFieldsChange(submitted, [{ name: 'name', touched: false }], allFields);
+    expect(submitted.current).toBe(true);
+
+    syncSubmittedFromFieldsChange(submitted, allFields, allFields);
+    expect(submitted.current).toBe(false);
+  });
+
+  it('getChangedNamePaths should flatten nested changed values', () => {
+    expect(getChangedNamePaths({ name: 'a' })).toEqual([['name']]);
+    expect(getChangedNamePaths({ user: { name: 'a' } })).toEqual([['user', 'name']]);
+  });
+
+  it('getFieldsToRevalidateOnChange should revalidate changed fields after submit', () => {
+    const form = {
+      getFieldsError: () => [],
+    } as never;
+
+    expect(
+      getFieldsToRevalidateOnChange(form, 'onSubmit', new Set(), {
+        submitted: true,
+        changedValues: { name: '' },
+      })
+    ).toEqual([['name']]);
+  });
+
+  it('getFieldsToRevalidateOnChange should not revalidate before submit without current errors', () => {
+    const form = {
+      getFieldsError: () => [],
+    } as never;
+
+    expect(
+      getFieldsToRevalidateOnChange(form, 'onSubmit', new Set(), {
+        submitted: false,
+        changedValues: { name: '' },
+      })
+    ).toEqual([]);
+  });
+});

--- a/packages/design/src/form/demo/validate-mode.tsx
+++ b/packages/design/src/form/demo/validate-mode.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Button, Form, Input, Radio, Space, Typography } from '@oceanbase/design';
+import type { FormValidateMode } from '@oceanbase/design';
+
+const modes: FormValidateMode[] = ['onSubmit', 'onBlur', 'onChange', 'onTouched', 'all'];
+
+const modeDescriptions: Record<FormValidateMode, string> = {
+  onSubmit: 'Submit before showing errors; live update after failed submit (default).',
+  onBlur: 'Validate on blur.',
+  onChange: 'Validate on every change (antd legacy default).',
+  onTouched: 'Validate on first blur, then on every change.',
+  all: 'Validate on blur and change.',
+};
+
+export default () => {
+  const [mode, setMode] = React.useState<FormValidateMode>('onSubmit');
+
+  return (
+    <Space direction="vertical" size="large" style={{ width: '100%', maxWidth: 480 }}>
+      <Radio.Group
+        value={mode}
+        onChange={e => setMode(e.target.value)}
+        optionType="button"
+        buttonStyle="solid"
+        options={modes.map(value => ({ label: value, value }))}
+      />
+      <Typography.Text type="secondary">{modeDescriptions[mode]}</Typography.Text>
+      <Form
+        key={mode}
+        validateMode={mode}
+        layout="vertical"
+        onFinish={values => {
+          console.log('Submitted:', values);
+        }}
+      >
+        <Form.Item
+          label="Username"
+          name="username"
+          rules={[{ required: true, min: 5, message: 'At least 5 characters' }]}
+        >
+          <Input placeholder="Try typing, blurring, and submitting" />
+        </Form.Item>
+        <Button type="primary" htmlType="submit">
+          Submit
+        </Button>
+      </Form>
+    </Space>
+  );
+};

--- a/packages/design/src/form/index.en-US.md
+++ b/packages/design/src/form/index.en-US.md
@@ -11,11 +11,13 @@ nav:
 - 📢 Form `requiredMark` defaults to `optional` style.
 - 🆕 Form.Item `tooltip` adds `type` prop for different Tooltip types, see [Tooltip docs](/components/Tooltip).
 - 🆕 Form.Item adds `description` prop for description before form control.
+- 🆕 Form adds `validateMode` / `reValidateMode`, aligned with [react-hook-form](https://react-hook-form.com/docs/useform). Defaults: `validateMode="onSubmit"` + `reValidateMode="onChange"`. Configure globally via [ConfigProvider](/components/config-provider) `form.validateMode`.
 
 ## Code Examples
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx" title="Basic" description="Default optional style."></code>
+<code src="./demo/validate-mode.tsx" title="Validation modes" description="Aligned with react-hook-form `mode` / `reValidateMode`; no errors until submit by default."></code>
 <code src="./demo/requiredMark-same-with-antd.tsx" title="Required Style" description="Set via `requiredMark`."></code>
 <code src="./demo/form-item-description.tsx" title="Description" description="Set description before form control via Form.Item `description`."></code>
 <code src="./demo/form-item-extra.tsx" title="Extra Info" description="Set extra info after form control via Form.Item `extra`."></code>
@@ -33,6 +35,14 @@ nav:
 | :-- | :-- | :-- | :-- | :-- |
 | preserve | Preserve field value when removed. Use `getFieldsValue(true)` to get preserved values | boolean | false | 0.3.1 |
 | requiredMark | Required or optional style. Form-level config, Form.Item cannot configure separately | boolean \| `optional` \| ((label: ReactNode, info: { required: boolean }) => ReactNode) | `optional` | - |
+| validateMode | When to run first validation (react-hook-form `mode`) | `onSubmit` \| `onBlur` \| `onChange` \| `onTouched` \| `all` | `onSubmit` | - |
+| reValidateMode | Re-validation after submit (react-hook-form `reValidateMode`; supports `onChange`, `onSubmit`) | `onChange` \| `onSubmit` | `onChange` | - |
+
+Explicit `validateTrigger` takes precedence. Use `validateMode="onChange"` to restore antd legacy behavior.
+
+### ConfigProvider
+
+Use `form.validateMode` / `form.reValidateMode` on ConfigProvider for global defaults. Applies only to `Form` from `@oceanbase/design` (not ProForm or other components that use antd Form internally).
 
 ### Form.Item
 

--- a/packages/design/src/form/index.md
+++ b/packages/design/src/form/index.md
@@ -11,11 +11,13 @@ nav:
 - 📢 Form `requiredMark` 默认为 `optional` 可选样式。
 - 🆕 Form.Item `tooltip` 新增 `type` 属性，支持不同类型的 Tooltip 提示，详见 [Tooltip 文档](/components/Tooltip)。
 - 🆕 Form.Item 新增 `description` 属性，用于设置表单控件前的描述信息。
+- 🆕 Form 新增 `validateMode` / `reValidateMode`，对齐 [react-hook-form](https://react-hook-form.com/docs/useform) 校验时机；默认 `validateMode="onSubmit"` + `reValidateMode="onChange"`（与 shadcn 官方示例一致）。可通过 [ConfigProvider](/components/config-provider) `form.validateMode` 全局配置。
 
 ## 代码演示
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx" title="基本" description="默认为可选样式。"></code>
+<code src="./demo/validate-mode.tsx" title="校验模式" description="对齐 react-hook-form 的 `mode` / `reValidateMode`，默认 submit 前不展示错误。"></code>
 <code src="./demo/requiredMark-same-with-antd.tsx" title="设置为必选样式" description="通过 `requiredMark` 进行设置。"></code>
 <code src="./demo/form-item-description.tsx" title="描述信息" description="可通过 `Form.Item` 的 `description` 属性在表单控件前设置描述信息。"></code>
 <code src="./demo/form-item-extra.tsx" title="额外信息" description="可通过 `Form.Item` 的 `extra` 属性在表单控件后设置额外信息。"></code>
@@ -33,6 +35,14 @@ nav:
 | :-- | :-- | :-- | :-- | :-- |
 | preserve | 当字段被删除时保留字段值。你可以通过 `getFieldsValue(true)` 来获取保留字段值 | boolean | false | 0.3.1 |
 | requiredMark | 设置必选或可选样式。此为 Form 配置，Form.Item 无法单独配置 | boolean \| `optional` \| ((label: ReactNode, info: { required: boolean }) => ReactNode) | `optional` | - |
+| validateMode | 首次校验时机，对齐 react-hook-form `mode` | `onSubmit` \| `onBlur` \| `onChange` \| `onTouched` \| `all` | `onSubmit` | - |
+| reValidateMode | submit 后的重校验时机，对齐 react-hook-form `reValidateMode`（支持 `onChange`、`onSubmit`） | `onChange` \| `onSubmit` | `onChange` | - |
+
+显式设置 `validateTrigger` 时以 `validateTrigger` 为准，不注入 `validateMode` 相关逻辑。恢复 antd 旧行为（输入即报错）：`validateMode="onChange"`。
+
+### ConfigProvider
+
+可通过 `ConfigProvider` 的 `form.validateMode` / `form.reValidateMode` 全局配置，仅对 `@oceanbase/design` 的 `Form` 生效（ProForm 等内部使用 antd Form 的组件不适用）。
 
 ### Form.Item
 

--- a/packages/design/src/form/index.tsx
+++ b/packages/design/src/form/index.tsx
@@ -1,15 +1,32 @@
-import React, { useContext } from 'react';
+import React, { useCallback, useContext, useRef } from 'react';
 import { Form as AntForm } from 'antd';
 import type { FormProps as AntFormProps } from 'antd/es/form';
 import classNames from 'classnames';
 import ConfigProvider from '../config-provider';
 import Item from './FormItem';
 import useStyle from './style';
+import type { FormReValidateMode, FormValidateMode, OBFormConfig } from './validateMode';
+import {
+  markFormSubmitted,
+  needsValidateModeFormInstance,
+  revalidateOnChange,
+  resolveReValidateMode,
+  resolveValidateMode,
+  resolveValidateTrigger,
+  shouldInjectRevalidateOnChange,
+  shouldTrackSubmitAttempt,
+  syncBlurredFieldsFromFieldsChange,
+  syncSubmittedFromFieldsChange,
+} from './validateMode';
 
 export * from 'antd/es/form';
 export type { FormItemProps } from './FormItem';
+export type { FormReValidateMode, FormValidateMode, OBFormConfig } from './validateMode';
 
-export type FormProps = AntFormProps;
+export type FormProps = AntFormProps & {
+  validateMode?: FormValidateMode;
+  reValidateMode?: FormReValidateMode;
+};
 
 type CompoundedComponent = React.FC<FormProps> & {
   Item: typeof Item;
@@ -26,9 +43,101 @@ const Form: CompoundedComponent = ({
   hideRequiredMark,
   prefixCls: customizePrefixCls,
   className,
+  validateMode: propValidateMode,
+  reValidateMode: propReValidateMode,
+  validateTrigger: propValidateTrigger,
+  onValuesChange,
+  onFieldsChange,
+  onFinish,
+  onFinishFailed,
+  form: propForm,
   ...restProps
 }) => {
   const { getPrefixCls, form: contextForm } = useContext(ConfigProvider.ConfigContext);
+  const obFormConfig = contextForm as OBFormConfig | undefined;
+
+  const validateMode = resolveValidateMode(propValidateMode, obFormConfig?.validateMode);
+  const reValidateMode = resolveReValidateMode(propReValidateMode, obFormConfig?.reValidateMode);
+  const resolvedValidateTrigger = resolveValidateTrigger(validateMode, propValidateTrigger);
+  const injectRevalidate = shouldInjectRevalidateOnChange(
+    validateMode,
+    reValidateMode,
+    propValidateTrigger
+  );
+  const trackSubmitAttempt = shouldTrackSubmitAttempt(
+    validateMode,
+    reValidateMode,
+    propValidateTrigger
+  );
+  const trackBlurredFields = validateMode === 'onTouched' && propValidateTrigger === undefined;
+
+  const [fallbackForm] = AntForm.useForm();
+  const needsFormInstance = needsValidateModeFormInstance(
+    validateMode,
+    injectRevalidate,
+    propValidateTrigger
+  );
+  const mergedForm = needsFormInstance ? (propForm ?? fallbackForm) : propForm;
+
+  const blurredFieldsRef = useRef(new Set<string>());
+  const submittedRef = useRef(false);
+
+  const markSubmittedIfNeeded = useCallback(() => {
+    if (trackSubmitAttempt) {
+      markFormSubmitted(submittedRef);
+    }
+  }, [trackSubmitAttempt]);
+
+  const handleFinish = useCallback(
+    (...args: Parameters<NonNullable<AntFormProps['onFinish']>>) => {
+      markSubmittedIfNeeded();
+      onFinish?.(...args);
+    },
+    [markSubmittedIfNeeded, onFinish]
+  );
+
+  const handleFinishFailed = useCallback(
+    (...args: Parameters<NonNullable<AntFormProps['onFinishFailed']>>) => {
+      markSubmittedIfNeeded();
+      onFinishFailed?.(...args);
+    },
+    [markSubmittedIfNeeded, onFinishFailed]
+  );
+
+  const handleFieldsChange = useCallback(
+    (
+      changedFields: Parameters<NonNullable<AntFormProps['onFieldsChange']>>[0],
+      allFields: Parameters<NonNullable<AntFormProps['onFieldsChange']>>[1]
+    ) => {
+      if (trackBlurredFields) {
+        syncBlurredFieldsFromFieldsChange(blurredFieldsRef.current, changedFields, validateMode);
+      }
+      if (trackSubmitAttempt) {
+        syncSubmittedFromFieldsChange(submittedRef, changedFields, allFields);
+      }
+      onFieldsChange?.(changedFields, allFields);
+    },
+    [onFieldsChange, trackBlurredFields, trackSubmitAttempt, validateMode]
+  );
+
+  const handleValuesChange = useCallback(
+    (
+      changedValues: Parameters<NonNullable<AntFormProps['onValuesChange']>>[0],
+      allValues: Parameters<NonNullable<AntFormProps['onValuesChange']>>[1]
+    ) => {
+      if (injectRevalidate && mergedForm) {
+        revalidateOnChange(mergedForm, {
+          validateMode,
+          reValidateMode,
+          blurredFields: blurredFieldsRef.current,
+          changedValues,
+          submitted: submittedRef.current,
+        });
+      }
+      onValuesChange?.(changedValues, allValues);
+    },
+    [injectRevalidate, mergedForm, onValuesChange, reValidateMode, validateMode]
+  );
 
   const prefixCls = getPrefixCls('form', customizePrefixCls);
   const [wrapCSSVar] = useStyle(prefixCls);
@@ -49,6 +158,14 @@ const Form: CompoundedComponent = ({
       preserve={false}
       prefixCls={customizePrefixCls}
       className={formCls}
+      form={mergedForm}
+      validateTrigger={resolvedValidateTrigger}
+      onValuesChange={injectRevalidate ? handleValuesChange : onValuesChange}
+      onFieldsChange={
+        trackBlurredFields || trackSubmitAttempt ? handleFieldsChange : onFieldsChange
+      }
+      onFinish={trackSubmitAttempt ? handleFinish : onFinish}
+      onFinishFailed={trackSubmitAttempt ? handleFinishFailed : onFinishFailed}
       {...restProps}
     />
   );

--- a/packages/design/src/form/interface.ts
+++ b/packages/design/src/form/interface.ts
@@ -1,1 +1,2 @@
 export * from 'antd/es/form/interface';
+export type { FormReValidateMode, FormValidateMode, OBFormConfig } from './validateMode';

--- a/packages/design/src/form/validateMode.ts
+++ b/packages/design/src/form/validateMode.ts
@@ -1,0 +1,318 @@
+import type { FormInstance } from 'antd/es/form';
+import type { NamePath } from 'antd/es/form/interface';
+import type { FormProps as AntFormProps } from 'antd/es/form';
+
+type FieldChangeMeta = {
+  name?: NamePath;
+  touched?: boolean;
+  errors?: string[];
+  warnings?: string[];
+  validating?: boolean;
+};
+
+export type FormValidateMode = 'onSubmit' | 'onBlur' | 'onChange' | 'onTouched' | 'all';
+
+export type FormReValidateMode = 'onChange' | 'onBlur' | 'onSubmit';
+
+export const DEFAULT_VALIDATE_MODE: FormValidateMode = 'onSubmit';
+
+export const DEFAULT_REVALIDATE_MODE: FormReValidateMode = 'onChange';
+
+export type OBFormConfig = {
+  validateMode?: FormValidateMode;
+  reValidateMode?: FormReValidateMode;
+};
+
+export function resolveValidateMode(
+  prop?: FormValidateMode,
+  context?: FormValidateMode
+): FormValidateMode {
+  return prop ?? context ?? DEFAULT_VALIDATE_MODE;
+}
+
+export function resolveReValidateMode(
+  prop?: FormReValidateMode,
+  context?: FormReValidateMode
+): FormReValidateMode {
+  return prop ?? context ?? DEFAULT_REVALIDATE_MODE;
+}
+
+export function resolveValidateTrigger(
+  validateMode: FormValidateMode,
+  explicitTrigger?: AntFormProps['validateTrigger']
+): AntFormProps['validateTrigger'] | undefined {
+  if (explicitTrigger !== undefined) {
+    return explicitTrigger;
+  }
+  switch (validateMode) {
+    case 'onSubmit':
+      return [];
+    case 'onBlur':
+    case 'onTouched':
+      return 'onBlur';
+    case 'onChange':
+      return 'onChange';
+    case 'all':
+      return ['onBlur', 'onChange'];
+    default:
+      return undefined;
+  }
+}
+
+export function shouldInjectRevalidateOnChange(
+  validateMode: FormValidateMode,
+  reValidateMode: FormReValidateMode,
+  explicitTrigger?: AntFormProps['validateTrigger']
+): boolean {
+  if (explicitTrigger !== undefined) {
+    return false;
+  }
+  // onTouched validates on change after first blur regardless of reValidateMode (RHF `mode` semantics)
+  if (validateMode === 'onTouched') {
+    return true;
+  }
+  if (reValidateMode !== 'onChange') {
+    return false;
+  }
+  return validateMode !== 'onChange' && validateMode !== 'all';
+}
+
+export function shouldTrackSubmitAttempt(
+  validateMode: FormValidateMode,
+  reValidateMode: FormReValidateMode,
+  explicitTrigger?: AntFormProps['validateTrigger']
+): boolean {
+  if (explicitTrigger !== undefined) {
+    return false;
+  }
+  if (injectRevalidateOnChangeNeeded(validateMode, reValidateMode)) {
+    return true;
+  }
+  return validateMode === 'onSubmit' || validateMode === 'onBlur' || validateMode === 'onTouched';
+}
+
+function injectRevalidateOnChangeNeeded(
+  validateMode: FormValidateMode,
+  reValidateMode: FormReValidateMode
+): boolean {
+  return reValidateMode === 'onChange' && validateMode !== 'onChange' && validateMode !== 'all';
+}
+
+/**
+ * Port of react-hook-form `skipValidation` for change events (`isBlurEvent = false`).
+ * Reference implementation for tests; runtime uses `getFieldsToRevalidateOnChange` instead.
+ * @see https://github.com/react-hook-form/react-hook-form/blob/master/src/logic/skipValidation.ts
+ */
+export function shouldSkipValidationOnChange(
+  validateMode: FormValidateMode,
+  reValidateMode: FormReValidateMode,
+  options: { isSubmitted: boolean; isFieldTouched: boolean }
+): boolean {
+  const { isSubmitted, isFieldTouched } = options;
+
+  if (validateMode === 'all') {
+    return false;
+  }
+  if (!isSubmitted && validateMode === 'onTouched') {
+    return !isFieldTouched;
+  }
+
+  const useOnBlur = isSubmitted ? reValidateMode === 'onBlur' : validateMode === 'onBlur';
+  const useOnChange = isSubmitted ? reValidateMode === 'onChange' : validateMode === 'onChange';
+
+  if (useOnBlur) {
+    return true;
+  }
+  if (useOnChange) {
+    return false;
+  }
+  return true;
+}
+
+export function markFormSubmitted(submitted: { current: boolean }): void {
+  submitted.current = true;
+}
+
+export function normalizeNamePath(name: NamePath): (string | number)[] {
+  return Array.isArray(name) ? name : [name];
+}
+
+export function serializeNamePath(name: NamePath): string {
+  return JSON.stringify(normalizeNamePath(name));
+}
+
+export function deserializeNamePath(key: string): NamePath {
+  return JSON.parse(key) as NamePath;
+}
+
+/** Collect leaf field name paths from `onValuesChange` changedValues. */
+export function getChangedNamePaths(
+  changedValues: Record<string, unknown>,
+  prefix: NamePath = []
+): NamePath[] {
+  const paths: NamePath[] = [];
+  Object.keys(changedValues).forEach(key => {
+    const value = changedValues[key];
+    const path: NamePath = [...(Array.isArray(prefix) ? prefix : [prefix]), key];
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      !(value instanceof Date)
+    ) {
+      paths.push(...getChangedNamePaths(value as Record<string, unknown>, path));
+    } else {
+      paths.push(path);
+    }
+  });
+  return paths;
+}
+
+/**
+ * Whether form submit was attempted (aligns with react-hook-form `isSubmitted`).
+ * Clear on full `resetFields()` only, not partial `resetFields(['field'])` (aligns with RHF `reset` vs `resetField`).
+ */
+export function syncSubmittedFromFieldsChange(
+  submitted: { current: boolean },
+  changedFields: FieldChangeMeta[],
+  allFields: FieldChangeMeta[] = []
+): void {
+  if (!submitted.current) {
+    return;
+  }
+
+  const resetInChange = changedFields.filter(
+    field => field.name !== undefined && field.touched === false
+  );
+  if (resetInChange.length === 0) {
+    return;
+  }
+
+  if (allFields.length === 0) {
+    submitted.current = false;
+    return;
+  }
+
+  const resetKeys = new Set(resetInChange.map(field => serializeNamePath(field.name!)));
+  const allFieldKeys = allFields
+    .filter(field => field.name !== undefined)
+    .map(field => serializeNamePath(field.name!));
+
+  if (allFieldKeys.length > 0 && allFieldKeys.every(key => resetKeys.has(key))) {
+    submitted.current = false;
+  }
+}
+
+/**
+ * Track fields touched by the user (for onTouched), aligned with RHF `touchedFields`.
+ * Add on blur / touch (`touched: true`); remove on reset (`touched: false`).
+ */
+export function syncBlurredFieldsFromFieldsChange(
+  blurredFields: Set<string>,
+  changedFields: FieldChangeMeta[],
+  validateMode: FormValidateMode
+): void {
+  if (validateMode !== 'onTouched') {
+    return;
+  }
+  changedFields.forEach(field => {
+    if (field.name === undefined) {
+      return;
+    }
+    const key = serializeNamePath(field.name);
+    if (field.touched === false) {
+      blurredFields.delete(key);
+      return;
+    }
+    if (field.touched === true) {
+      blurredFields.add(key);
+      return;
+    }
+    // rc-field-form may omit `touched` when blur is the first interaction (e.g. blur empty input).
+    if (field.errors && field.errors.length > 0) {
+      blurredFields.add(key);
+    }
+  });
+}
+
+/** Collect field keys that currently have validation errors. */
+function getCurrentErrorFieldKeys(form: FormInstance): Set<string> {
+  return new Set(
+    form
+      .getFieldsError()
+      .filter(({ errors }) => errors.length > 0)
+      .map(({ name }) => serializeNamePath(name))
+  );
+}
+
+export function getFieldsToRevalidateOnChange(
+  form: FormInstance,
+  validateMode: FormValidateMode,
+  blurredFields: Set<string>,
+  options: {
+    changedValues?: Record<string, unknown>;
+    submitted?: boolean;
+  } = {}
+): NamePath[] {
+  const { changedValues, submitted } = options;
+  const changedNames = changedValues ? getChangedNamePaths(changedValues) : [];
+  if (changedNames.length === 0) {
+    return [];
+  }
+
+  // After submit: revalidate every changed field (shadcn / RHF isSubmitted + reValidateMode onChange)
+  if (submitted) {
+    return changedNames;
+  }
+
+  // Before submit: only revalidate changed fields that still show errors (clear errors live, no new ones)
+  const errorKeys = getCurrentErrorFieldKeys(form);
+
+  if (validateMode === 'onTouched') {
+    return changedNames.filter(name => {
+      const key = serializeNamePath(name);
+      return blurredFields.has(key) || errorKeys.has(key);
+    });
+  }
+
+  return changedNames.filter(name => errorKeys.has(serializeNamePath(name)));
+}
+
+export function revalidateOnChange(
+  form: FormInstance,
+  options: {
+    validateMode: FormValidateMode;
+    reValidateMode: FormReValidateMode;
+    blurredFields: Set<string>;
+    changedValues?: Record<string, unknown>;
+    submitted?: boolean;
+  }
+): void {
+  const { validateMode, reValidateMode, blurredFields, changedValues, submitted } = options;
+  const shouldRevalidateOnChange =
+    reValidateMode === 'onChange' || (!submitted && validateMode === 'onTouched');
+  if (!shouldRevalidateOnChange) {
+    return;
+  }
+  if (validateMode === 'onChange' || validateMode === 'all') {
+    return;
+  }
+  const names = getFieldsToRevalidateOnChange(form, validateMode, blurredFields, {
+    changedValues,
+    submitted,
+  });
+  if (names.length > 0) {
+    // Defer until rc-field-form commits changed values (aligns with RHF async field updates)
+    queueMicrotask(() => {
+      form.validateFields(names).catch(() => {});
+    });
+  }
+}
+
+export function needsValidateModeFormInstance(
+  validateMode: FormValidateMode,
+  injectRevalidate: boolean,
+  explicitTrigger?: AntFormProps['validateTrigger']
+): boolean {
+  return injectRevalidate || (validateMode === 'onTouched' && explicitTrigger === undefined);
+}


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Align `@oceanbase/design` `Form` validation timing with [react-hook-form](https://react-hook-form.com/docs/useform) / shadcn defaults:

- Default: `validateMode="onSubmit"` + `reValidateMode="onChange"` — no errors until submit; live revalidation after failed submit.
- Supports `onBlur`, `onChange`, `onTouched`, and `all` for first validation.
- `reValidateMode` supports `onChange` (default) and `onSubmit`.
- Global defaults via `ConfigProvider` `form.validateMode` / `form.reValidateMode`.
- Explicit `validateTrigger` bypasses injected logic (restore antd legacy: `validateMode="onChange"`).
- Applies only to design `Form` (not ProForm).

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Form<br/>&nbsp;&nbsp;- 🆕 Added `validateMode` and `reValidateMode` aligned with react-hook-form; defaults to submit-before-error with live revalidation after failed submit.<br/>&nbsp;&nbsp;- 🆕 Global defaults via ConfigProvider `form.validateMode` / `form.reValidateMode`. |
| 🇨🇳 Chinese | - Form<br/>&nbsp;&nbsp;- 🆕 新增 `validateMode` / `reValidateMode`，对齐 react-hook-form；默认 submit 前不展示错误，提交失败后实时重校验。<br/>&nbsp;&nbsp;- 🆕 支持通过 ConfigProvider `form.validateMode` / `form.reValidateMode` 全局配置。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed

### Test plan

- [x] `pnpm vitest run packages/design/src/form/__tests__/validateMode` (50 tests)
- [x] `pnpm vitest run packages/design/src/form/__tests__/` (63 tests)


Made with [Cursor](https://cursor.com)