### PR TITLE
feat(ui): built-in Password blur feedback in Form.Item explain

### DIFF
--- a/packages/design/src/form/FormItem.tsx
+++ b/packages/design/src/form/FormItem.tsx
@@ -9,6 +9,10 @@ import classNames from 'classnames';
 import ConfigProvider from '../config-provider';
 import type { TooltipProps } from '../tooltip';
 import { useTooltipTypeList } from '../tooltip/hooks/useTooltipTypeList';
+import {
+  FormItemChildFeedbackProvider,
+  useFormItemChildFeedbackState,
+} from './FormItemChildFeedback';
 import useStyle from './style';
 
 const AntFormItem = AntForm.Item;
@@ -40,8 +44,17 @@ const FormItem: CompoundedComponent = ({
   layout: externalLayout,
   prefixCls: customizePrefixCls,
   className,
+  help: propHelp,
+  validateStatus: propValidateStatus,
   ...restProps
 }) => {
+  const { childFeedback, contextValue } = useFormItemChildFeedbackState();
+  // Child feedback is opt-in (e.g. Password blur hints). When absent, props pass through unchanged.
+  const mergedHelp = childFeedback != null ? (childFeedback.help ?? propHelp) : propHelp;
+  const mergedValidateStatus =
+    childFeedback != null
+      ? (childFeedback.validateStatus ?? propValidateStatus)
+      : propValidateStatus;
   const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
 
   const prefixCls = getPrefixCls('form', customizePrefixCls);
@@ -86,29 +99,33 @@ const FormItem: CompoundedComponent = ({
     ) : null;
 
   return wrapCSSVar(
-    <AntFormItem
-      layout={layout}
-      label={
-        actionContent || descriptionContent ? (
-          <div>
-            {label}
-            {actionContent}
-            {descriptionContent}
-          </div>
-        ) : (
-          label
-        )
-      }
-      tooltip={tooltip}
-      // auto set required for Switch children to hide optional mark
-      // @ts-ignore
-      required={isPlainObject(children) && children.type?.__ANT_SWITCH ? true : undefined}
-      prefixCls={customizePrefixCls}
-      className={formItemCls}
-      {...restProps}
-    >
-      {children}
-    </AntFormItem>
+    <FormItemChildFeedbackProvider contextValue={contextValue}>
+      <AntFormItem
+        layout={layout}
+        label={
+          actionContent || descriptionContent ? (
+            <div>
+              {label}
+              {actionContent}
+              {descriptionContent}
+            </div>
+          ) : (
+            label
+          )
+        }
+        tooltip={tooltip}
+        help={mergedHelp}
+        validateStatus={mergedValidateStatus}
+        // auto set required for Switch children to hide optional mark
+        // @ts-ignore
+        required={isPlainObject(children) && children.type?.__ANT_SWITCH ? true : undefined}
+        prefixCls={customizePrefixCls}
+        className={formItemCls}
+        {...restProps}
+      >
+        {children}
+      </AntFormItem>
+    </FormItemChildFeedbackProvider>
   );
 };
 

--- a/packages/design/src/form/FormItemChildFeedback.tsx
+++ b/packages/design/src/form/FormItemChildFeedback.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+
+export type FormItemChildFeedback = {
+  help?: ReactNode;
+  validateStatus?: 'success' | 'warning' | 'error' | 'validating';
+} | null;
+
+type FormItemChildFeedbackContextValue = {
+  setFeedback: (feedback: FormItemChildFeedback) => void;
+};
+
+const FormItemChildFeedbackContext = createContext<FormItemChildFeedbackContextValue | null>(null);
+
+/** Internal: used by built-in field components inside Form.Item (e.g. Password). */
+export function useFormItemChildFeedback() {
+  return useContext(FormItemChildFeedbackContext);
+}
+
+export function FormItemChildFeedbackProvider({
+  children,
+  contextValue,
+}: {
+  children: ReactNode;
+  contextValue: FormItemChildFeedbackContextValue;
+}) {
+  return (
+    <FormItemChildFeedbackContext.Provider value={contextValue}>
+      {children}
+    </FormItemChildFeedbackContext.Provider>
+  );
+}
+
+export function useFormItemChildFeedbackState() {
+  const [childFeedback, setChildFeedbackState] = useState<FormItemChildFeedback>(null);
+
+  const setFeedback = useCallback((feedback: FormItemChildFeedback) => {
+    setChildFeedbackState(feedback);
+  }, []);
+
+  const contextValue = useMemo(() => ({ setFeedback }), [setFeedback]);
+
+  return { childFeedback, contextValue };
+}

--- a/packages/design/src/form/__tests__/FormItemChildFeedback.test.tsx
+++ b/packages/design/src/form/__tests__/FormItemChildFeedback.test.tsx
@@ -1,0 +1,206 @@
+import React, { useEffect } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Form, Input } from '@oceanbase/design';
+import { useFormItemChildFeedback } from '../FormItemChildFeedback';
+
+function ChildWithFeedback({ message }: { message: string }) {
+  const childFeedback = useFormItemChildFeedback();
+
+  useEffect(() => {
+    if (!childFeedback) return;
+    childFeedback.setFeedback({ help: message, validateStatus: 'error' });
+    return () => childFeedback.setFeedback(null);
+  }, [childFeedback, message]);
+
+  return <input aria-label="child-input" />;
+}
+
+function FeedbackToggleWrapper({ showFeedback }: { showFeedback: boolean }) {
+  return (
+    <Form>
+      <Form.Item label="Test" name="test" help="Static help">
+        {showFeedback ? (
+          <ChildWithFeedback message="Child help message" />
+        ) : (
+          <input aria-label="plain-input" />
+        )}
+      </Form.Item>
+    </Form>
+  );
+}
+
+describe('Form.Item child feedback', () => {
+  it('merges child feedback into explain', () => {
+    render(
+      <Form>
+        <Form.Item label="Test" name="test">
+          <ChildWithFeedback message="Child help message" />
+        </Form.Item>
+      </Form>
+    );
+
+    expect(screen.getByText('Child help message')).toBeTruthy();
+  });
+
+  it('prefers child feedback over static help', () => {
+    render(
+      <Form>
+        <Form.Item label="Test" name="test" help="Static help">
+          <ChildWithFeedback message="Child help message" />
+        </Form.Item>
+      </Form>
+    );
+
+    expect(screen.getByText('Child help message')).toBeTruthy();
+    expect(screen.queryByText('Static help')).toBeFalsy();
+  });
+
+  it('keeps static help when child does not report feedback', () => {
+    render(
+      <Form>
+        <Form.Item label="Test" name="test" help="Static help">
+          <input aria-label="plain-input" />
+        </Form.Item>
+      </Form>
+    );
+
+    expect(screen.getByText('Static help')).toBeTruthy();
+  });
+
+  it('restores static help after child feedback is cleared', () => {
+    const { rerender } = render(<FeedbackToggleWrapper showFeedback={true} />);
+
+    expect(screen.getByText('Child help message')).toBeTruthy();
+
+    rerender(<FeedbackToggleWrapper showFeedback={false} />);
+
+    expect(screen.getByText('Static help')).toBeTruthy();
+    expect(screen.queryByText('Child help message')).toBeFalsy();
+  });
+
+  it('supports function children without wrapping provider', () => {
+    render(
+      <Form initialValues={{ other: 'value' }}>
+        <Form.Item label="Test" shouldUpdate>
+          {() => <input data-testid="render-prop-input" readOnly value="rendered" />}
+        </Form.Item>
+      </Form>
+    );
+
+    expect(screen.getByTestId('render-prop-input')).toBeTruthy();
+    expect(screen.getByDisplayValue('rendered')).toBeTruthy();
+  });
+
+  it('applies child validateStatus to form item', () => {
+    const { container } = render(
+      <Form>
+        <Form.Item label="Test" name="test">
+          <ChildWithFeedback message="Child help message" />
+        </Form.Item>
+      </Form>
+    );
+
+    expect(container.querySelector('.ant-form-item-has-error')).toBeTruthy();
+  });
+});
+
+describe('Form.Item regression: existing usage without child feedback', () => {
+  it('renders Input inside Form.Item as before', () => {
+    render(
+      <Form>
+        <Form.Item label="Name" name="name">
+          <Input aria-label="name-input" />
+        </Form.Item>
+      </Form>
+    );
+
+    expect(screen.getByLabelText('name-input')).toBeTruthy();
+  });
+
+  it('keeps field id on control for label association', () => {
+    render(
+      <Form>
+        <Form.Item label="Name" name="name">
+          <Input />
+        </Form.Item>
+      </Form>
+    );
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('id', 'name');
+  });
+
+  it('keeps validateStatus from Form.Item props', () => {
+    const { container } = render(
+      <Form>
+        <Form.Item label="Name" name="name" help="Warning text" validateStatus="warning">
+          <Input />
+        </Form.Item>
+      </Form>
+    );
+
+    expect(screen.getByText('Warning text')).toBeTruthy();
+    expect(container.querySelector('.ant-form-item-has-warning')).toBeTruthy();
+    expect(container.querySelector('.ant-form-item-has-error')).toBeFalsy();
+  });
+
+  it('keeps extra below the control', () => {
+    render(
+      <Form>
+        <Form.Item label="Name" name="name" extra="Extra hint">
+          <Input />
+        </Form.Item>
+      </Form>
+    );
+
+    expect(screen.getByText('Extra hint')).toBeTruthy();
+  });
+
+  it('keeps rules validation errors in explain', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Form>
+        <Form.Item
+          label="Name"
+          name="name"
+          rules={[{ required: true, message: 'Name is required' }]}
+        >
+          <Input />
+        </Form.Item>
+        <button type="submit">Submit</button>
+      </Form>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Name is required')).toBeTruthy();
+    });
+  });
+
+  it('does not override props when child feedback is cleared to null', () => {
+    function ClearingChild() {
+      const childFeedback = useFormItemChildFeedback();
+
+      useEffect(() => {
+        childFeedback?.setFeedback({ help: 'Transient help', validateStatus: 'error' });
+        childFeedback?.setFeedback(null);
+      }, [childFeedback]);
+
+      return <Input />;
+    }
+
+    const { container } = render(
+      <Form>
+        <Form.Item label="Name" name="name" help="Static help" validateStatus="warning">
+          <ClearingChild />
+        </Form.Item>
+      </Form>
+    );
+
+    expect(screen.getByText('Static help')).toBeTruthy();
+    expect(container.querySelector('.ant-form-item-has-warning')).toBeTruthy();
+    expect(container.querySelector('.ant-form-item-has-error')).toBeFalsy();
+  });
+});

--- a/packages/design/src/form/index.tsx
+++ b/packages/design/src/form/index.tsx
@@ -4,6 +4,7 @@ import type { FormProps as AntFormProps } from 'antd/es/form';
 import classNames from 'classnames';
 import ConfigProvider from '../config-provider';
 import Item from './FormItem';
+import { useFormItemChildFeedback } from './FormItemChildFeedback';
 import useStyle from './style';
 import type { FormReValidateMode, FormValidateMode, OBFormConfig } from './validateMode';
 import {
@@ -35,6 +36,7 @@ type CompoundedComponent = React.FC<FormProps> & {
   useForm: typeof AntForm.useForm;
   useFormInstance: typeof AntForm.useFormInstance;
   useWatch: typeof AntForm.useWatch;
+  useFormItemChildFeedback: typeof useFormItemChildFeedback;
   Provider: typeof AntForm.Provider;
   create: typeof AntForm.create;
 };
@@ -177,6 +179,7 @@ Form.ErrorList = AntForm.ErrorList;
 Form.useForm = AntForm.useForm;
 Form.useFormInstance = AntForm.useFormInstance;
 Form.useWatch = AntForm.useWatch;
+Form.useFormItemChildFeedback = useFormItemChildFeedback;
 Form.Provider = AntForm.Provider;
 Form.create = AntForm.create;
 

--- a/packages/ui/src/Password/RememberHint.tsx
+++ b/packages/ui/src/Password/RememberHint.tsx
@@ -1,0 +1,34 @@
+import { Space, Typography, theme } from '@oceanbase/design';
+import React from 'react';
+import { CheckOutlined, CopyOutlined } from '@oceanbase/icons';
+import type { PasswordLocale } from './index';
+
+export const PasswordRememberHint: React.FC<{
+  value?: string;
+  locale: PasswordLocale;
+}> = ({ value, locale }) => {
+  const { token } = theme.useToken();
+
+  return (
+    <span style={{ color: token.colorTextDescription }}>
+      {locale.pleaseRememberYourPassword}
+      <Typography.Text
+        copyable={{
+          text: value,
+          icon: [
+            <Space key="copy" size={token.marginXXS}>
+              <CopyOutlined aria-hidden />
+              <a>{locale.copyPassword}</a>
+            </Space>,
+            <Space key="copy-success" size={token.marginXXS}>
+              <CheckOutlined aria-hidden />
+              <a>{locale.copyPassword}</a>
+            </Space>,
+          ],
+          tooltips: [locale.copyPassword, locale.copySuccessfully],
+        }}
+        style={{ marginLeft: token.marginXXS }}
+      />
+    </span>
+  );
+};

--- a/packages/ui/src/Password/__tests__/rememberHint.test.tsx
+++ b/packages/ui/src/Password/__tests__/rememberHint.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Form } from '@oceanbase/design';
+import Password from '../index';
+
+const VALID_PASSWORD = 'Abcdef12';
+const REMEMBER_TEXT = '请牢记并妥善保存密码';
+
+describe('Password remember hint in Form.Item', () => {
+  it('shows remember hint in Form.Item explain after valid blur', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Form>
+        <Form.Item name="password" label="Password">
+          <Password />
+        </Form.Item>
+      </Form>
+    );
+
+    const passwordInput = document.querySelector('input[type="password"]') as HTMLInputElement;
+    expect(passwordInput).toBeTruthy();
+
+    await user.type(passwordInput, VALID_PASSWORD);
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText(REMEMBER_TEXT, { exact: false })).toBeTruthy();
+    });
+  });
+});

--- a/packages/ui/src/Password/demo/change-password-scenario.tsx
+++ b/packages/ui/src/Password/demo/change-password-scenario.tsx
@@ -24,7 +24,7 @@ export default () => {
             label="Current password"
             rules={[{ required: true, message: 'Please enter current password' }]}
           >
-            <Password mode="plain" />
+            <Password autoComplete="current-password" />
           </Form.Item>
           <Form.Item
             name="newPassword"

--- a/packages/ui/src/Password/index.en-US.md
+++ b/packages/ui/src/Password/index.en-US.md
@@ -24,7 +24,9 @@ Built-in defaults follow the multi-cloud password spec (**Breaking**: was length
 - **At least 3 of 4** classes: uppercase, lowercase, digits, special characters
 - No spaces, tabs, newlines, emoji, or CJK characters (shown on blur; not listed as a separate popover rule)
 
-On focus, a popover shows the three rules above and a strength bar. `mode="new"` defaults to `autoComplete="new-password"` to reduce saved-password dropdown overlap. For tenant DB accounts (**8–64**, etc.), override with custom `rules` / `generatePasswordRegex`.
+On focus, a popover shows the three rules above and a strength bar. Defaults to `autoComplete="new-password"` to reduce saved-password dropdown overlap; `autoComplete="current-password"` skips the strength popover for current-password fields.
+
+For tenant DB accounts (**8–64**, etc.), override with custom `rules` / `generatePasswordRegex`.
 
 ## Form integration
 
@@ -49,8 +51,17 @@ import { Password } from '@oceanbase/ui';
 
 Use `ConfigProvider` `locale.Password` for messages (`emptyMessage`, `genericFailMessage`, `forbiddenCharsMessage`, etc.). For custom `rules` / `generatePasswordRegex`, keep `Form.Item` validators or patterns aligned with the component `rules`.
 
-- **New password**: `<Password />` (`mode="new"`). Form validation errors use `Form.Item` explain. Blur rule messages and the copy hint are absolutely positioned below the input (no document-flow height).
-- **Current password**: `<Password mode="plain" />` with `required` only; map API accuracy errors on submit.
+- **New password**: `<Password />` (default `autoComplete="new-password"`). Inside `Form.Item`, use it like `Input` — blur rule messages and the copy hint are written to `Form.Item` explain automatically.
+
+```tsx
+<Form.Item name="password" rules={[...]}>
+  <Password />
+</Form.Item>
+```
+
+Outside `Form.Item`, blur feedback stays inline below the control.
+
+- **Current password**: `<Password autoComplete="current-password" />` with `required` only; map API accuracy errors on submit.
 - **Confirm password**: `Input.Password` + match validator.
 - **Registration**: `Login` `RegisterForm` includes cloud password validation out of the box.
 
@@ -58,7 +69,7 @@ Use `ConfigProvider` `locale.Password` for messages (`emptyMessage`, `genericFai
 
 | Property | Description | Type | Default | Version |
 | :-- | :-- | :-- | :-- | :-- |
-| mode | `new` shows strength popover on focus; `plain` is a simple input | `'new' \| 'plain'` | `'new'` | - |
+| autoComplete | Browser autofill hint; `new-password` shows strength popover, `current-password` is a plain current-password field | string | `'new-password'` | - |
 | rules | Rules shown in the popover (UI only; Form handles validation timing) | [Validator](password#validator)[] | Cloud defaults | - |
 | generatePasswordRegex | Regex for random password; non-empty shows generate button | RegExp | - | - |
 | value | Password value | string | - | - |

--- a/packages/ui/src/Password/index.md
+++ b/packages/ui/src/Password/index.md
@@ -24,7 +24,7 @@ nav:
 - 大写字母、小写字母、数字、特殊字符，**至少包含 3 种**
 - 禁止空格、Tab、换行、emoji、中文等（失焦时报错，不单独展示为气泡规则）
 
-聚焦时通过气泡展示上述三条规则及强度进度。`mode="new"` 默认 `autoComplete="new-password"`，减轻浏览器已保存密码下拉遮挡气泡。
+聚焦时通过气泡展示上述三条规则及强度进度。默认 `autoComplete="new-password"`，减轻浏览器已保存密码下拉遮挡气泡；当前密码使用 `autoComplete="current-password"` 时不展示强度气泡。
 
 租户建库等 **8~64** 场景请通过 `rules` / `generatePasswordRegex` 自定义覆盖。
 
@@ -51,8 +51,17 @@ import { Password } from '@oceanbase/ui';
 
 文案可来自 `ConfigProvider` 的 `locale.Password`（`emptyMessage`、`genericFailMessage`、`forbiddenCharsMessage` 等）。自定义 `rules` / `generatePasswordRegex` 时，在 `Form.Item` 中用对应的 `validator` 或 `pattern` 与组件 `rules` 保持一致。
 
-- **新密码**：`<Password />`（`mode="new"`）；Form 校验报错由 `Form.Item` explain 展示；失焦后的规则分析文案与「请牢记并妥善保存密码」以绝对定位输出在输入框下方，不占文档流高度、不挤压布局。
-- **当前密码**：`<Password mode="plain" />`，仅 `required`，不校验格式（允许空格等）；准确性由提交时接口报错映射到字段。
+- **新密码**：`<Password />`（默认 `autoComplete="new-password"`）；在 `Form.Item` 内与 `Input` 用法相同，失焦规则分析与「请牢记密码」会自动写入 `Form.Item` explain，与校验文案共用同一区域。
+
+```tsx
+<Form.Item name="password" rules={[...]}>
+  <Password />
+</Form.Item>
+```
+
+非 `Form.Item` 场景下，失焦文案仍以内联方式展示在控件下方。
+
+- **当前密码**：`<Password autoComplete="current-password" />`，仅 `required`，不校验格式（允许空格等）；准确性由提交时接口报错映射到字段。
 - **确认密码**：`Input.Password` + 一致性 `validator`。
 - **注册表单**：`Login` 的 `RegisterForm` 已内置多云密码校验，可直接使用。
 
@@ -60,7 +69,7 @@ import { Password } from '@oceanbase/ui';
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | :-- | :-- | :-- | :-- | :-- |
-| mode | `new` 聚焦展示规则气泡；`plain` 为简单密码输入（当前密码） | `'new' \| 'plain'` | `'new'` | - |
+| autoComplete | 浏览器自动填充提示；`new-password` 展示强度气泡，`current-password` 为简单当前密码输入 | string | `'new-password'` | - |
 | rules | 气泡内展示的密码规则（仅 UI，校验时机由 Form 负责） | [Validator](password#validator)[] | 多云默认规则 | - |
 | generatePasswordRegex | 随机生成密码的正则表达式，不为空则展示随机生成的按钮 | RegExp | - | - |
 | value | 密码框内容 | string | - | - |

--- a/packages/ui/src/Password/index.tsx
+++ b/packages/ui/src/Password/index.tsx
@@ -1,8 +1,8 @@
-import { Button, Form, Input, Popover, Space, Typography, theme } from '@oceanbase/design';
+import { Button, Form, Input, Popover, theme } from '@oceanbase/design';
+import type { FormItemChildFeedback } from '@oceanbase/design/es/form/FormItemChildFeedback';
 import type { PasswordProps as InputPasswordProps } from '@oceanbase/design/es/input';
 import RandExp from 'randexp';
-import React, { useCallback, useEffect, useId, useState } from 'react';
-import { CheckOutlined, CopyOutlined } from '@oceanbase/icons';
+import React, { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import type { LocaleWrapperProps } from '../locale/LocaleWrapper';
 import LocaleWrapper from '../locale/LocaleWrapper';
 import Content, {
@@ -13,10 +13,12 @@ import Content, {
   type Validator,
 } from './Content';
 import zhCN from './locale/zh-CN';
+import { PasswordRememberHint } from './RememberHint';
 
 type FormItemInputContextValue = {
   status?: string;
   isFormItemInput?: boolean;
+  errors?: string[];
 };
 
 const FormItemInputContext =
@@ -44,8 +46,6 @@ export interface PasswordProps extends LocaleWrapperProps, Omit<InputPasswordPro
   rules?: Validator[];
   generatePasswordRegex?: RegExp;
   locale?: PasswordLocale;
-  /** `new` shows strength popover; `plain` is a simple password input for current password. */
-  mode?: 'new' | 'plain';
 }
 
 const Password: React.FC<PasswordProps> = ({
@@ -55,7 +55,6 @@ const Password: React.FC<PasswordProps> = ({
   onChange,
   generatePassword,
   generatePasswordRegex,
-  mode = 'new',
   onFocus: restOnFocus,
   onBlur: restOnBlur,
   autoComplete: autoCompleteProp,
@@ -63,13 +62,16 @@ const Password: React.FC<PasswordProps> = ({
   ...restProps
 }) => {
   const { token } = theme.useToken();
+  const autoComplete = autoCompleteProp ?? 'new-password';
+  const isCurrentPassword = autoComplete === 'current-password';
   const [isFocused, setIsFocused] = useState(false);
   const [hasBlurred, setHasBlurred] = useState(false);
   const [displayValue, setDisplayValue] = useState<string | undefined>(value);
   const strengthRulesId = useId();
+  const formItemChildFeedback = Form.useFormItemChildFeedback();
   const formItemStatus = React.useContext(FormItemInputContext);
   const isInFormItem = Boolean(formItemStatus?.isFormItemInput);
-  const formHasError = isInFormItem && formItemStatus?.status === 'error';
+  const formHasError = isInFormItem && (formItemStatus?.errors?.length ?? 0) > 0;
 
   useEffect(() => {
     setDisplayValue(value);
@@ -80,7 +82,7 @@ const Password: React.FC<PasswordProps> = ({
 
   const getAnalysis = useCallback(
     (newValue?: string, interactive = false) => {
-      if (mode === 'plain') {
+      if (isCurrentPassword) {
         const empty = !newValue;
         return {
           passed: !empty,
@@ -93,19 +95,42 @@ const Password: React.FC<PasswordProps> = ({
       }
       return analyzeCloudPassword(newValue, cloudLocale, { touched: interactive });
     },
-    [cloudLocale, mode]
+    [cloudLocale, isCurrentPassword]
   );
 
   const popoverInteractive = Boolean(displayValue) || isFocused;
   const analysis = getAnalysis(displayValue, popoverInteractive || hasBlurred);
   const blurFeedbackMessage = hasBlurred && !formHasError ? analysis.fieldError : undefined;
   const showRememberHint =
-    mode === 'new' &&
-    value &&
+    !isCurrentPassword &&
+    displayValue &&
     analysis.passed &&
     !blurFeedbackMessage &&
     !formHasError &&
     hasBlurred;
+
+  const fieldFeedback = useMemo((): FormItemChildFeedback => {
+    if (formHasError) return null;
+    if (blurFeedbackMessage) return { help: blurFeedbackMessage, validateStatus: 'error' };
+    if (showRememberHint) {
+      return {
+        help: <PasswordRememberHint value={displayValue} locale={cloudLocale} />,
+      };
+    }
+    return null;
+  }, [formHasError, blurFeedbackMessage, showRememberHint, displayValue, cloudLocale]);
+
+  useEffect(() => {
+    if (!formItemChildFeedback) return;
+    formItemChildFeedback.setFeedback(fieldFeedback);
+  }, [formItemChildFeedback, fieldFeedback]);
+
+  useEffect(() => {
+    if (!formItemChildFeedback) return;
+    return () => formItemChildFeedback.setFeedback(null);
+  }, [formItemChildFeedback]);
+
+  const showInlineFeedback = !formItemChildFeedback && (blurFeedbackMessage || showRememberHint);
 
   const getRandomPassword = () => {
     const newValue = new RandExp(generatePasswordRegex!).gen();
@@ -119,10 +144,10 @@ const Password: React.FC<PasswordProps> = ({
     <Input.Password
       {...restProps}
       value={value}
-      autoComplete={autoCompleteProp ?? (mode === 'plain' ? 'current-password' : 'new-password')}
+      autoComplete={autoComplete}
       readOnly={readOnlyProp}
-      aria-haspopup={mode === 'new' ? 'dialog' : undefined}
-      aria-describedby={mode === 'new' ? strengthRulesId : undefined}
+      aria-haspopup={!isCurrentPassword ? 'dialog' : undefined}
+      aria-describedby={!isCurrentPassword ? strengthRulesId : undefined}
       onChange={e => {
         const newValue = e?.target?.value;
         setDisplayValue(newValue);
@@ -144,9 +169,9 @@ const Password: React.FC<PasswordProps> = ({
   );
 
   return (
-    <div style={{ position: 'relative', width: '100%' }}>
+    <div style={{ width: '100%' }}>
       <div style={{ display: 'flex' }}>
-        {mode === 'new' ? (
+        {!isCurrentPassword ? (
           <Popover
             open={isFocused}
             onOpenChange={open => {
@@ -198,39 +223,16 @@ const Password: React.FC<PasswordProps> = ({
           </Button>
         )}
       </div>
-      {(blurFeedbackMessage || showRememberHint) && (
+      {showInlineFeedback && (
         <div
           style={{
-            position: 'absolute',
-            top: '100%',
-            left: 0,
-            width: '100%',
             marginTop: token.marginXXS,
             fontSize: token.fontSizeSM,
-            lineHeight: token.lineHeight,
+            lineHeight: token.lineHeightSM,
           }}
         >
           {showRememberHint ? (
-            <div style={{ color: token.colorTextDescription }}>
-              {cloudLocale.pleaseRememberYourPassword}
-              <Typography.Text
-                copyable={{
-                  text: value,
-                  icon: [
-                    <Space key="copy" size={token.marginXXS}>
-                      <CopyOutlined aria-hidden />
-                      <a>{cloudLocale.copyPassword}</a>
-                    </Space>,
-                    <Space key="copy-success" size={token.marginXXS}>
-                      <CheckOutlined aria-hidden />
-                      <a>{cloudLocale.copyPassword}</a>
-                    </Space>,
-                  ],
-                  tooltips: [cloudLocale.copyPassword, cloudLocale.copySuccessfully],
-                }}
-                style={{ marginLeft: token.marginXXS }}
-              />
-            </div>
+            <PasswordRememberHint value={displayValue} locale={cloudLocale} />
           ) : (
             <div role="alert" style={{ color: token.colorError }}>
               {blurFeedbackMessage}


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [x] @oceanbase/ui

### 🤔 This is a ...

- [x] New feature
- [x] Enhancement feature
- [x] Test Case

### 🔗 Related issue link

N/A

### 💡 Background and solution

Password blur validation messages and the “remember your password” hint need to appear in `Form.Item` explain (same slot as rule errors) to avoid overlapping Submit and extra layout shift.

**Solution:**
- `Form.Item` merges built-in field feedback from child controls into explain when present.
- `Password` in `Form.Item` works like `Input` — no manual `help` wiring. Blur errors and the remember hint are shown in explain automatically; non-Form usage keeps inline fallback below the control.
- Current-password fields use `autoComplete="current-password"` (no strength popover); new-password fields default to `autoComplete="new-password"`.

| Before | After |
| :--- | :--- |
| Required `usePasswordFieldFeedback` + `help` on `Form.Item` | `<Form.Item><Password /></Form.Item>` only |

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Form<br/>&nbsp;&nbsp;- 🆕 `Form.Item` explain can show built-in blur and hint feedback from child controls in the same area as rule errors.<br/>- Password<br/>&nbsp;&nbsp;- 🆕 Blur rule messages and the “remember your password” hint automatically appear in `Form.Item` explain when used inside `Form.Item`; usage matches other form controls.<br/>&nbsp;&nbsp;- 🆕 Defaults to `autoComplete="new-password"` (strength popover on focus); use `autoComplete="current-password"` for current-password fields without the strength popover. |
| 🇨🇳 Chinese | - Form<br/>&nbsp;&nbsp;- 🆕 `Form.Item` explain 可与规则报错共用同一区域，展示子控件内置的失焦提示与辅助说明。<br/>- Password<br/>&nbsp;&nbsp;- 🆕 在 `Form.Item` 内使用时，失焦校验与「请牢记密码」提示自动写入 explain，用法与其他表单控件一致。<br/>&nbsp;&nbsp;- 🆕 默认 `autoComplete="new-password"`（聚焦展示强度气泡）；当前密码字段使用 `autoComplete="current-password"`，不展示强度气泡。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed

Made with [Cursor](https://cursor.com)
