### PR TITLE
feat(ui): align Password with cloud password rules and Form validation

### DIFF
--- a/packages/design/src/input/Password.tsx
+++ b/packages/design/src/input/Password.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useContext } from 'react';
+import React, { forwardRef, useContext, useEffect, useState } from 'react';
 import { Input as AntInput } from 'antd';
 import type { PasswordProps as AntPasswordProps } from 'antd/es/input/Password';
 import type { InputLocale, InputRef } from './Input';
@@ -14,13 +14,31 @@ export interface PasswordProps extends AntPasswordProps {
   locale?: InputLocale;
 }
 
+function isNewPasswordField(autoComplete?: string): boolean {
+  return autoComplete === 'new-password';
+}
+
 const Password = forwardRef<InputRef, PasswordProps>(
-  ({ prefixCls: customizePrefixCls, locale: customLocale, showCount, ...restProps }, ref) => {
+  (
+    {
+      prefixCls: customizePrefixCls,
+      locale: customLocale,
+      showCount,
+      autoComplete,
+      readOnly,
+      onFocus,
+      onBlur,
+      ...restProps
+    },
+    ref
+  ) => {
     const { getPrefixCls, locale: contextLocale } = useContext<ConfigConsumerProps>(
       ConfigProvider.ConfigContext
     );
     const prefixCls = getPrefixCls('input', customizePrefixCls);
     const [wrapCSSVar] = useStyle(prefixCls);
+    const preventSavedPasswordDropdown = isNewPasswordField(autoComplete);
+    const [autofillLocked, setAutofillLocked] = useState(preventSavedPasswordDropdown);
     const inputLocale: InputLocale = {
       placeholder:
         contextLocale?.global?.inputPlaceholder || defaultLocale.global?.inputPlaceholder,
@@ -29,12 +47,42 @@ const Password = forwardRef<InputRef, PasswordProps>(
       ...customLocale,
     };
 
+    useEffect(() => {
+      setAutofillLocked(preventSavedPasswordDropdown);
+    }, [preventSavedPasswordDropdown]);
+
+    const handleFocus: AntPasswordProps['onFocus'] = e => {
+      if (preventSavedPasswordDropdown) {
+        setAutofillLocked(false);
+      }
+      onFocus?.(e);
+    };
+
+    const handleBlur: AntPasswordProps['onBlur'] = e => {
+      if (preventSavedPasswordDropdown) {
+        setAutofillLocked(true);
+      }
+      onBlur?.(e);
+    };
+
     return wrapCSSVar(
       <AntInput.Password
         ref={ref}
         prefixCls={customizePrefixCls}
         placeholder={inputLocale.placeholder}
         showCount={showCount === true ? { formatter: showCountFormatter } : showCount}
+        autoComplete={autoComplete}
+        readOnly={readOnly ?? (preventSavedPasswordDropdown && autofillLocked)}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        {...(preventSavedPasswordDropdown
+          ? {
+              'data-lpignore': 'true',
+              'data-1p-ignore': 'true',
+              'data-bwignore': 'true',
+              'data-form-type': 'other',
+            }
+          : {})}
         {...restProps}
       />
     );

--- a/packages/design/src/input/__tests__/password.test.tsx
+++ b/packages/design/src/input/__tests__/password.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { Input } from '@oceanbase/design';
+
+describe('Input.Password autoComplete="new-password"', () => {
+  it('does not lock input by default', () => {
+    const { container } = render(<Input.Password />);
+    const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
+    expect(input.readOnly).toBe(false);
+    expect(input.getAttribute('autocomplete')).toBeNull();
+  });
+
+  it('applies saved-password dropdown mitigation for new-password', () => {
+    const { container } = render(<Input.Password autoComplete="new-password" />);
+    const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
+    expect(input.readOnly).toBe(true);
+    expect(input.getAttribute('autocomplete')).toBe('new-password');
+    expect(input.getAttribute('data-lpignore')).toBe('true');
+
+    fireEvent.focus(input);
+    expect(input.readOnly).toBe(false);
+
+    fireEvent.blur(input);
+    expect(input.readOnly).toBe(true);
+  });
+
+  it('does not apply mitigation for current-password', () => {
+    const { container } = render(<Input.Password autoComplete="current-password" />);
+    const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
+    expect(input.readOnly).toBe(false);
+    expect(input.getAttribute('data-lpignore')).toBeNull();
+  });
+});

--- a/packages/design/src/input/demo/password.tsx
+++ b/packages/design/src/input/demo/password.tsx
@@ -6,8 +6,10 @@ const App: React.FC = () => {
     <Space direction="vertical" style={{ width: '100%' }}>
       <div>Input.Password</div>
       <Input.Password />
-      <div>Input.Password with autoComplete="new-password"</div>
+      <div>Input.Password autoComplete=&quot;new-password&quot;</div>
       <Input.Password autoComplete="new-password" />
+      <div>Input.Password autoComplete=&quot;current-password&quot;</div>
+      <Input.Password autoComplete="current-password" />
     </Space>
   );
 };

--- a/packages/design/src/input/index.en-US.md
+++ b/packages/design/src/input/index.en-US.md
@@ -16,11 +16,15 @@ demo:
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx" title="Basic" description="Default `placeholder` filled."></code>
 <code src="./demo/search.tsx" title="Search"></code>
-<code src="./demo/password.tsx" title="Password" description='Set `autoComplete="new-password"` to avoid auto-fill, see [MDN docs](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Attributes/autocomplete).'></code>
+<code src="./demo/password.tsx" title="Password" description='Use `autoComplete="new-password"` for new-password fields; Input.Password applies extra hints to reduce saved-password dropdown overlap. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete).'></code>
 <code src="./demo/presuffix.tsx" title="Prefix and Suffix" description="Add prefix or suffix icon to input."></code>
 <code src="./demo/showCount.tsx" title="Character Count" description="Cannot input beyond max length."></code>
 <code src="./demo/allowClear.tsx" title="Clear Icon" description="One-click clear input."></code>
 
 ## API
 
-- See antd Input docs: https://ant.design/components/input-cn
+- See antd Input docs: https://ant.design/components/input
+
+### Input.Password extensions
+
+When `autoComplete="new-password"`, the component also uses readOnly-until-focus and password-manager `data-*` hints to reduce saved-password dropdown overlap beyond the standard autocomplete value.

--- a/packages/design/src/input/index.md
+++ b/packages/design/src/input/index.md
@@ -16,7 +16,7 @@ demo:
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx" title="基本使用" description="默认填充 `placeholder`。"></code>
 <code src="./demo/search.tsx" title="搜索框"></code>
-<code src="./demo/password.tsx" title="密码输入框" description='设置 `autoComplete="new-password"` 可避免自动填充密码，详见 [MDN 文档](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Attributes/autocomplete)。'></code>
+<code src="./demo/password.tsx" title="密码输入框" description='新密码请设 `autoComplete="new-password"`，组件会减轻浏览器已保存密码下拉遮挡；详见 [MDN](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Attributes/autocomplete)。'></code>
 <code src="./demo/presuffix.tsx" title="前缀和后缀" description="在输入框上添加前缀或后缀图标。"></code>
 <code src="./demo/showCount.tsx" title="字数提示" description="超出字数长度后无法输入。"></code>
 <code src="./demo/allowClear.tsx" title="清除图标" description="用于一键清除输入内容。"></code>
@@ -24,3 +24,7 @@ demo:
 ## API
 
 - 详见 antd Input 文档: https://ant.design/components/input-cn
+
+### Input.Password 扩展
+
+`autoComplete="new-password"` 时，除标准语义外还会：失焦前 `readOnly`、聚焦解锁，并附加密码管理器 `data-*` hint，减轻已保存密码下拉遮挡 UI。

--- a/packages/ui/src/Login/RegisterForm.tsx
+++ b/packages/ui/src/Login/RegisterForm.tsx
@@ -1,15 +1,22 @@
 import { Alert, Button, ConfigProvider, Form, Input } from '@oceanbase/design';
 import type { FormProps, RuleObject } from '@oceanbase/design/es/form';
 import { isFunction, toString } from 'lodash';
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback, useContext, useMemo } from 'react';
+import Password, { type PasswordLocale } from '../Password';
+import zhCN from '../Password/locale/zh-CN';
+import {
+  CLOUD_PASSWORD_REGEX,
+  createCloudPasswordValidator,
+  type CloudPasswordLocale,
+} from '../Password/Content';
 import type { LoginLocale } from './index';
 
 /**
- * 冗余的转义符可以增强正则的可读性
+ * Cloud password regex aligned with {@link CLOUD_PASSWORD_REGEX}.
+ * Prefer `analyzeCloudPassword` for validation.
  */
 // eslint-disable-next-line
-export const PASSWORD_REGEX =
-  /^(?=(.*[a-z]){2,})(?=(.*[A-Z]){2,})(?=(.*\d){2,})(?=(.*[ !"#\$%&'\(\)\*\+,-\./:;<=>\?@\[\\\]\^_`\{\|\}~]){2,})[A-Za-z\d !"#\$%&'\(\)\*\+,-\./:;<=>\?@\[\\\]\^_`\{\|\}~]{8,32}$/;
+export const PASSWORD_REGEX = CLOUD_PASSWORD_REGEX;
 
 export interface IRegisterFormProps extends FormProps {
   locale?: LoginLocale;
@@ -33,9 +40,26 @@ const Register: React.FC<IRegisterFormProps> = ({
   errorMessage,
   ...restProps
 }) => {
-  const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
+  const { getPrefixCls, locale: antLocale } = useContext(ConfigProvider.ConfigContext);
   const prefixCls = getPrefixCls('login');
   const [form] = Form.useForm();
+  const passwordLocaleFromContext = (
+    antLocale as { Password?: Partial<PasswordLocale> } | undefined
+  )?.Password;
+  const passwordMessages = useMemo<PasswordLocale>(
+    () => ({
+      ...zhCN,
+      ...passwordLocaleFromContext,
+    }),
+    [passwordLocaleFromContext]
+  );
+  const passwordCloudLocale = useMemo<CloudPasswordLocale>(
+    () => ({
+      ...passwordMessages,
+      emptyMessage: locale.passwordMessage,
+    }),
+    [passwordMessages, locale.passwordMessage]
+  );
 
   const handleValidateAccount = useCallback(
     async (rule: RuleObject, value: string) => {
@@ -47,29 +71,32 @@ const Register: React.FC<IRegisterFormProps> = ({
         throw new Error(locale.userExistMessage);
       }
     },
-    [isUserExists]
+    [isUserExists, locale.userExistMessage]
+  );
+
+  const handleValidatePassword = useCallback(
+    (_: RuleObject, value?: string) => {
+      if (passwordRule) {
+        if (!value || !passwordRule.pattern.test(value)) {
+          return Promise.reject(new Error(passwordRule.message));
+        }
+        return Promise.resolve();
+      }
+      return createCloudPasswordValidator(passwordCloudLocale)(_, value);
+    },
+    [passwordCloudLocale, passwordRule]
   );
 
   const handleValidateConfirmPassword = useCallback(
-    (rule, value, callback) => {
-      if (!form) {
-        callback();
-        return;
-      }
-      const pwd = (form as any).getFieldValue('password');
+    (_: RuleObject, value?: string) => {
+      const pwd = form.getFieldValue('password');
       if (toString(value) !== toString(pwd)) {
-        callback(locale.samePasswordMessage);
-        return;
+        return Promise.reject(new Error(passwordMessages.confirmMismatchMessage));
       }
-      callback();
+      return Promise.resolve();
     },
-    [form]
+    [form, passwordMessages.confirmMismatchMessage]
   );
-
-  const passwordRegexpRule = passwordRule || {
-    pattern: PASSWORD_REGEX,
-    message: locale.passwordHelp,
-  };
 
   return (
     <Form
@@ -119,17 +146,18 @@ const Register: React.FC<IRegisterFormProps> = ({
         name="password"
         label={locale.passwordLabel}
         dependencies={['confirmPassword']}
-        help={passwordRegexpRule.message}
         validateFirst
         rules={[
           {
             required: true,
             message: locale.passwordMessage,
           },
-          passwordRegexpRule,
+          {
+            validator: handleValidatePassword,
+          },
         ]}
       >
-        <Input.Password size="large" visibilityToggle={true} autoComplete="new-password" />
+        <Password size="large" visibilityToggle />
       </Form.Item>
       <Form.Item
         name="confirmPassword"
@@ -149,7 +177,6 @@ const Register: React.FC<IRegisterFormProps> = ({
         <Input.Password size="large" visibilityToggle={true} autoComplete="new-password" />
       </Form.Item>
       <Button
-        // 按下回车键，即可触发点击事件
         htmlType="submit"
         size="large"
         loading={loading}

--- a/packages/ui/src/Password/Content.tsx
+++ b/packages/ui/src/Password/Content.tsx
@@ -1,25 +1,196 @@
+import type { RuleObject } from 'antd/es/form';
 import { CheckCircleFilled, CloseCircleFilled, LoadingOutlined } from '@oceanbase/icons';
 import { Progress, Space } from '@oceanbase/design';
 import React from 'react';
 import { theme } from '@oceanbase/design';
 
+export const CLOUD_PASSWORD_MIN_LENGTH = 8;
+export const CLOUD_PASSWORD_MAX_LENGTH = 20;
+
+/** Compact display for inline messages. */
+export const CLOUD_PASSWORD_SPECIAL_CHARS_DISPLAY = '!@#$%^&*()_-+={}[]|\\:;"\'<>,.?~`';
+
+/** Spaced display aligned with cloud password spec docs. */
+export const CLOUD_PASSWORD_SPECIAL_CHARS_DISPLAY_SPACED =
+  '! @ # $ % ^ & * ( ) _ - + = [ ] { } | \\ : ; " \' < > , . ? ~ `';
+
+const SPECIAL_CHAR_PATTERN = /[!@#$%^&*()_\-+={}\[\]|\\:;"'<>,.?~`]/;
+const ALLOWED_CHAR_PATTERN = /^[A-Za-z\d!@#$%^&*()_\-+={}\[\]|\\:;"'<>,.?~`]+$/;
+const FORBIDDEN_CHAR_PATTERN =
+  /[\s\u4e00-\u9fff\uf900-\ufaff\u3040-\u309f\u30a0-\u30ff]|[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/u;
+
+export type PasswordRiskLevel = 'none' | 'low' | 'medium' | 'high' | 'success';
+export type PasswordRuleStatus = 'pass' | 'fail' | 'wait';
+
 export interface Validator {
   validate: (value?: string) => boolean;
   message: string;
   optional?: boolean;
+  messageLines?: string[];
 }
+
+export interface CloudPasswordLocale {
+  lengthRuleMessage: string;
+  charRuleMessage: string;
+  strengthRuleMessage: string;
+  strengthRuleMessageLine2: string;
+  emptyMessage: string;
+  forbiddenCharsMessage: string;
+  genericFailMessage: string;
+}
+
+export interface CloudPasswordAnalysis {
+  passed: boolean;
+  failedRuleCount: number;
+  riskLevel: PasswordRiskLevel;
+  fieldError?: string;
+  ruleStatuses: PasswordRuleStatus[];
+  fieldErrors: string[];
+}
+
+function countCharacterTypes(value: string): number {
+  let count = 0;
+  if (/[a-z]/.test(value)) count += 1;
+  if (/[A-Z]/.test(value)) count += 1;
+  if (/\d/.test(value)) count += 1;
+  if (SPECIAL_CHAR_PATTERN.test(value)) count += 1;
+  return count;
+}
+
+export function hasForbiddenPasswordChars(value?: string): boolean {
+  return Boolean(value) && FORBIDDEN_CHAR_PATTERN.test(value);
+}
+
+export function validateCloudPasswordLength(value?: string): boolean {
+  return (
+    Boolean(value) &&
+    value.length >= CLOUD_PASSWORD_MIN_LENGTH &&
+    value.length <= CLOUD_PASSWORD_MAX_LENGTH
+  );
+}
+
+export function validateCloudPasswordChars(value?: string): boolean {
+  return Boolean(value) && ALLOWED_CHAR_PATTERN.test(value);
+}
+
+export function validateCloudPasswordStrength(value?: string): boolean {
+  return Boolean(value) && countCharacterTypes(value) >= 3;
+}
+
+export function getCloudPasswordValidators(locale: CloudPasswordLocale): Validator[] {
+  return [
+    { validate: validateCloudPasswordLength, message: locale.lengthRuleMessage },
+    { validate: validateCloudPasswordChars, message: locale.charRuleMessage },
+    {
+      validate: validateCloudPasswordStrength,
+      message: locale.strengthRuleMessage,
+      messageLines: [locale.strengthRuleMessage, locale.strengthRuleMessageLine2].filter(Boolean),
+    },
+  ];
+}
+
+function formatRuleFieldError(rule: Validator): string {
+  const lines = rule.messageLines?.filter(Boolean);
+  if (lines && lines.length > 1) {
+    return lines.join(' ');
+  }
+  return rule.message;
+}
+
+function resolveFieldError(
+  value: string | undefined,
+  locale: CloudPasswordLocale,
+  validators: Validator[],
+  touched: boolean
+): string | undefined {
+  if (!touched) return undefined;
+  if (!value) return locale.emptyMessage;
+  if (hasForbiddenPasswordChars(value)) return locale.forbiddenCharsMessage;
+
+  const failedRules = validators.filter(rule => !rule.validate(value));
+  if (failedRules.length >= 2) return locale.genericFailMessage;
+  if (!validateCloudPasswordLength(value)) return locale.lengthRuleMessage;
+  if (failedRules.length === 1) return formatRuleFieldError(failedRules[0]);
+  return undefined;
+}
+
+function resolveRiskLevel(
+  value: string | undefined,
+  failedRuleCount: number,
+  touched: boolean
+): PasswordRiskLevel {
+  if (!value || !touched) return 'none';
+  if (failedRuleCount === 0 && !hasForbiddenPasswordChars(value)) return 'success';
+  if (failedRuleCount === 1) return 'medium';
+  return 'high';
+}
+
+export function analyzeCloudPassword(
+  value: string | undefined,
+  locale: CloudPasswordLocale,
+  options?: { touched?: boolean }
+): CloudPasswordAnalysis {
+  const touched = options?.touched ?? true;
+  const validators = getCloudPasswordValidators(locale);
+  const fieldFailures = validators
+    .map(rule => (rule.validate(value) ? undefined : rule.message))
+    .filter((message): message is string => Boolean(message));
+
+  const ruleStatuses: PasswordRuleStatus[] = validators.map(rule => {
+    if (!touched || !value) return 'wait';
+    return rule.validate(value) ? 'pass' : 'fail';
+  });
+
+  const failedRuleCount = fieldFailures.length;
+  const passed = Boolean(value) && failedRuleCount === 0 && !hasForbiddenPasswordChars(value);
+
+  return {
+    passed,
+    failedRuleCount,
+    riskLevel: resolveRiskLevel(value, failedRuleCount, touched),
+    fieldError: passed ? undefined : resolveFieldError(value, locale, validators, touched),
+    ruleStatuses,
+    fieldErrors: fieldFailures,
+  };
+}
+
+/** Internal Form validator for built-in flows (e.g. RegisterForm). */
+export function createCloudPasswordValidator(locale: CloudPasswordLocale) {
+  return (_: RuleObject, value?: string) => {
+    const analysis = analyzeCloudPassword(value, locale, { touched: true });
+    if (analysis.passed) {
+      return Promise.resolve();
+    }
+    return Promise.reject(new Error(analysis.fieldError || locale.genericFailMessage));
+  };
+}
+
+/** Full-match regex aligned with cloud password rules (length + charset + 3-of-4 types). */
+// eslint-disable-next-line no-useless-escape
+export const CLOUD_PASSWORD_REGEX =
+  /^(?=(?:.*[a-z])(?:.*[A-Z])(?:.*\d)|(?:.*[a-z])(?:.*[A-Z])(?:.*[!@#$%^&*()_\-+={}\[\]|\\:;"'<>,.?~`])|(?:.*[a-z])(?:.*\d)(?:.*[!@#$%^&*()_\-+={}\[\]|\\:;"'<>,.?~`])|(?:.*[A-Z])(?:.*\d)(?:.*[!@#$%^&*()_\-+={}\[\]|\\:;"'<>,.?~`]))[A-Za-z\d!@#$%^&*()_\-+={}\[\]|\\:;"'<>,.?~`]{8,20}$/;
 
 type ValidateStatus = 'success' | 'error' | 'wait';
 
 const Content: React.FC<{
   rules: Validator[];
-  fieldError: string[];
   isValidating: boolean;
   value?: string;
   isTouched: boolean;
+  ruleStatuses: PasswordRuleStatus[];
+  riskLevel: PasswordRiskLevel;
   rulesRegionId?: string;
   rulesAriaLabel?: string;
-}> = ({ rules, fieldError, isValidating, value, isTouched, rulesRegionId, rulesAriaLabel }) => {
+}> = ({
+  rules,
+  isValidating,
+  value,
+  isTouched,
+  ruleStatuses,
+  riskLevel,
+  rulesRegionId,
+  rulesAriaLabel,
+}) => {
   const { token } = theme.useToken();
   const statusIconMap = {
     error: <CloseCircleFilled style={{ color: token.colorError }} />,
@@ -45,54 +216,44 @@ const Content: React.FC<{
     ),
   };
 
-  const isRequireFail =
-    rules.filter(rule => !rule.optional).filter(rule => fieldError.includes(rule.message)).length >
-    0;
-  // 密码强度
-  const percent = Math.max(
-    0,
-    Math.min(100, ((rules.length - fieldError.length) / rules.length) * 100)
-  );
+  const passedCount = ruleStatuses.filter(status => status === 'pass').length;
+  const percent =
+    value && isTouched ? Math.max(0, Math.min(100, (passedCount / rules.length) * 100)) : 0;
 
-  let strokeColor = '';
-  if (isRequireFail) {
-    strokeColor = token.colorError;
-    if (percent > 50 && percent < 100 && percent !== 100) {
-      strokeColor = token.colorWarning;
-    }
-  } else {
+  let strokeColor = token.colorFillSecondary;
+  if (riskLevel === 'success') {
     strokeColor = token.colorSuccess;
+  } else if (riskLevel === 'medium') {
+    strokeColor = token.colorWarning;
+  } else if (riskLevel === 'high') {
+    strokeColor = token.colorError;
   }
+
+  const mapRuleStatus = (index: number): ValidateStatus => {
+    const status = ruleStatuses[index];
+    if (!isTouched || !value) return 'wait';
+    if (status === 'pass') return 'success';
+    if (status === 'fail') return rules[index]?.optional ? 'wait' : 'error';
+    return 'wait';
+  };
 
   return (
     <div id={rulesRegionId} role="region" aria-label={rulesAriaLabel}>
-      <Progress
-        percent={value ? percent : 0}
-        strokeColor={strokeColor}
-        showInfo={false}
-        aria-hidden
-      />
+      <Progress percent={percent} strokeColor={strokeColor} showInfo={false} aria-hidden />
       <ul style={{ margin: 0, marginTop: '10px', listStyle: 'none', padding: '0' }}>
         <Space size={4} direction="vertical">
-          {rules?.map(rule => {
-            const isError = fieldError.includes(rule.message);
-            let status: ValidateStatus = 'wait';
-            if (isError) {
-              status = rule.optional ? 'wait' : 'error';
-            } else {
-              status = 'success';
-            }
-            if (!value) {
-              status = 'error';
-            }
-            if (!isTouched) {
-              status = 'wait';
-            }
+          {rules?.map((rule, index) => {
+            const status = mapRuleStatus(index);
+            const lines = rule.messageLines?.length ? rule.messageLines : [rule.message];
             return (
               <li key={`${rule.message}`}>
                 <Space size={status === 'wait' ? 14 : 8} align="start">
                   {isValidating ? <LoadingOutlined aria-hidden /> : statusIconMap[status]}
-                  <span>{rule.message}</span>
+                  <div>
+                    {lines.map(line => (
+                      <div key={line}>{line}</div>
+                    ))}
+                  </div>
                 </Space>
               </li>
             );

--- a/packages/ui/src/Password/__tests__/passwordRules.test.ts
+++ b/packages/ui/src/Password/__tests__/passwordRules.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import enUS from '../locale/en-US';
+import {
+  analyzeCloudPassword,
+  CLOUD_PASSWORD_REGEX,
+  hasForbiddenPasswordChars,
+  validateCloudPasswordLength,
+  validateCloudPasswordStrength,
+} from '../Content';
+
+const locale = {
+  lengthRuleMessage: enUS.lengthRuleMessage,
+  charRuleMessage: enUS.charRuleMessage,
+  strengthRuleMessage: enUS.strengthRuleMessage,
+  strengthRuleMessageLine2: enUS.strengthRuleMessageLine2,
+  emptyMessage: enUS.emptyMessage,
+  forbiddenCharsMessage: enUS.forbiddenCharsMessage,
+  genericFailMessage: enUS.genericFailMessage,
+};
+
+describe('passwordRules', () => {
+  it('accepts a valid cloud password', () => {
+    const value = 'Abcd1234!';
+    const analysis = analyzeCloudPassword(value, locale, { touched: true });
+    expect(analysis.passed).toBe(true);
+    expect(analysis.riskLevel).toBe('success');
+    expect(analysis.ruleStatuses).toEqual(['pass', 'pass', 'pass']);
+    expect(CLOUD_PASSWORD_REGEX.test(value)).toBe(true);
+  });
+
+  it('rejects passwords shorter than 8 characters', () => {
+    const analysis = analyzeCloudPassword('Ab1!', locale, { touched: true });
+    expect(analysis.passed).toBe(false);
+    expect(analysis.fieldError).toBe(locale.lengthRuleMessage);
+    expect(analysis.riskLevel).toBe('medium');
+  });
+
+  it('rejects passwords longer than 20 characters', () => {
+    const analysis = analyzeCloudPassword('Abcdefghij123456789!x', locale, { touched: true });
+    expect(analysis.passed).toBe(false);
+    expect(analysis.fieldError).toBe(locale.lengthRuleMessage);
+  });
+
+  it('rejects forbidden characters such as spaces and emoji', () => {
+    expect(hasForbiddenPasswordChars('Abcd1234! ')).toBe(true);
+    expect(hasForbiddenPasswordChars('Abcd1234!😀')).toBe(true);
+    expect(hasForbiddenPasswordChars('密码Abcd123!')).toBe(true);
+
+    const analysis = analyzeCloudPassword('Abcd1234! ', locale, { touched: true });
+    expect(analysis.fieldError).toBe(locale.forbiddenCharsMessage);
+  });
+
+  it('requires at least three character classes', () => {
+    expect(validateCloudPasswordStrength('abcdefgh')).toBe(false);
+    const analysis = analyzeCloudPassword('abcdefgh', locale, { touched: true });
+    expect(analysis.passed).toBe(false);
+    expect(analysis.failedRuleCount).toBe(1);
+    expect(analysis.fieldError).toBe(
+      `${locale.strengthRuleMessage} ${locale.strengthRuleMessageLine2}`
+    );
+  });
+
+  it('returns generic message when multiple rules fail', () => {
+    const analysis = analyzeCloudPassword('abc', locale, { touched: true });
+    expect(analysis.passed).toBe(false);
+    expect(analysis.failedRuleCount).toBeGreaterThanOrEqual(2);
+    expect(analysis.fieldError).toBe(locale.genericFailMessage);
+    expect(analysis.riskLevel).toBe('high');
+  });
+
+  it('returns empty message when touched with no value', () => {
+    const analysis = analyzeCloudPassword('', locale, { touched: true });
+    expect(analysis.fieldError).toBe(locale.emptyMessage);
+  });
+
+  it('keeps wait state before touch', () => {
+    const analysis = analyzeCloudPassword('abc', locale, { touched: false });
+    expect(analysis.ruleStatuses.every(status => status === 'wait')).toBe(true);
+    expect(analysis.fieldError).toBeUndefined();
+  });
+
+  it('validates length boundaries', () => {
+    expect(validateCloudPasswordLength('1234567')).toBe(false);
+    expect(validateCloudPasswordLength('12345678')).toBe(true);
+    expect(validateCloudPasswordLength('12345678901234567890')).toBe(true);
+    expect(validateCloudPasswordLength('123456789012345678901')).toBe(false);
+  });
+});

--- a/packages/ui/src/Password/demo/basic.tsx
+++ b/packages/ui/src/Password/demo/basic.tsx
@@ -1,11 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Button, Form, Input } from '@oceanbase/design';
 import { Password } from '@oceanbase/ui';
 
 export default () => {
   const [form] = Form.useForm();
   const { validateFields } = form;
-  const [passed, setPassed] = useState(false);
   const formItemLayout = {
     labelCol: {
       span: 4,
@@ -32,35 +31,17 @@ export default () => {
     <Form form={form} {...formItemLayout}>
       <Form.Item
         name="username"
-        label="Username"
-        rules={[{ required: true, message: 'Please enter username' }]}
+        label="用户名"
+        rules={[{ required: true, message: '请输入用户名' }]}
       >
         <Input />
       </Form.Item>
-      <Form.Item
-        name="password"
-        label="Password"
-        rules={[
-          {
-            required: true,
-            message: 'Please enter password',
-          },
-          {
-            validator: (rule, value, callback) => {
-              if (value && !passed) {
-                callback('Password does not meet requirements');
-              } else {
-                callback();
-              }
-            },
-          },
-        ]}
-      >
-        <Password onValidate={setPassed} />
+      <Form.Item name="password" label="密码" rules={[{ required: true, message: '请输入密码' }]}>
+        <Password />
       </Form.Item>
       <Form.Item {...tailFormItemLayout}>
         <Button type="primary" onClick={onSubmit}>
-          Submit
+          提交
         </Button>
       </Form.Item>
     </Form>

--- a/packages/ui/src/Password/demo/change-password-scenario.tsx
+++ b/packages/ui/src/Password/demo/change-password-scenario.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import { Button, Form, Input, Modal } from '@oceanbase/design';
+import { Password } from '@oceanbase/ui';
+
+export default () => {
+  const [open, setOpen] = useState(false);
+  const [form] = Form.useForm();
+
+  return (
+    <>
+      <Button type="primary" onClick={() => setOpen(true)}>
+        修改密码
+      </Button>
+      <Modal
+        open={open}
+        title="修改密码"
+        okText="确定"
+        cancelText="取消"
+        onCancel={() => setOpen(false)}
+        onOk={() => form.validateFields()}
+        destroyOnClose
+      >
+        <Form form={form} layout="vertical" requiredMark={false}>
+          <Form.Item
+            name="currentPassword"
+            label="当前密码"
+            rules={[{ required: true, message: '请输入当前密码' }]}
+          >
+            <Password mode="plain" />
+          </Form.Item>
+          <Form.Item
+            name="newPassword"
+            label="新密码"
+            rules={[{ required: true, message: '请输入新密码' }]}
+          >
+            <Password />
+          </Form.Item>
+          <Form.Item
+            name="confirmPassword"
+            label="确认新密码"
+            dependencies={['newPassword']}
+            rules={[
+              { required: true, message: '请再次输入新密码' },
+              {
+                validator: (_, value) => {
+                  const pwd = form.getFieldValue('newPassword');
+                  if (value !== pwd) {
+                    return Promise.reject(new Error('两次输入的密码不一致'));
+                  }
+                  return Promise.resolve();
+                },
+              },
+            ]}
+          >
+            <Input.Password autoComplete="new-password" />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
+};

--- a/packages/ui/src/Password/demo/custom-generate-password.tsx
+++ b/packages/ui/src/Password/demo/custom-generate-password.tsx
@@ -1,9 +1,11 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Button, Form } from '@oceanbase/design';
 import { Password } from '@oceanbase/ui';
 
+const generatePasswordRegex =
+  /^(?=(.*[a-z]){2,})(?=(.*[A-Z]){2,})(?=(.*\d){2,})(?=(.*[._+@#$%]){2,})[A-Za-z\d._+@#$%]{8,32}$/;
+
 export default () => {
-  const [passed, setPassed] = useState(true);
   const formItemLayout = {
     labelCol: {
       span: 4,
@@ -19,42 +21,23 @@ export default () => {
     },
   };
 
-  const onFinish = (values: any) => {
-    const { password } = values;
-    alert(`Form validation passed. password: ${password}`);
+  const onFinish = (values: { password?: string }) => {
+    alert(`Form validation passed. password: ${values.password}`);
   };
+
   return (
     <Form onFinish={onFinish} {...formItemLayout}>
       <Form.Item
         label="Password"
         name="password"
-        validateTrigger={['onChange', 'onValidate']}
         rules={[
-          {
-            required: true,
-            message: 'Please enter password',
-          },
-          {
-            validator: (rule, value, callback) => {
-              console.log(passed);
-              if (value && !passed) {
-                callback('Password does not meet requirements');
-              } else {
-                callback();
-              }
-            },
-          },
+          { required: true, message: 'Please enter password' },
+          { pattern: generatePasswordRegex, message: 'Password does not meet requirements' },
         ]}
       >
         <Password
-          generatePasswordRegex={
-            /^(?=(.*[a-z]){2,})(?=(.*[A-Z]){2,})(?=(.*\d){2,})(?=(.*[._+@#$%]){2,})[A-Za-z\d._+@#$%]{8,32}$/
-          }
-          generatePassword={() => {
-            // your custom password generate logic
-            return 'custom_password';
-          }}
-          onValidate={setPassed}
+          generatePasswordRegex={generatePasswordRegex}
+          generatePassword={() => 'custom_password'}
         />
       </Form.Item>
       <Form.Item {...tailFormItemLayout}>

--- a/packages/ui/src/Password/demo/custom-rules-and-random-generate.tsx
+++ b/packages/ui/src/Password/demo/custom-rules-and-random-generate.tsx
@@ -1,9 +1,26 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Button, Form } from '@oceanbase/design';
 import { Password } from '@oceanbase/ui';
 
+const rules = [
+  {
+    validate: (val?: string) => Boolean(val && val.length >= 8),
+    message: 'At least 8 characters',
+  },
+  {
+    validate: (val?: string) => Boolean(val && /[a-z]+/.test(val) && /[A-Z]+/.test(val)),
+    message: 'Contains lowercase (a-z) and uppercase (A-Z) letters',
+  },
+  {
+    message: 'Contains at least one digit (0-9) or symbol',
+    validate: (val?: string) => Boolean(val && /([0-9]|[._+@#$%])+/.test(val)),
+  },
+];
+
+const generatePasswordRegex =
+  /^(?=(.*[a-z]){2,})(?=(.*[A-Z]){2,})(?=(.*\d){2,})(?=(.*[._+@#$%]){2,})[A-Za-z\d._+@#$%]{8,32}$/;
+
 export default () => {
-  const [passed, setPassed] = useState(false);
   const formItemLayout = {
     labelCol: {
       span: 4,
@@ -18,31 +35,9 @@ export default () => {
       span: 12,
     },
   };
-  const rules = [
-    {
-      validate: val => val?.length >= 8,
-      message: 'At least 8 characters',
-    },
-    {
-      validate: val => {
-        if (/[a-z]+/.test(val) && /[A-Z]+/.test(val)) {
-          return true;
-        }
-        return false;
-      },
-      message: 'Contains lowercase (a-z) and uppercase (A-Z) letters',
-    },
-    {
-      message: 'Contains at least one digit (0-9) or symbol',
-      validate: val => {
-        return /([0-9]|[._+@#$%])+/.test(val);
-      },
-    },
-  ];
 
-  const onFinish = (values: any) => {
-    const { password } = values;
-    alert(`Form validation passed. password: ${password}`);
+  const onFinish = (values: { password?: string }) => {
+    alert(`Form validation passed. password: ${values.password}`);
   };
 
   return (
@@ -51,28 +46,21 @@ export default () => {
         name="password"
         label="Password"
         rules={[
+          { required: true, message: 'Please enter password' },
           {
-            required: true,
-            message: 'Please enter password',
-          },
-          {
-            validator: (rule, value, callback) => {
-              if (value && !passed) {
-                callback('Password does not meet requirements');
-              } else {
-                callback();
+            validator: async (_, value) => {
+              if (!value) {
+                return;
+              }
+              const failed = rules.find(rule => !rule.validate(value));
+              if (failed) {
+                throw new Error(failed.message);
               }
             },
           },
         ]}
       >
-        <Password
-          rules={rules}
-          generatePasswordRegex={
-            /^(?=(.*[a-z]){2,})(?=(.*[A-Z]){2,})(?=(.*\d){2,})(?=(.*[._+@#$%]){2,})[A-Za-z\d._+@#$%]{8,32}$/
-          }
-          onValidate={setPassed}
-        />
+        <Password rules={rules} generatePasswordRegex={generatePasswordRegex} />
       </Form.Item>
       <Form.Item {...tailFormItemLayout}>
         <Button type="primary" htmlType="submit">

--- a/packages/ui/src/Password/demo/custom-rules.tsx
+++ b/packages/ui/src/Password/demo/custom-rules.tsx
@@ -1,11 +1,25 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Button, Form, Input } from '@oceanbase/design';
 import { Password } from '@oceanbase/ui';
+
+const rules = [
+  {
+    validate: (val?: string) => Boolean(val && val.length >= 8),
+    message: 'At least 8 characters',
+  },
+  {
+    validate: (val?: string) => Boolean(val && /[a-z]+/.test(val) && /[A-Z]+/.test(val)),
+    message: 'Contains lowercase (a-z) and uppercase (A-Z) letters',
+  },
+  {
+    message: 'Contains at least one digit (0-9) or symbol',
+    validate: (val?: string) => Boolean(val && /([0-9]|[._+@#$%])+/.test(val)),
+  },
+];
 
 export default () => {
   const [form] = Form.useForm();
   const { validateFields } = form;
-  const [passed, setPassed] = useState(false);
   const formItemLayout = {
     labelCol: {
       span: 4,
@@ -20,28 +34,6 @@ export default () => {
       span: 10,
     },
   };
-
-  const rules = [
-    {
-      validate: val => val?.length >= 8,
-      message: 'At least 8 characters',
-    },
-    {
-      validate: val => {
-        if (/[a-z]+/.test(val) && /[A-Z]+/.test(val)) {
-          return true;
-        }
-        return false;
-      },
-      message: 'Contains lowercase (a-z) and uppercase (A-Z) letters',
-    },
-    {
-      message: 'Contains at least one digit (0-9) or symbol',
-      validate: val => {
-        return /([0-9]|[._+@#$%])+/.test(val);
-      },
-    },
-  ];
 
   const onSubmit = () => {
     validateFields().then(values => {
@@ -63,22 +55,21 @@ export default () => {
         name="password"
         label="Password"
         rules={[
+          { required: true, message: 'Please enter password' },
           {
-            required: true,
-            message: 'Please enter password',
-          },
-          {
-            validator: (rule, value, callback) => {
-              if (value && !passed) {
-                callback('Password does not meet requirements');
-              } else {
-                callback();
+            validator: async (_, value) => {
+              if (!value) {
+                return;
+              }
+              const failed = rules.find(rule => !rule.validate(value));
+              if (failed) {
+                throw new Error(failed.message);
               }
             },
           },
         ]}
       >
-        <Password rules={rules} onValidate={setPassed} />
+        <Password rules={rules} />
       </Form.Item>
       <Form.Item {...tailFormItemLayout}>
         <Button type="primary" onClick={onSubmit}>

--- a/packages/ui/src/Password/demo/random-generate-password.tsx
+++ b/packages/ui/src/Password/demo/random-generate-password.tsx
@@ -1,9 +1,11 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Button, Form } from '@oceanbase/design';
 import { Password } from '@oceanbase/ui';
 
+const generatePasswordRegex =
+  /^(?=(.*[a-z]){2,})(?=(.*[A-Z]){2,})(?=(.*\d){2,})(?=(.*[._+@#$%]){2,})[A-Za-z\d._+@#$%]{8,32}$/;
+
 export default () => {
-  const [passed, setPassed] = useState(true);
   const formItemLayout = {
     labelCol: {
       span: 4,
@@ -19,39 +21,21 @@ export default () => {
     },
   };
 
-  const onFinish = (values: any) => {
-    const { password } = values;
-    alert(`Form validation passed. password: ${password}`);
+  const onFinish = (values: { password?: string }) => {
+    alert(`Form validation passed. password: ${values.password}`);
   };
+
   return (
     <Form onFinish={onFinish} {...formItemLayout}>
       <Form.Item
         label="Password"
         name="password"
-        validateTrigger={['onChange', 'onValidate']}
         rules={[
-          {
-            required: true,
-            message: 'Please enter password',
-          },
-          {
-            validator: (rule, value, callback) => {
-              console.log(passed);
-              if (value && !passed) {
-                callback('Password does not meet requirements');
-              } else {
-                callback();
-              }
-            },
-          },
+          { required: true, message: 'Please enter password' },
+          { pattern: generatePasswordRegex, message: 'Password does not meet requirements' },
         ]}
       >
-        <Password
-          generatePasswordRegex={
-            /^(?=(.*[a-z]){2,})(?=(.*[A-Z]){2,})(?=(.*\d){2,})(?=(.*[._+@#$%]){2,})[A-Za-z\d._+@#$%]{8,32}$/
-          }
-          onValidate={setPassed}
-        />
+        <Password generatePasswordRegex={generatePasswordRegex} />
       </Form.Item>
       <Form.Item {...tailFormItemLayout}>
         <Button type="primary" htmlType="submit">

--- a/packages/ui/src/Password/index.en-US.md
+++ b/packages/ui/src/Password/index.en-US.md
@@ -9,26 +9,67 @@ nav:
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx" title="Basic" description="Built-in validation rules."></code>
+<code src="./demo/change-password-scenario.tsx" title="Change password"></code>
 <code src="./demo/custom-rules.tsx" title="Custom validation rules"></code>
 <code src="./demo/random-generate-password.tsx" title="Generate random password"></code>
 <code src="./demo/custom-generate-password.tsx" title="Custom generate password" description="Use generatePassword for custom logic when built-in is insufficient"></code>
 <code src="./demo/custom-rules-and-random-generate.tsx" title="Custom rules + random generate"></code>
 
+## Default password rules
+
+Built-in defaults follow the multi-cloud password spec (**Breaking**: was length 8–32 and at least 2 of each character class):
+
+- Length **8–20** characters
+- Letters, digits, and special characters only (`! @ # $ % ^ & * ( ) _ - + = [ ] { } | \ : ; " ' < > , . ? ~ `)
+- **At least 3 of 4** classes: uppercase, lowercase, digits, special characters
+- No spaces, tabs, newlines, emoji, or CJK characters (shown on blur; not listed as a separate popover rule)
+
+On focus, a popover shows the three rules above and a strength bar. `mode="new"` defaults to `autoComplete="new-password"` to reduce saved-password dropdown overlap. For tenant DB accounts (**8–64**, etc.), override with custom `rules` / `generatePasswordRegex`.
+
+## Form integration
+
+Validation timing follows Form default `validateMode`. `Password` handles the rules popover, strength UI, and messages; configure `Form.Item` rules as usual:
+
+```tsx
+import { Form } from '@oceanbase/design';
+import { Password } from '@oceanbase/ui';
+
+<Form>
+  <Form.Item
+    name="password"
+    rules={[
+      { required: true, message: passwordLocale.emptyMessage },
+      { pattern: passwordPattern, message: passwordLocale.genericFailMessage },
+    ]}
+  >
+    <Password />
+  </Form.Item>
+</Form>;
+```
+
+Use `ConfigProvider` `locale.Password` for messages (`emptyMessage`, `genericFailMessage`, `forbiddenCharsMessage`, etc.). For custom `rules` / `generatePasswordRegex`, keep `Form.Item` validators or patterns aligned with the component `rules`.
+
+- **New password**: `<Password />` (`mode="new"`). Form validation errors use `Form.Item` explain. Blur rule messages and the copy hint are absolutely positioned below the input (no document-flow height).
+- **Current password**: `<Password mode="plain" />` with `required` only; map API accuracy errors on submit.
+- **Confirm password**: `Input.Password` + match validator.
+- **Registration**: `Login` `RegisterForm` includes cloud password validation out of the box.
+
 ## API
 
 | Property | Description | Type | Default | Version |
 | :-- | :-- | :-- | :-- | :-- |
-| rules | Password validation rules | [Validator](password#validator)[] | - | - |
+| mode | `new` shows strength popover on focus; `plain` is a simple input | `'new' \| 'plain'` | `'new'` | - |
+| rules | Rules shown in the popover (UI only; Form handles validation timing) | [Validator](password#validator)[] | Cloud defaults | - |
 | generatePasswordRegex | Regex for random password; non-empty shows generate button | RegExp | - | - |
 | value | Password value | string | - | - |
 | onChange | Value change callback | (value?: string) => void | - | - |
-| onValidate | Validation callback on value change | (passed: boolean) => void | - | - |
 | generatePassword | Custom generate function | () => string | - | - |
 
 ### Validator
 
-| Property | Description              | Type                        | Default | Version |
-| :------- | :----------------------- | :-------------------------- | :------ | :------ |
-| validate | Password rule            | (value?: string) => boolean | -       | -       |
-| message  | Rule description         | string                      | -       | -       |
-| optional | Whether rule is optional | boolean                     | true    | -       |
+| Property     | Description              | Type                        | Default | Version |
+| :----------- | :----------------------- | :-------------------------- | :------ | :------ |
+| validate     | Password rule            | (value?: string) => boolean | -       | -       |
+| message      | Rule description         | string                      | -       | -       |
+| messageLines | Multi-line rule text     | string[]                    | -       | -       |
+| optional     | Whether rule is optional | boolean                     | `true`  | -       |

--- a/packages/ui/src/Password/index.md
+++ b/packages/ui/src/Password/index.md
@@ -9,26 +9,69 @@ nav:
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx" title="基本" description="使用内置的校验规则。"></code>
+<code src="./demo/change-password-scenario.tsx" title="修改密码场景"></code>
 <code src="./demo/custom-rules.tsx" title="自定义校验规则"></code>
 <code src="./demo/random-generate-password.tsx" title="生成随机密码"></code>
 <code src="./demo/custom-generate-password.tsx" title="自定义生成密码" description="当内置的生成逻辑不满足需求时，可以通过 `generatePassword` 进行自定义"></code>
 <code src="./demo/custom-rules-and-random-generate.tsx" title="自定义校验规则 + 生成随机密码"></code>
 
+## 默认密码规则
+
+内置默认规则对齐多云密码规范（**Breaking**：原默认长度为 8~32、各类字符至少 2 个）：
+
+- 长度为 **8~20** 个字符
+- 只能包含字母、数字和特殊字符（`! @ # $ % ^ & * ( ) _ - + = [ ] { } | \ : ; " ' < > , . ? ~ `）
+- 大写字母、小写字母、数字、特殊字符，**至少包含 3 种**
+- 禁止空格、Tab、换行、emoji、中文等（失焦时报错，不单独展示为气泡规则）
+
+聚焦时通过气泡展示上述三条规则及强度进度。`mode="new"` 默认 `autoComplete="new-password"`，减轻浏览器已保存密码下拉遮挡气泡。
+
+租户建库等 **8~64** 场景请通过 `rules` / `generatePasswordRegex` 自定义覆盖。
+
+## 与 Form 集成
+
+校验时机由 Form 默认 `validateMode` 处理（提交前不报错，提交失败后输入实时更新）。`Password` 负责规则气泡、强度与文案；在 `Form.Item` 的 `rules` 中配置校验即可：
+
+```tsx
+import { Form } from '@oceanbase/design';
+import { Password } from '@oceanbase/ui';
+
+<Form>
+  <Form.Item
+    name="password"
+    rules={[
+      { required: true, message: passwordLocale.emptyMessage },
+      { pattern: passwordPattern, message: passwordLocale.genericFailMessage },
+    ]}
+  >
+    <Password />
+  </Form.Item>
+</Form>;
+```
+
+文案可来自 `ConfigProvider` 的 `locale.Password`（`emptyMessage`、`genericFailMessage`、`forbiddenCharsMessage` 等）。自定义 `rules` / `generatePasswordRegex` 时，在 `Form.Item` 中用对应的 `validator` 或 `pattern` 与组件 `rules` 保持一致。
+
+- **新密码**：`<Password />`（`mode="new"`）；Form 校验报错由 `Form.Item` explain 展示；失焦后的规则分析文案与「请牢记并妥善保存密码」以绝对定位输出在输入框下方，不占文档流高度、不挤压布局。
+- **当前密码**：`<Password mode="plain" />`，仅 `required`，不校验格式（允许空格等）；准确性由提交时接口报错映射到字段。
+- **确认密码**：`Input.Password` + 一致性 `validator`。
+- **注册表单**：`Login` 的 `RegisterForm` 已内置多云密码校验，可直接使用。
+
 ## API
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | :-- | :-- | :-- | :-- | :-- |
-| rules | 密码校验规则 | [Validator](password#validator)[] | - | - |
+| mode | `new` 聚焦展示规则气泡；`plain` 为简单密码输入（当前密码） | `'new' \| 'plain'` | `'new'` | - |
+| rules | 气泡内展示的密码规则（仅 UI，校验时机由 Form 负责） | [Validator](password#validator)[] | 多云默认规则 | - |
 | generatePasswordRegex | 随机生成密码的正则表达式，不为空则展示随机生成的按钮 | RegExp | - | - |
 | value | 密码框内容 | string | - | - |
 | onChange | 密码框内容变化的回调 | (value?: string) => void | - | - |
-| onValidate | 密码框内容变化触发校验的回调 | (passed: boolean) => void | - | - |
 | generatePassword | 自定义生成密码 | () => string | - | - |
 
 ### Validator
 
-| 参数     | 说明                     | 类型                        | 默认值 | 版本 |
-| :------- | :----------------------- | :-------------------------- | :----- | :--- |
-| validate | 密码规则                 | (value?: string) => boolean | -      | -    |
-| message  | 密码规则说明             | string                      | -      | -    |
-| optional | 密码规则是否为校验可选项 | boolean                     | true   | -    |
+| 参数         | 说明                     | 类型                        | 默认值 | 版本 |
+| :----------- | :----------------------- | :-------------------------- | :----- | :--- |
+| validate     | 密码规则                 | (value?: string) => boolean | -      | -    |
+| message      | 密码规则说明             | string                      | -      | -    |
+| messageLines | 多行规则说明             | string[]                    | -      | -    |
+| optional     | 密码规则是否为校验可选项 | boolean                     | `true` | -    |

--- a/packages/ui/src/Password/index.tsx
+++ b/packages/ui/src/Password/index.tsx
@@ -1,19 +1,32 @@
-import { Button, Input, message, Popover, Space, Typography } from '@oceanbase/design';
+import { Button, Form, Input, Popover, Space, Typography, theme } from '@oceanbase/design';
 import type { PasswordProps as InputPasswordProps } from '@oceanbase/design/es/input';
 import RandExp from 'randexp';
-import React, { useId, useState } from 'react';
-import { theme } from '@oceanbase/design';
+import React, { useCallback, useEffect, useId, useState } from 'react';
 import { CheckOutlined, CopyOutlined } from '@oceanbase/icons';
 import type { LocaleWrapperProps } from '../locale/LocaleWrapper';
 import LocaleWrapper from '../locale/LocaleWrapper';
-import type { Validator } from './Content';
-import Content from './Content';
+import Content, {
+  analyzeCloudPassword,
+  getCloudPasswordValidators,
+  type CloudPasswordLocale,
+  type PasswordRiskLevel,
+  type Validator,
+} from './Content';
 import zhCN from './locale/zh-CN';
 
-export interface PasswordLocale {
-  lengthRuleMessage: string;
-  charRuleMessage: string;
-  strengthRuleMessage: string;
+type FormItemInputContextValue = {
+  status?: string;
+  isFormItemInput?: boolean;
+};
+
+const FormItemInputContext =
+  (
+    Form.Item.useStatus as typeof Form.Item.useStatus & {
+      Context?: React.Context<FormItemInputContextValue>;
+    }
+  ).Context ?? React.createContext<FormItemInputContextValue>({});
+
+export interface PasswordLocale extends CloudPasswordLocale {
   placeholder: string;
   generatePlaceholder: string;
   randomlyGenerate: string;
@@ -21,6 +34,7 @@ export interface PasswordLocale {
   copySuccessfully: string;
   copyPassword: string;
   passwordStrengthRules: string;
+  confirmMismatchMessage: string;
 }
 
 export interface PasswordProps extends LocaleWrapperProps, Omit<InputPasswordProps, 'onChange'> {
@@ -28,9 +42,10 @@ export interface PasswordProps extends LocaleWrapperProps, Omit<InputPasswordPro
   onChange?: (value?: string) => void;
   generatePassword?: () => string;
   rules?: Validator[];
-  onValidate?: (passed: boolean) => void;
   generatePasswordRegex?: RegExp;
   locale?: PasswordLocale;
+  /** `new` shows strength popover; `plain` is a simple password input for current password. */
+  mode?: 'new' | 'plain';
 }
 
 const Password: React.FC<PasswordProps> = ({
@@ -39,149 +54,191 @@ const Password: React.FC<PasswordProps> = ({
   rules,
   onChange,
   generatePassword,
-  onValidate,
   generatePasswordRegex,
+  mode = 'new',
+  onFocus: restOnFocus,
+  onBlur: restOnBlur,
+  autoComplete: autoCompleteProp,
+  readOnly: readOnlyProp,
   ...restProps
 }) => {
   const { token } = theme.useToken();
-  const [fieldError, setFieldError] = useState<string[]>([]);
-  const [isValidating, setIsValidating] = useState(false);
-  const [isTouched, setIsTouched] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  const [hasBlurred, setHasBlurred] = useState(false);
+  const [displayValue, setDisplayValue] = useState<string | undefined>(value);
   const strengthRulesId = useId();
+  const formItemStatus = React.useContext(FormItemInputContext);
+  const isInFormItem = Boolean(formItemStatus?.isFormItemInput);
+  const formHasError = isInFormItem && formItemStatus?.status === 'error';
 
-  const defaultRules: Validator[] = [
-    {
-      validate: (val?: string) => val?.length >= 8 && val?.length <= 32,
-      message: locale.lengthRuleMessage,
-    },
-    {
-      validate: (val?: string) => /^[0-9a-zA-Z~!@#%^&*_\-+=|(){}\[\]:;,.?/`$'"<>\\]+$/.test(val),
-      message: locale.charRuleMessage,
-    },
-    {
-      validate: (val?: string) =>
-        /(?=(.*[a-z]){2,})(?=(.*[A-Z]){2,})(?=(.*\d){2,})(?=(.*[~!@#%^&*_\-+=|(){}\[\]:;,.?/`$'"<>\\]){2,})/.test(
-          val
-        ),
-      message: locale.strengthRuleMessage,
-    },
-  ];
-  const newRules = rules || defaultRules;
+  useEffect(() => {
+    setDisplayValue(value);
+  }, [value]);
 
-  const handleChange = (newValue?: string) => {
-    if (!isTouched) {
-      setIsTouched(true);
-    }
-    setIsValidating(true);
-    const newFieldError = newRules
-      .map(rule => {
-        // 规则校验通过，返回空的校验信息
-        if (rule.validate(newValue)) {
-          return undefined;
-        }
-        // 规则校验不通过，返回对应的校验信息
-        return rule.message;
-      })
-      .filter(ruleMessage => ruleMessage);
-    setIsValidating(false);
-    setFieldError(newFieldError);
-    onValidate?.(newFieldError.length === 0);
-    onChange?.(newValue);
-  };
+  const cloudLocale = locale!;
+  const activeRules = rules || getCloudPasswordValidators(cloudLocale);
 
-  // 根据正则表达式获取符合要求的随机密码
+  const getAnalysis = useCallback(
+    (newValue?: string, interactive = false) => {
+      if (mode === 'plain') {
+        const empty = !newValue;
+        return {
+          passed: !empty,
+          failedRuleCount: empty ? 1 : 0,
+          riskLevel: (empty ? 'none' : 'success') as PasswordRiskLevel,
+          fieldError: empty && interactive ? cloudLocale.emptyMessage : undefined,
+          ruleStatuses: [],
+          fieldErrors: [],
+        };
+      }
+      return analyzeCloudPassword(newValue, cloudLocale, { touched: interactive });
+    },
+    [cloudLocale, mode]
+  );
+
+  const popoverInteractive = Boolean(displayValue) || isFocused;
+  const analysis = getAnalysis(displayValue, popoverInteractive || hasBlurred);
+  const blurFeedbackMessage = hasBlurred && !formHasError ? analysis.fieldError : undefined;
+  const showRememberHint =
+    mode === 'new' &&
+    value &&
+    analysis.passed &&
+    !blurFeedbackMessage &&
+    !formHasError &&
+    hasBlurred;
+
   const getRandomPassword = () => {
-    const newValue = new RandExp(generatePasswordRegex).gen();
-    // 由于生成密码的库目前不支持包含前后断言的正则表达式，因此需要多次生成密码，直到符合密码强度要求
-    if (generatePasswordRegex.test(newValue)) {
+    const newValue = new RandExp(generatePasswordRegex!).gen();
+    if (generatePasswordRegex!.test(newValue)) {
       return newValue;
     }
     return getRandomPassword();
   };
 
+  const passwordInput = (
+    <Input.Password
+      {...restProps}
+      value={value}
+      autoComplete={autoCompleteProp ?? (mode === 'plain' ? 'current-password' : 'new-password')}
+      readOnly={readOnlyProp}
+      aria-haspopup={mode === 'new' ? 'dialog' : undefined}
+      aria-describedby={mode === 'new' ? strengthRulesId : undefined}
+      onChange={e => {
+        const newValue = e?.target?.value;
+        setDisplayValue(newValue);
+        onChange?.(newValue);
+      }}
+      onFocus={e => {
+        setIsFocused(true);
+        restOnFocus?.(e);
+      }}
+      onBlur={e => {
+        setHasBlurred(true);
+        setIsFocused(false);
+        restOnBlur?.(e);
+      }}
+      placeholder={
+        generatePasswordRegex ? cloudLocale.generatePlaceholder : cloudLocale.placeholder
+      }
+    />
+  );
+
   return (
-    <>
+    <div style={{ position: 'relative', width: '100%' }}>
       <div style={{ display: 'flex' }}>
-        <Popover
-          trigger="click"
-          placement="right"
-          // ref: https://github.com/ant-design/ant-design/issues/5899
-          // @ts-ignore
-          popupAlign={{
-            offset: [16, 0],
-          }}
-          content={
-            <Content
-              isTouched={isTouched}
-              value={value}
-              isValidating={isValidating}
-              rules={newRules}
-              fieldError={fieldError}
-              rulesRegionId={strengthRulesId}
-              rulesAriaLabel={locale.passwordStrengthRules}
-            />
-          }
-          overlayStyle={{ maxWidth: 400 }}
-          overlayInnerStyle={{
-            padding: `${token.padding / 2}px ${token.padding}px ${token.padding}px ${token.padding}px`,
-          }}
-        >
-          <Input.Password
-            value={value}
-            autoComplete="new-password"
-            aria-haspopup="dialog"
-            aria-describedby={strengthRulesId}
-            onChange={e => {
-              handleChange(e?.target?.value);
+        {mode === 'new' ? (
+          <Popover
+            open={isFocused}
+            onOpenChange={open => {
+              if (!open) {
+                setIsFocused(false);
+              }
             }}
-            placeholder={generatePasswordRegex ? locale.generatePlaceholder : locale.placeholder}
-            {...restProps}
-          />
-        </Popover>
+            trigger={[]}
+            placement="rightTop"
+            // ref: https://github.com/ant-design/ant-design/issues/5899
+            // @ts-ignore
+            popupAlign={{
+              offset: [16, 0],
+            }}
+            content={
+              <Content
+                isTouched={popoverInteractive}
+                value={displayValue}
+                isValidating={false}
+                rules={activeRules}
+                ruleStatuses={analysis.ruleStatuses}
+                riskLevel={analysis.riskLevel}
+                rulesRegionId={strengthRulesId}
+                rulesAriaLabel={cloudLocale.passwordStrengthRules}
+              />
+            }
+            overlayStyle={{ maxWidth: 400 }}
+            overlayInnerStyle={{
+              padding: `${token.padding / 2}px ${token.padding}px ${token.padding}px ${token.padding}px`,
+            }}
+          >
+            {passwordInput}
+          </Popover>
+        ) : (
+          passwordInput
+        )}
         {generatePasswordRegex && (
           <Button
             onClick={() => {
-              if (generatePassword instanceof Function) {
-                handleChange(generatePassword());
-              } else {
-                handleChange(getRandomPassword());
-              }
+              setHasBlurred(true);
+              const newValue =
+                generatePassword instanceof Function ? generatePassword() : getRandomPassword();
+              setDisplayValue(newValue);
+              onChange?.(newValue);
             }}
             style={{ marginLeft: 8 }}
           >
-            {locale.randomlyGenerate}
+            {cloudLocale.randomlyGenerate}
           </Button>
         )}
       </div>
-      {value && fieldError?.length === 0 && (
+      {(blurFeedbackMessage || showRememberHint) && (
         <div
           style={{
-            fontSize: token.fontSizeSM,
-            color: token.colorTextDescription,
+            position: 'absolute',
+            top: '100%',
+            left: 0,
+            width: '100%',
             marginTop: token.marginXXS,
+            fontSize: token.fontSizeSM,
+            lineHeight: token.lineHeight,
           }}
         >
-          {locale.pleaseRememberYourPassword}
-          <Typography.Text
-            copyable={{
-              text: value,
-              icon: [
-                <Space key="copy" size={token.marginXXS}>
-                  <CopyOutlined aria-hidden />
-                  <a>{locale.copyPassword}</a>
-                </Space>,
-                <Space key="copy-success" size={token.marginXXS}>
-                  <CheckOutlined aria-hidden />
-                  <a>{locale.copyPassword}</a>
-                </Space>,
-              ],
-              tooltips: [locale.copyPassword, locale.copySuccessfully],
-            }}
-            style={{ marginLeft: token.marginXXS }}
-          />
+          {showRememberHint ? (
+            <div style={{ color: token.colorTextDescription }}>
+              {cloudLocale.pleaseRememberYourPassword}
+              <Typography.Text
+                copyable={{
+                  text: value,
+                  icon: [
+                    <Space key="copy" size={token.marginXXS}>
+                      <CopyOutlined aria-hidden />
+                      <a>{cloudLocale.copyPassword}</a>
+                    </Space>,
+                    <Space key="copy-success" size={token.marginXXS}>
+                      <CheckOutlined aria-hidden />
+                      <a>{cloudLocale.copyPassword}</a>
+                    </Space>,
+                  ],
+                  tooltips: [cloudLocale.copyPassword, cloudLocale.copySuccessfully],
+                }}
+                style={{ marginLeft: token.marginXXS }}
+              />
+            </div>
+          ) : (
+            <div role="alert" style={{ color: token.colorError }}>
+              {blurFeedbackMessage}
+            </div>
+          )}
         </div>
       )}
-    </>
+    </div>
   );
 };
 

--- a/packages/ui/src/Password/locale/en-US.ts
+++ b/packages/ui/src/Password/locale/en-US.ts
@@ -1,14 +1,20 @@
+import { CLOUD_PASSWORD_SPECIAL_CHARS_DISPLAY_SPACED } from '../Content';
+
 export default {
-  lengthRuleMessage: '8 to 32 characters',
-  charRuleMessage:
-    'Contains only letters, numbers and symbols including ~!@#%^&*_-+=|(){}[]:;,.?/`$"<>\\',
-  strengthRuleMessage:
-    'Containes at least 2 characters for each of uppercase letters, lowercase letters, numbers and symbols',
+  lengthRuleMessage: 'Should be 8 to 20 characters in length',
+  charRuleMessage: `Can only contain letters, numbers, and special characters (${CLOUD_PASSWORD_SPECIAL_CHARS_DISPLAY_SPACED})`,
+  strengthRuleMessage: 'Must include at least 3 of the following: uppercase',
+  strengthRuleMessageLine2: 'letters, lowercase letters, numbers, special characters',
   placeholder: 'Please enter the password',
   generatePlaceholder: 'Enter or randomly generate',
   randomlyGenerate: 'Randomly generate',
-  pleaseRememberYourPassword: 'Please remember and keep your password.',
+  pleaseRememberYourPassword: 'Please remember and keep your password',
   copySuccessfully: 'Copied',
   copyPassword: 'Copy Password',
   passwordStrengthRules: 'Password strength rules',
+  emptyMessage: 'Please enter your password',
+  forbiddenCharsMessage: 'Cannot contain spaces, emojis, tab characters, or Chinese characters',
+  genericFailMessage: 'The password does not meet the requirements. Please follow the rules',
+  confirmMismatchMessage:
+    'The password you entered here does not match the password you entered above',
 };

--- a/packages/ui/src/Password/locale/ja-JP.ts
+++ b/packages/ui/src/Password/locale/ja-JP.ts
@@ -1,7 +1,10 @@
+import { CLOUD_PASSWORD_SPECIAL_CHARS_DISPLAY_SPACED } from '../Content';
+
 export default {
-  lengthRuleMessage: '長さは 8~32 文字',
-  charRuleMessage: '英字、数字、および特殊文字（~!@#%^&*_-+= (){}[]:;,.?/`$"<>\）のみ使用可能',
-  strengthRuleMessage: '大文字・小文字・数字・特殊文字をそれぞれ2文字以上含める必要があります',
+  lengthRuleMessage: '8〜20 文字の長さ',
+  charRuleMessage: `英字、数字、特殊文字（${CLOUD_PASSWORD_SPECIAL_CHARS_DISPLAY_SPACED}）のみ使用可能`,
+  strengthRuleMessage: '大文字・小文字・数字・特殊文字のうち少なくとも 3 種類を含める',
+  strengthRuleMessageLine2: '',
   placeholder: 'パスワードを入力してください',
   generatePlaceholder: '入力またはランダム生成',
   randomlyGenerate: 'ランダム生成',
@@ -10,4 +13,8 @@ export default {
   copyPassword: 'パスワードをコピーし',
   passwordStrengthRules: 'パスワード強度ルール',
   andKeepItProperly: '適切に保管してください',
+  emptyMessage: 'パスワードを入力してください',
+  forbiddenCharsMessage: 'スペース、絵文字、タブ文字、中国語などの文字は使用できません',
+  genericFailMessage: 'パスワードが要件を満たしていません。ルールに従って修正してください',
+  confirmMismatchMessage: 'ここで入力したパスワードは、上で入力したパスワードと一致しません',
 };

--- a/packages/ui/src/Password/locale/zh-CN.ts
+++ b/packages/ui/src/Password/locale/zh-CN.ts
@@ -1,7 +1,10 @@
+import { CLOUD_PASSWORD_SPECIAL_CHARS_DISPLAY_SPACED } from '../Content';
+
 export default {
-  lengthRuleMessage: '长度为 8~32 个字符',
-  charRuleMessage: '只能包含字母、数字和特殊字符（~!@#%^&*_-+=|(){}[]:;,.?/`$"<>\\）',
-  strengthRuleMessage: '大小写字母、数字和特殊字符都至少包含 2 个',
+  lengthRuleMessage: '长度为 8~20 个字符',
+  charRuleMessage: `只能包含字母、数字和特殊字符 (${CLOUD_PASSWORD_SPECIAL_CHARS_DISPLAY_SPACED})`,
+  strengthRuleMessage: '大写字母、小写字母、数字、特殊字符，至少包含 3 种',
+  strengthRuleMessageLine2: '',
   placeholder: '请输入密码',
   generatePlaceholder: '请输入或随机生成',
   randomlyGenerate: '随机生成',
@@ -10,4 +13,8 @@ export default {
   copyPassword: '复制密码',
   passwordStrengthRules: '密码强度规则',
   andKeepItProperly: '并妥善保存',
+  emptyMessage: '请输入密码',
+  forbiddenCharsMessage: '不能包含空格、表情符号、制表符或中文等字符',
+  genericFailMessage: '密码不符合要求，请按规则修改',
+  confirmMismatchMessage: '此处输入的密码与上方输入的密码不一致',
 };

--- a/packages/ui/src/Password/locale/zh-TW.ts
+++ b/packages/ui/src/Password/locale/zh-TW.ts
@@ -1,7 +1,10 @@
+import { CLOUD_PASSWORD_SPECIAL_CHARS_DISPLAY_SPACED } from '../Content';
+
 export default {
-  lengthRuleMessage: '長度為 8~32 個字符',
-  charRuleMessage: '只能包含字母、數字和特殊字符（~!@#%^&*_-+=|(){}[]:;,.?/`$"<>\\）',
-  strengthRuleMessage: '大小寫字母、數字和特殊字符都至少包含 2 個',
+  lengthRuleMessage: '長度為 8~20 個字符',
+  charRuleMessage: `只能包含字母、數字和特殊字符 (${CLOUD_PASSWORD_SPECIAL_CHARS_DISPLAY_SPACED})`,
+  strengthRuleMessage: '大寫字母、小寫字母、數字、特殊字符至少包含 3 種',
+  strengthRuleMessageLine2: '',
   placeholder: '請輸入密碼',
   generatePlaceholder: '請輸入或隨機生成',
   randomlyGenerate: '隨機生成',
@@ -9,4 +12,8 @@ export default {
   copySuccessfully: '複製成功',
   copyPassword: '複製密碼',
   passwordStrengthRules: '密碼強度規則',
+  emptyMessage: '請輸入密碼',
+  forbiddenCharsMessage: '不能包含空格、表情符號、製表符或中文等字符',
+  genericFailMessage: '密碼不符合要求，請按規則修改',
+  confirmMismatchMessage: '此處輸入的密碼與上方輸入的密碼不一致',
 };


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [x] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Align `@oceanbase/ui` Password with the multi-cloud password spec (8–20 chars, 3-of-4 character classes, forbidden chars) and the change-password interaction pattern.

- **Password (`@oceanbase/ui`)**: strength popover, blur feedback messages, copy hint; validation timing delegated to Form; demos and docs updated.
- **Input.Password (`@oceanbase/design`)**: `autoComplete="new-password"` suppresses browser saved-password dropdown overlap.
- **RegisterForm**: uses shared cloud password validator and Password component.

**Breaking**: default cloud password rules changed from 8–32 with at least 2 of each class to 8–20 with 3-of-4 classes.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Password<br/>&nbsp;&nbsp;- 💥 Default rules align with multi-cloud spec (8–20 chars, 3-of-4 types; was 8–32 and 2-of-4).<br/>&nbsp;&nbsp;- ✨ Change-password flow: `mode="plain"` for current password, blur feedback, remember/copy hint; Form handles validation timing.<br/>&nbsp;&nbsp;- 🌐 Updated validation messages (zh-CN, en-US, zh-TW, ja-JP).<br/>- Login RegisterForm<br/>&nbsp;&nbsp;- ✨ Uses Password component and shared cloud password validation.<br/>- Input.Password<br/>&nbsp;&nbsp;- ✨ `autoComplete="new-password"` reduces saved-password dropdown overlap. |
| 🇨🇳 Chinese | - Password<br/>&nbsp;&nbsp;- 💥 默认规则对齐多云规范（8–20 位、四类至少 3 种；原为 8–32、各类至少 2 种）。<br/>&nbsp;&nbsp;- ✨ 修改密码场景：`mode="plain"` 当前密码、失焦反馈与牢记/复制提示；校验时机由 Form 负责。<br/>&nbsp;&nbsp;- 🌐 更新四语言校验文案。<br/>- Login RegisterForm<br/>&nbsp;&nbsp;- ✨ 接入 Password 组件与多云密码校验。<br/>- Input.Password<br/>&nbsp;&nbsp;- ✨ `autoComplete="new-password"` 减轻已保存密码下拉遮挡。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed


Made with [Cursor](https://cursor.com)