### PR TITLE
feat(design): add defaultTheme and compactTheme locale typography presets

### DIFF
--- a/packages/design/src/config-provider/__tests__/localeFontSize.test.ts
+++ b/packages/design/src/config-provider/__tests__/localeFontSize.test.ts
@@ -1,14 +1,4 @@
-import type { ThemeConfig } from 'antd/es/config-provider';
-import defaultTheme from '../../theme/default';
-import zhCN from '../../locale/zh-CN';
-import enUS from '../../locale/en-US';
-import {
-  fontSizeEn,
-  tableCellFontSizeEn,
-  isCnLikeLocale,
-  isEnLikeLocale,
-} from '../../theme/default';
-import { getLocaleFontSizeThemePatch } from '../index';
+import { isCnLikeLocale, isEnLikeLocale } from '../../theme/default';
 
 describe('isCnLikeLocale', () => {
   it('matches zh / ja / ko primary subtags', () => {
@@ -45,69 +35,5 @@ describe('isEnLikeLocale', () => {
     expect(isEnLikeLocale('de-DE')).toBe(false);
     expect(isEnLikeLocale('')).toBe(false);
     expect(isEnLikeLocale(undefined)).toBe(false);
-  });
-});
-
-describe('getLocaleFontSizeThemePatch', () => {
-  const baseTheme = defaultTheme as ThemeConfig;
-  const resolvedFs = baseTheme.token?.fontSize;
-
-  it('returns Cn locale patch for zh locale', () => {
-    const patch = getLocaleFontSizeThemePatch(
-      zhCN as Parameters<typeof getLocaleFontSizeThemePatch>[0],
-      baseTheme,
-      resolvedFs
-    );
-    expect(patch.token?.fontSize).toBe(14);
-    expect(patch.token?.fontHeight).toBe(22);
-    expect(patch.components?.Table?.cellFontSize).toBe(14);
-  });
-
-  it('returns only Table localeEnEmbeddedControls for en locale', () => {
-    expect(
-      getLocaleFontSizeThemePatch(
-        enUS as Parameters<typeof getLocaleFontSizeThemePatch>[0],
-        baseTheme,
-        resolvedFs
-      )
-    ).toEqual({
-      components: { Table: { localeEnEmbeddedControls: true } },
-    });
-  });
-
-  it('does not override custom body fontSize', () => {
-    const custom: ThemeConfig = {
-      ...baseTheme,
-      token: { ...baseTheme.token, fontSize: 16 },
-    };
-    const patch = getLocaleFontSizeThemePatch(
-      zhCN as Parameters<typeof getLocaleFontSizeThemePatch>[0],
-      custom,
-      custom.token?.fontSize
-    );
-    expect(patch.token).toBeUndefined();
-    expect(patch.components?.Table?.cellFontSize).toBe(14);
-  });
-
-  it('does not override custom Table cellFontSize', () => {
-    const custom: ThemeConfig = {
-      ...baseTheme,
-      components: {
-        ...baseTheme.components,
-        Table: { ...baseTheme.components?.Table, cellFontSize: 13 },
-      },
-    };
-    const patch = getLocaleFontSizeThemePatch(
-      zhCN as Parameters<typeof getLocaleFontSizeThemePatch>[0],
-      custom,
-      custom.token?.fontSize
-    );
-    expect(patch.token?.fontSize).toBe(14);
-    expect(patch.components).toBeUndefined();
-  });
-
-  it('uses defaults from defaultTheme for guard values', () => {
-    expect(fontSizeEn).toBe(13);
-    expect(tableCellFontSizeEn).toBe(12);
   });
 });

--- a/packages/design/src/config-provider/__tests__/localeTypography.test.tsx
+++ b/packages/design/src/config-provider/__tests__/localeTypography.test.tsx
@@ -1,0 +1,270 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { ThemeConfig } from 'antd/es/config-provider';
+import { ConfigProvider, useToken } from '@oceanbase/design';
+import seedTheme from '../../theme/default';
+import zhCN from '../../locale/zh-CN';
+import enUS from '../../locale/en-US';
+import { fontFamilyEn } from '../../theme/default';
+import {
+  compactTheme,
+  defaultTheme,
+  isTypographyThemeLocked,
+  resolveLocaleTypographyPatch,
+} from '../../theme/localeTypography';
+
+const seedToken = seedTheme.token!;
+const resolvedTokens = {
+  fontFamily: seedToken.fontFamily!,
+  fontWeightWeak: seedToken.fontWeightWeak!,
+  fontWeight: seedToken.fontWeight!,
+  fontWeightStrong: seedToken.fontWeightStrong!,
+};
+
+describe('locale typography presets', () => {
+  it('exports defaultTheme and compactTheme markers', () => {
+    expect(isTypographyThemeLocked(defaultTheme)).toBe(true);
+    expect(isTypographyThemeLocked(compactTheme)).toBe(true);
+    expect(isTypographyThemeLocked({ ...compactTheme, isDark: true })).toBe(true);
+    expect(isTypographyThemeLocked({ isDark: true })).toBe(false);
+  });
+
+  it('resolveLocaleTypographyPatch returns Cn patch for zh locale', () => {
+    const baseTheme = seedTheme as ThemeConfig;
+    const patch = resolveLocaleTypographyPatch(
+      zhCN,
+      baseTheme,
+      baseTheme.token?.fontSize,
+      resolvedTokens
+    );
+    expect(patch.token?.fontSize).toBe(14);
+    expect(patch.token?.fontHeight).toBe(22);
+    expect(patch.components?.Table?.cellFontSize).toBe(14);
+  });
+
+  it('resolveLocaleTypographyPatch returns en typography patch', () => {
+    const baseTheme = seedTheme as ThemeConfig;
+    const patch = resolveLocaleTypographyPatch(
+      enUS,
+      baseTheme,
+      baseTheme.token?.fontSize,
+      resolvedTokens
+    );
+    expect(patch.token?.fontFamily).toBe(fontFamilyEn);
+    expect(patch.components?.Table?.localeEnEmbeddedControls).toBe(true);
+  });
+
+  it('resolveLocaleTypographyPatch does not override custom Table cellFontSize', () => {
+    const custom: ThemeConfig = {
+      ...seedTheme,
+      components: {
+        ...seedTheme.components,
+        Table: { ...seedTheme.components?.Table, cellFontSize: 13 },
+      },
+    };
+    const patch = resolveLocaleTypographyPatch(
+      zhCN,
+      custom,
+      custom.token?.fontSize,
+      resolvedTokens
+    );
+    expect(patch.token?.fontSize).toBe(14);
+    expect(patch.components?.Table?.cellFontSize).toBeUndefined();
+  });
+
+  it('zh locale without theme uses 14px body and seed fontFamily', () => {
+    const Child = () => {
+      const { token } = useToken();
+      expect(token.fontSize).toBe(14);
+      expect(token.fontFamily).toBe(seedTheme.token.fontFamily);
+      return <div />;
+    };
+    render(
+      <ConfigProvider locale={zhCN}>
+        <Child />
+      </ConfigProvider>
+    );
+  });
+
+  it('en locale without theme uses compact typography', () => {
+    const Child = () => {
+      const { token } = useToken();
+      expect(token.fontSize).toBe(13);
+      expect(token.fontFamily).toBe(fontFamilyEn);
+      return <div />;
+    };
+    render(
+      <ConfigProvider locale={enUS}>
+        <Child />
+      </ConfigProvider>
+    );
+  });
+
+  it('en-US locale string applies fontFamilyEn via isEnLikeLocale', () => {
+    const Child = () => {
+      const { token } = useToken();
+      expect(token.fontFamily).toBe(fontFamilyEn);
+      return <div />;
+    };
+    render(
+      <ConfigProvider locale={{ ...enUS, locale: 'en-US' }}>
+        <Child />
+      </ConfigProvider>
+    );
+  });
+
+  it('custom fontSize guard skips locale body fontSize patch for zh', () => {
+    const Child = () => {
+      const { token } = useToken();
+      expect(token.fontSize).toBe(16);
+      return <div />;
+    };
+    render(
+      <ConfigProvider
+        locale={zhCN}
+        theme={{
+          token: { fontSize: 16 },
+        }}
+      >
+        <Child />
+      </ConfigProvider>
+    );
+  });
+
+  it('custom fontSize guard still patches Table cellFontSize for zh', () => {
+    const customTheme: ThemeConfig = { token: { fontSize: 16 } };
+    const patch = resolveLocaleTypographyPatch(zhCN, customTheme, 16, {
+      fontFamily: seedTheme.token.fontFamily,
+      fontWeightWeak: seedTheme.token.fontWeightWeak,
+      fontWeight: seedTheme.token.fontWeight,
+      fontWeightStrong: seedTheme.token.fontWeightStrong,
+    });
+    expect(patch.token?.fontSize).toBeUndefined();
+    expect(patch.components?.Table?.cellFontSize).toBe(14);
+  });
+
+  it('custom fontFamily guard skips locale fontFamily patch for en', () => {
+    const Child = () => {
+      const { token } = useToken();
+      expect(token.fontFamily).toBe(`'Custom Font'`);
+      return <div />;
+    };
+    render(
+      <ConfigProvider
+        locale={enUS}
+        theme={{
+          token: { fontFamily: `'Custom Font'` },
+        }}
+      >
+        <Child />
+      </ConfigProvider>
+    );
+  });
+
+  it('zh locale with compactTheme locks size but keeps locale fontFamily', () => {
+    const Child = () => {
+      const { token } = useToken();
+      expect(token.fontSize).toBe(13);
+      expect(token.fontFamily).toBe(seedTheme.token.fontFamily);
+      return <div />;
+    };
+    render(
+      <ConfigProvider locale={zhCN} theme={compactTheme}>
+        <Child />
+      </ConfigProvider>
+    );
+  });
+
+  it('en locale with isDark still applies locale typography and dark colors', () => {
+    const Child = () => {
+      const { token } = useToken();
+      expect(token.fontSize).toBe(13);
+      expect(token.fontFamily).toBe(fontFamilyEn);
+      expect(token.colorBgLayout).not.toBe(seedTheme.token.colorBgLayout);
+      return <div />;
+    };
+    render(
+      <ConfigProvider locale={enUS} theme={{ isDark: true }}>
+        <Child />
+      </ConfigProvider>
+    );
+  });
+
+  it('de locale has no compact typography patch', () => {
+    const Child = () => {
+      const { token } = useToken();
+      expect(token.fontSize).toBe(13);
+      expect(token.fontFamily).toBe(seedTheme.token.fontFamily);
+      return <div />;
+    };
+    render(
+      <ConfigProvider locale={{ ...enUS, locale: 'de-DE' }}>
+        <Child />
+      </ConfigProvider>
+    );
+  });
+
+  it('zh locale with defaultTheme preset uses 14px', () => {
+    const custom: ThemeConfig = { ...defaultTheme };
+    const Child = () => {
+      const { token } = useToken();
+      expect(token.fontSize).toBe(14);
+      return <div />;
+    };
+    render(
+      <ConfigProvider locale={zhCN} theme={custom}>
+        <Child />
+      </ConfigProvider>
+    );
+  });
+
+  it('en locale with defaultTheme preset locks size but keeps locale fontFamily', () => {
+    const Child = () => {
+      const { token } = useToken();
+      expect(token.fontSize).toBe(14);
+      expect(token.fontFamily).toBe(fontFamilyEn);
+      return <div />;
+    };
+    render(
+      <ConfigProvider locale={enUS} theme={defaultTheme}>
+        <Child />
+      </ConfigProvider>
+    );
+  });
+
+  it('nested ConfigProvider inherits size lock but font follows child locale', () => {
+    const Child = () => {
+      const { token } = useToken();
+      expect(token.fontSize).toBe(13);
+      expect(token.fontFamily).toBe(fontFamilyEn);
+      return <div />;
+    };
+    render(
+      <ConfigProvider locale={zhCN} theme={compactTheme}>
+        <ConfigProvider locale={enUS}>
+          <Child />
+        </ConfigProvider>
+      </ConfigProvider>
+    );
+  });
+
+  it('spread preset preserves size lock and locale fontFamily on zh', () => {
+    const merged = {
+      ...compactTheme,
+      token: { ...compactTheme.token, colorPrimary: '#abc123' },
+    };
+    expect(isTypographyThemeLocked(merged)).toBe(true);
+
+    const Child = () => {
+      const { token } = useToken();
+      expect(token.fontFamily).toBe(seedTheme.token.fontFamily);
+      expect(token.colorPrimary).toBe('#abc123');
+      return <div />;
+    };
+    render(
+      <ConfigProvider locale={zhCN} theme={merged}>
+        <Child />
+      </ConfigProvider>
+    );
+  });
+});

--- a/packages/design/src/config-provider/demo/locale-typography-theme.tsx
+++ b/packages/design/src/config-provider/demo/locale-typography-theme.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { ConfigProvider, Radio, Space, Typography, theme } from '@oceanbase/design';
+import { compactTheme, defaultTheme } from '@oceanbase/design';
+import zhCN from '@oceanbase/design/locale/zh-CN';
+import enUS from '@oceanbase/design/locale/en-US';
+
+const { Text } = Typography;
+
+type TypographyPreset = 'auto' | 'default' | 'compact';
+
+const TokenPreview = () => {
+  const { token } = theme.useToken();
+  return (
+    <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+      fontSize: {token.fontSize}px · fontFamily: {token.fontFamily.split(',')[0]}
+    </Typography.Paragraph>
+  );
+};
+
+export default () => {
+  const [locale, setLocale] = useState(zhCN);
+  const [preset, setPreset] = useState<TypographyPreset>('auto');
+
+  const themeConfig =
+    preset === 'default' ? defaultTheme : preset === 'compact' ? compactTheme : undefined;
+
+  return (
+    <ConfigProvider locale={locale} theme={themeConfig}>
+      <Space direction="vertical" size={16} style={{ width: '100%', paddingTop: 16 }}>
+        <Space wrap>
+          <Radio.Group
+            value={locale === zhCN ? 'zh' : 'en'}
+            onChange={e => setLocale(e.target.value === 'zh' ? zhCN : enUS)}
+          >
+            <Radio.Button value="zh">中文</Radio.Button>
+            <Radio.Button value="en">English</Radio.Button>
+          </Radio.Group>
+          <Radio.Group value={preset} onChange={e => setPreset(e.target.value)}>
+            <Radio.Button value="auto">随 locale 自动</Radio.Button>
+            <Radio.Button value="default">defaultTheme</Radio.Button>
+            <Radio.Button value="compact">compactTheme</Radio.Button>
+          </Radio.Group>
+        </Space>
+        <TokenPreview />
+        <Text>正文示例 OceanBase Design / 奥星贝斯设计系统</Text>
+      </Space>
+    </ConfigProvider>
+  );
+};

--- a/packages/design/src/config-provider/index.en-US.md
+++ b/packages/design/src/config-provider/index.en-US.md
@@ -17,10 +17,13 @@ nav:
 - 🆕 `styleProviderProps` for [StyleProvider](https://github.com/ant-design/cssinjs#styleprovider) config (e.g. `hashPriority`, `transformers`) for style fallback on Chrome < 88. See [antd v5 style compatibility](https://ant-design.antgroup.com/docs/react/compatible-style-cn).
 - 🆕 `appProps` for embedded [App component props](https://ant-design.antgroup.com/components/app-cn#app).
 
+- 🆕 Locale typography presets `defaultTheme` / `compactTheme`: auto-applied by `locale`, or pass via `theme` to override. `compactTheme` is locale typography, not `theme.isCompact` (spacing).
+
 ## Code Examples
 
 <!-- prettier-ignore -->
 <code src="../locale/demo/basic.tsx" title="Internationalization"></code>
+<code src="./demo/locale-typography-theme.tsx" title="Locale typography theme" description="Switch locale and defaultTheme / compactTheme presets."></code>
 <code src="./demo/size.tsx" title="Size"></code>
 <code src="./demo/theme.tsx" title="Theme"></code>
 <code src="./demo/css-var.tsx" title="CSS Variable Mode"></code>
@@ -164,5 +167,16 @@ CSS variable mode supports static theme switching via CSS classes, no JavaScript
 | table | Table global config | `{ selectionColumnWidth?: width; className?: string; style?: React.CSSProperties; }` | - | - |
 | styleProviderProps | [StyleProvider](https://github.com/ant-design/cssinjs#styleprovider) config (e.g. `hashPriority`, `transformers`) for style fallback | [StyleProviderProps](https://github.com/ant-design/cssinjs/blob/master/src/StyleContext.tsx#L88) | - | - |
 | appProps | Embedded App component props | [AppProps](https://ant-design.antgroup.com/components/app-cn#app) | - | - |
+
+### Locale typography presets
+
+| Export | Description |
+| :-- | :-- |
+| `defaultTheme` | Cn-like (zh/ja/ko) standard typography: 14px body and table cells; **font follows locale** |
+| `compactTheme` | Compact typography: 13px body and table cells; **font follows locale** |
+
+- When `theme` is omitted, the matching preset is merged from `locale` automatically.
+- Pass `theme={defaultTheme}` or `theme={compactTheme}` to lock **font size / table cell** typography; **font family and weights still follow `locale`**.
+- Combine with other theme fields via spread: `theme={{ ...compactTheme, isDark: true }}`; when overriding `token`, merge preset fields: `token: { ...compactTheme.token, colorPrimary: '#0064c8' }`.
 
 - More API: https://ant.design/components/config-provider-cn

--- a/packages/design/src/config-provider/index.md
+++ b/packages/design/src/config-provider/index.md
@@ -16,12 +16,13 @@ nav:
 - 🆕 新增 `table.selectionColumnWidth` 属性，用于配置表格的选择列宽度。
 - 🆕 新增 `styleProviderProps` 属性，一般用于配置 [StyleProvider](https://github.com/ant-design/cssinjs#styleprovider) 的 `hashPriority` 和 `transformers` 属性实现样式降级，来兼容 Chrome 88 以下的低版本浏览器，详见 [antd v5 样式兼容说明](https://ant-design.antgroup.com/docs/react/compatible-style-cn)。
 - 🆕 新增 `appProps` 属性，用于配置内嵌的 [App 组件属性](https://ant-design.antgroup.com/components/app-cn#app)。
-- 🆕 按 `locale` 自动调整正文字号与表格单元格字号：`zh` / `ja` / `ko`（含 `zh-cn`、`ja-JP` 等）下默认正文 **14px**、表格单元格 **14px**；其它 locale（如 `en`、`de`）与英文一致，为 **13px / 12px**。
+- 🆕 按 `locale` 自动调整排版：导出 `defaultTheme`（标准，14px）与 `compactTheme`（紧凑，Inter 字体 + 13px）；默认随语言生效，也可通过 `theme={defaultTheme}` / `theme={compactTheme}` 手动覆盖。`compactTheme` 为 locale 排版 preset，与 `theme.isCompact`（间距算法）无关。
 
 ## 代码演示
 
 <!-- prettier-ignore -->
 <code src="../locale/demo/basic.tsx" title="国际化"></code>
+<code src="./demo/locale-typography-theme.tsx" title="Locale 排版主题" description="切换 locale 与 defaultTheme / compactTheme；默认随语言自动应用排版 preset。"></code>
 <code src="./demo/size.tsx" title="尺寸"></code>
 <code src="./demo/theme.tsx" title="主题"></code>
 <code src="./demo/css-var.tsx" title="CSS 变量模式"></code>
@@ -165,5 +166,16 @@ CSS 变量模式支持通过 CSS 类实现静态主题切换，无需 JavaScript
 | table | Table 全局配置 | `{ selectionColumnWidth?: width; className?: string; style?: React.CSSProperties; }` | - | - |
 | styleProviderProps | [StyleProvider 配置](https://github.com/ant-design/cssinjs#styleprovider)，一般用于配置 `hashPriority` 和 `transformers` 属性实现样式降级 | [StyleProviderProps](https://github.com/ant-design/cssinjs/blob/master/src/StyleContext.tsx#L88) | - | - |
 | appProps | 内嵌的 App 组件属性 | [AppProps](https://ant-design.antgroup.com/components/app-cn#app) | - | - |
+
+### Locale 排版主题
+
+| 导出           | 说明                                                                          |
+| :------------- | :---------------------------------------------------------------------------- |
+| `defaultTheme` | Cn-like（zh/ja/ko）标准排版：14px 正文与表格单元格；**字体随 locale**         |
+| `compactTheme` | En-like 紧凑排版：13px 正文与表格单元格；**字体随 locale**（非 Inter 硬编码） |
+
+- 未传 `theme` 时按 `locale` 自动 merge 对应 preset；传入 `defaultTheme` / `compactTheme` 后锁定**字号/表格单元格**排版，**字体与字重仍随 locale**。
+- 与 preset 组合其它 `theme` 字段时使用展开：`theme={{ ...compactTheme, isDark: true }}`；覆盖 `token` 时需合并 preset 已有字段：`token: { ...compactTheme.token, colorPrimary: '#0064c8' }`。
+- `theme.isCompact` 为间距紧凑算法，与 `compactTheme` 无关。
 
 - 更多 API 详见 antd ConfigProvider 文档: https://ant.design/components/config-provider-cn

--- a/packages/design/src/config-provider/index.tsx
+++ b/packages/design/src/config-provider/index.tsx
@@ -23,22 +23,10 @@ import { merge } from 'lodash';
 import App from '../app';
 import StaticFunction from '../static-function';
 import themeConfig from '../theme';
-import defaultTheme, {
-  fontFamilyEn,
-  fontSizeCn,
-  fontHeightCn,
-  lineHeightCn,
-  fontSizeEn,
-  fontWeightWeakEn,
-  fontWeightEn,
-  fontWeightStrongEn,
-  isCnLikeLocale,
-  isEnLikeLocale,
-  tableCellFontSizeEn,
-} from '../theme/default';
+import seedTheme from '../theme/default';
 import darkTheme from '../theme/dark';
-import compactTheme from '../theme/compact';
-import type { GlobalToken } from '../theme/interface';
+import compactSpacingTheme from '../theme/compactSpacing';
+import { isTypographyThemeLocked, resolveLocaleTypographyPatch } from '../theme/localeTypography';
 import DefaultRenderEmpty from './DefaultRenderEmpty';
 import type { NavigateFunction } from './navigate';
 import type { Locale } from '../locale';
@@ -52,6 +40,8 @@ export * from 'antd/es/config-provider/context';
 export * from 'antd/es/config-provider/SizeContext';
 export * from 'antd/es/config-provider/DisabledContext';
 export * from 'antd/es/config-provider';
+
+export { compactTheme, defaultTheme } from '../theme/localeTypography';
 
 export interface ThemeConfig extends AntThemeConfig {
   isAliyun?: boolean;
@@ -125,85 +115,6 @@ export type ConfigProviderType = React.FC<ConfigProviderProps> & {
   useConfig: typeof AntConfigProvider.useConfig;
 };
 
-/** `en` / `en-gb` → `tokenValueEn`（与 `fontFamilyEn` 等一致）。 */
-const getLocaleTokenValue = (
-  mergedThemeToken: GlobalToken,
-  locale: Locale,
-  tokenKey: string,
-  tokenValue: string | number,
-  tokenValueEn: string | number
-) => {
-  return tokenValue !== mergedThemeToken[tokenKey]
-    ? { [tokenKey]: tokenValue }
-    : ['en', 'en-gb'].includes(locale.locale)
-      ? { [tokenKey]: tokenValueEn }
-      : {};
-};
-
-/** Cn（zh/ja/ko）且仍为拉丁基线 `tokenValueEn` 时 → `tokenValueCn`，结构上与 {@link getLocaleTokenValue} 对称。 */
-const getLocaleTokenValueCn = (
-  mergedThemeToken: GlobalToken,
-  locale: Locale,
-  tokenKey: string,
-  tokenValue: string | number | undefined,
-  tokenValueEn: number,
-  tokenValueCn: number
-) => {
-  return tokenValue !== mergedThemeToken[tokenKey]
-    ? { [tokenKey]: tokenValue }
-    : isCnLikeLocale(locale.locale) && (tokenValue === undefined || tokenValue === tokenValueEn)
-      ? { [tokenKey]: tokenValueCn }
-      : {};
-};
-
-/**
- * 按 locale 合并主题补丁：Cn 正文/表内字号、英文 Table 内嵌控件与分页对齐（`localeEnEmbeddedControls`）。
- * 供单测与 ConfigProvider 共用。
- */
-export function getLocaleFontSizeThemePatch(
-  mergedLocale: Locale,
-  mergedTheme: ThemeConfig,
-  resolvedFontSize: number | undefined
-): ThemeConfig {
-  const tokenPatch = getLocaleTokenValueCn(
-    (mergedTheme.token ?? {}) as GlobalToken,
-    mergedLocale,
-    'fontSize',
-    resolvedFontSize,
-    fontSizeEn,
-    fontSizeCn
-  );
-
-  const patch: ThemeConfig = {};
-  if ('fontSize' in tokenPatch && tokenPatch.fontSize !== undefined) {
-    patch.token = {
-      fontSize: tokenPatch.fontSize as number,
-      lineHeight: lineHeightCn,
-      fontHeight: fontHeightCn,
-    } as ThemeConfig['token'];
-  }
-
-  const tablePatch: NonNullable<ThemeConfig['components']>['Table'] = {};
-
-  const cellFs = mergedTheme.components?.Table?.cellFontSize;
-  if (
-    (cellFs === undefined || cellFs === tableCellFontSizeEn) &&
-    isCnLikeLocale(mergedLocale.locale)
-  ) {
-    Object.assign(tablePatch, { cellFontSize: fontSizeCn });
-  }
-
-  if (isEnLikeLocale(mergedLocale.locale)) {
-    Object.assign(tablePatch, { localeEnEmbeddedControls: true });
-  }
-
-  if (Object.keys(tablePatch as object).length > 0) {
-    patch.components = { Table: tablePatch };
-  }
-
-  return patch;
-}
-
 const ConfigProvider: ConfigProviderType = ({
   children,
   theme,
@@ -236,23 +147,23 @@ const ConfigProvider: ConfigProviderType = ({
             token: {
               ...darkTheme.token,
               ...Object.fromEntries(
-                Object.entries(defaultTheme.token).filter(
+                Object.entries(seedTheme.token).filter(
                   ([key]) => !key?.toLowerCase()?.startsWith('color')
                 )
               ),
             },
           }
       : undefined;
-  const compactThemeConfig =
+  const compactSpacingThemeConfig =
     isCompact && !isAliyun
       ? isDark
-        ? compactTheme
+        ? compactSpacingTheme
         : {
-            ...compactTheme,
+            ...compactSpacingTheme,
             token: {
-              ...compactTheme.token,
+              ...compactSpacingTheme.token,
               ...Object.fromEntries(
-                Object.entries(defaultTheme.token).filter(
+                Object.entries(seedTheme.token).filter(
                   ([key]) =>
                     key?.toLowerCase()?.startsWith('color') &&
                     !['colorBgBase', 'colorTextBase'].includes(key)
@@ -263,11 +174,11 @@ const ConfigProvider: ConfigProviderType = ({
       : undefined;
   const mergedTheme = merge(
     {},
-    isAliyun ? {} : isDark || isCompact ? themeConfig.defaultSeed : defaultTheme,
+    isAliyun ? {} : isDark || isCompact ? themeConfig.defaultSeed : seedTheme,
     parentContext.theme,
     aliyunThemeConfig,
     darkThemeConfig,
-    compactThemeConfig,
+    compactSpacingThemeConfig,
     theme
   );
 
@@ -283,43 +194,22 @@ const ConfigProvider: ConfigProviderType = ({
   const mergedStyleProviderProps = merge({}, parentStyleContext, styleProviderProps);
   const mergedLocale = merge({}, parentContext.locale, locale);
 
-  const resolvedAntTheme = merge(
-    {},
+  const typographyLocked = isTypographyThemeLocked(mergedTheme);
+  const resolvedTokens = {
+    fontFamily,
+    fontWeightWeak,
+    fontWeight,
+    fontWeightStrong,
+  };
+  const localeTypographyPatch = resolveLocaleTypographyPatch(
+    mergedLocale,
     mergedTheme,
-    getLocaleFontSizeThemePatch(mergedLocale, mergedTheme, fontSize),
-    {
-      token: {
-        ...getLocaleTokenValue(
-          mergedTheme.token || {},
-          mergedLocale,
-          'fontFamily',
-          fontFamily,
-          fontFamilyEn
-        ),
-        ...getLocaleTokenValue(
-          mergedTheme.token || {},
-          mergedLocale,
-          'fontWeightWeak',
-          fontWeightWeak,
-          fontWeightWeakEn
-        ),
-        ...getLocaleTokenValue(
-          mergedTheme.token || {},
-          mergedLocale,
-          'fontWeight',
-          fontWeight,
-          fontWeightEn
-        ),
-        ...getLocaleTokenValue(
-          mergedTheme.token || {},
-          mergedLocale,
-          'fontWeightStrong',
-          fontWeightStrong,
-          fontWeightStrongEn
-        ),
-      },
-    } as ConfigProviderProps['theme']
+    fontSize,
+    resolvedTokens,
+    { sizeLocked: typographyLocked }
   );
+
+  const resolvedAntTheme = merge({}, mergedTheme, localeTypographyPatch);
 
   // cssVar 模式下 App 必须有真实 DOM 节点挂载 cssVarCls，component={false} 会导致变量作用域丢失
   const cssVarEnabled = Boolean(resolvedAntTheme?.cssVar);

--- a/packages/design/src/index.ts
+++ b/packages/design/src/index.ts
@@ -24,6 +24,7 @@ export type { AppProps } from './app';
 
 export { default as ConfigProvider } from './config-provider';
 export type { ConfigProviderProps, ConfigConsumerProps, ThemeConfig } from './config-provider';
+export { compactTheme, defaultTheme } from './theme/localeTypography';
 
 export { default as Descriptions } from './descriptions';
 export type {

--- a/packages/design/src/theme/compactSpacing.ts
+++ b/packages/design/src/theme/compactSpacing.ts
@@ -1,6 +1,6 @@
 import theme from './index';
 
-const compactTheme = {
+const compactSpacingTheme = {
   token: theme.defaultSeed,
   components: {
     InputNumber: {
@@ -14,4 +14,4 @@ const compactTheme = {
   },
 };
 
-export default compactTheme;
+export default compactSpacingTheme;

--- a/packages/design/src/theme/default.ts
+++ b/packages/design/src/theme/default.ts
@@ -97,14 +97,14 @@ export const fontSizeEn = 13;
 /** Table 单元格字号（非 Cn），与 components.Table.cellFontSize 默认值一致 */
 export const tableCellFontSizeEn = fontSizeSM;
 
-/** Cn 正文/表内字号等 locale 主题补丁（由 config-provider `getLocaleFontSizeThemePatch` 消费） */
+/** Cn 正文/表内字号等 locale 主题补丁（由 `localeTypography` 消费） */
 export const fontSizeCn = 14;
 export const fontHeightCn = 22;
 export const lineHeightCn = fontHeightCn / fontSizeCn;
 
 const lineHeightSM = 20 / 12;
 
-const defaultTheme: ThemeConfig = {
+const seedTheme: ThemeConfig = {
   token: {
     fontFamily: `-apple-system, 'Noto Sans', BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'`,
     fontFamilyCode: `Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace`,
@@ -454,16 +454,16 @@ const defaultTheme: ThemeConfig = {
   },
 };
 
-defaultTheme.token = {
-  ...defaultTheme.token,
+seedTheme.token = {
+  ...seedTheme.token,
   // preset colors below should be same with semantic colors
-  blue: defaultTheme?.token?.colorInfo,
-  green: defaultTheme?.token?.colorSuccess,
-  yellow: defaultTheme?.token?.colorWarning,
-  red: defaultTheme?.token?.colorError,
+  blue: seedTheme?.token?.colorInfo,
+  green: seedTheme?.token?.colorSuccess,
+  yellow: seedTheme?.token?.colorWarning,
+  red: seedTheme?.token?.colorError,
 };
 
-export default formatTheme(defaultTheme);
+export default formatTheme(seedTheme);
 
 /**
  * Whether the BCP 47 locale should use Cn typography sizing (14px body + table cells; zh/ja/ko).

--- a/packages/design/src/theme/index.ts
+++ b/packages/design/src/theme/index.ts
@@ -3,7 +3,7 @@ import type { Theme } from '@ant-design/cssinjs';
 import { pick } from 'lodash';
 // umi 插件只能 import 支持 CommonJS 语法库和文件，因此需要使用 lib 产物
 import type { SeedToken } from 'antd/lib/theme/interface';
-import defaultTheme from './default';
+import seedTheme from './default';
 import type { GlobalToken, AliasToken } from './interface';
 import { genObToken } from './obToken';
 
@@ -12,7 +12,7 @@ export * from 'antd/lib/theme';
 
 const seedTokenKeys = Object.keys(theme.defaultSeed);
 const seedToken = {
-  ...pick(defaultTheme.token, seedTokenKeys),
+  ...pick(seedTheme.token, seedTokenKeys),
   // some special seed token should set to ''
   // ref: https://github.com/ant-design/ant-design/blob/master/components/theme/themes/seed.ts#L32
   colorBgBase: '',

--- a/packages/design/src/theme/localeTypography.ts
+++ b/packages/design/src/theme/localeTypography.ts
@@ -1,0 +1,233 @@
+import { merge } from 'lodash';
+import type { ThemeConfig } from '../config-provider/context';
+import type { Locale } from '../locale';
+import type { AliasToken, GlobalToken } from './interface';
+import seedTheme, {
+  fontFamilyEn,
+  fontSizeCn,
+  fontHeightCn,
+  lineHeightCn,
+  fontSizeEn,
+  fontWeightWeakEn,
+  fontWeightEn,
+  fontWeightStrongEn,
+  isCnLikeLocale,
+  isEnLikeLocale,
+  tableCellFontSizeEn,
+} from './default';
+
+const OB_TYPOGRAPHY_PRESET_KEY = '__obTypographyPreset' as const;
+
+type OBTypographyPreset = 'default' | 'compact';
+
+type TypographyThemeConfig = ThemeConfig & {
+  [OB_TYPOGRAPHY_PRESET_KEY]?: OBTypographyPreset;
+};
+
+/** Cn-like locale typography: 14px body + table cells; fontFamily stays on seed stack. */
+export const defaultTheme: TypographyThemeConfig = {
+  [OB_TYPOGRAPHY_PRESET_KEY]: 'default',
+  token: {
+    fontSize: fontSizeCn,
+    lineHeight: lineHeightCn,
+    fontHeight: fontHeightCn,
+  },
+  components: {
+    Table: {
+      cellFontSize: fontSizeCn,
+    },
+  },
+};
+
+type LocaleFontTokens = {
+  fontFamily: string;
+  fontWeightWeak: number;
+  fontWeight: number;
+  fontWeightStrong: number;
+};
+
+const seedToken = seedTheme.token as Partial<AliasToken>;
+
+/** En-like locale typography: 13px body + table cells; fontFamily follows locale. */
+export const compactTheme: TypographyThemeConfig = {
+  [OB_TYPOGRAPHY_PRESET_KEY]: 'compact',
+  token: {
+    fontSize: fontSizeEn,
+    lineHeight: seedToken.lineHeight,
+    fontHeight: seedToken.fontHeight,
+  },
+  components: {
+    Table: {
+      cellFontSize: tableCellFontSizeEn,
+    },
+  },
+};
+
+export function isTypographyThemeLocked(theme?: ThemeConfig): boolean {
+  if (!theme) {
+    return false;
+  }
+  if (theme === defaultTheme || theme === compactTheme) {
+    return true;
+  }
+  const preset = (theme as TypographyThemeConfig)[OB_TYPOGRAPHY_PRESET_KEY];
+  return preset === 'default' || preset === 'compact';
+}
+
+const getLocaleTokenValue = (
+  mergedThemeToken: GlobalToken,
+  locale: Locale,
+  tokenKey: string,
+  tokenValue: string | number,
+  tokenValueEn: string | number,
+  tokenValueSeed: string | number
+) => {
+  if (tokenValue !== mergedThemeToken[tokenKey]) {
+    return { [tokenKey]: tokenValue };
+  }
+  if (
+    isEnLikeLocale(locale.locale) &&
+    (mergedThemeToken[tokenKey] === undefined || tokenValue === tokenValueSeed)
+  ) {
+    return { [tokenKey]: tokenValueEn };
+  }
+  return {};
+};
+
+const getLocaleTokenValueCn = (
+  mergedThemeToken: GlobalToken,
+  locale: Locale,
+  tokenKey: string,
+  tokenValue: string | number | undefined,
+  tokenValueEn: number,
+  tokenValueCn: number
+) => {
+  return tokenValue !== mergedThemeToken[tokenKey]
+    ? { [tokenKey]: tokenValue }
+    : isCnLikeLocale(locale.locale) && (tokenValue === undefined || tokenValue === tokenValueEn)
+      ? { [tokenKey]: tokenValueCn }
+      : {};
+};
+
+/**
+ * Locale font-family and font-weight patch (always applied; follows locale).
+ */
+function resolveLocaleFontPatch(
+  mergedLocale: Locale,
+  mergedTheme: ThemeConfig,
+  resolvedTokens: LocaleFontTokens
+): ThemeConfig {
+  const mergedThemeToken = (mergedTheme.token ?? {}) as GlobalToken;
+
+  return {
+    token: {
+      ...getLocaleTokenValue(
+        mergedThemeToken,
+        mergedLocale,
+        'fontFamily',
+        resolvedTokens.fontFamily,
+        fontFamilyEn,
+        seedToken.fontFamily!
+      ),
+      ...getLocaleTokenValue(
+        mergedThemeToken,
+        mergedLocale,
+        'fontWeightWeak',
+        resolvedTokens.fontWeightWeak,
+        fontWeightWeakEn,
+        seedToken.fontWeightWeak!
+      ),
+      ...getLocaleTokenValue(
+        mergedThemeToken,
+        mergedLocale,
+        'fontWeight',
+        resolvedTokens.fontWeight,
+        fontWeightEn,
+        seedToken.fontWeight!
+      ),
+      ...getLocaleTokenValue(
+        mergedThemeToken,
+        mergedLocale,
+        'fontWeightStrong',
+        resolvedTokens.fontWeightStrong,
+        fontWeightStrongEn,
+        seedToken.fontWeightStrong!
+      ),
+    },
+  };
+}
+
+/** Table locale alignment patch (always applied; follows locale). */
+function getLocaleTableLocalePatch(mergedLocale: Locale): ThemeConfig {
+  if (!isEnLikeLocale(mergedLocale.locale)) {
+    return {};
+  }
+  return {
+    components: {
+      Table: {
+        localeEnEmbeddedControls: true,
+      },
+    },
+  };
+}
+
+/**
+ * Locale typography patch. Size/table cell patches skip when preset locks size;
+ * font and table locale alignment always follow locale.
+ */
+export function resolveLocaleTypographyPatch(
+  mergedLocale: Locale,
+  mergedTheme: ThemeConfig,
+  resolvedFontSize: number | undefined,
+  resolvedTokens: LocaleFontTokens,
+  options?: { sizeLocked?: boolean }
+): ThemeConfig {
+  return merge(
+    {},
+    options?.sizeLocked
+      ? {}
+      : getLocaleFontSizeThemePatch(mergedLocale, mergedTheme, resolvedFontSize),
+    resolveLocaleFontPatch(mergedLocale, mergedTheme, resolvedTokens),
+    getLocaleTableLocalePatch(mergedLocale)
+  );
+}
+
+function getLocaleFontSizeThemePatch(
+  mergedLocale: Locale,
+  mergedTheme: ThemeConfig,
+  resolvedFontSize: number | undefined
+): ThemeConfig {
+  const tokenPatch = getLocaleTokenValueCn(
+    (mergedTheme.token ?? {}) as GlobalToken,
+    mergedLocale,
+    'fontSize',
+    resolvedFontSize,
+    fontSizeEn,
+    fontSizeCn
+  );
+
+  const patch: ThemeConfig = {};
+  if ('fontSize' in tokenPatch && tokenPatch.fontSize !== undefined) {
+    patch.token = {
+      fontSize: tokenPatch.fontSize as number,
+      lineHeight: lineHeightCn,
+      fontHeight: fontHeightCn,
+    };
+  }
+
+  const tablePatch: NonNullable<ThemeConfig['components']>['Table'] = {};
+
+  const cellFs = mergedTheme.components?.Table?.cellFontSize;
+  if (
+    (cellFs === undefined || cellFs === tableCellFontSizeEn) &&
+    isCnLikeLocale(mergedLocale.locale)
+  ) {
+    Object.assign(tablePatch, { cellFontSize: fontSizeCn });
+  }
+
+  if (Object.keys(tablePatch as object).length > 0) {
+    patch.components = { Table: tablePatch };
+  }
+
+  return patch;
+}


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

`ConfigProvider` already adjusted typography by `locale` (zh/ja/ko → 14px, en → Inter + 13px). This PR extracts that behavior into public presets and keeps backward-compatible auto-merge when `theme` is omitted.

- Export **`defaultTheme`** (Cn-like: 14px body/table) and **`compactTheme`** (En-like: Inter, en font weights, Table embedded control alignment).
- Passing either preset locks typography regardless of `locale`; partial `token` overrides still use per-field guards.
- Rename internal `compact.ts` → `compactSpacing.ts` to avoid confusion with locale `compactTheme`; rename seed object to `seedTheme` in `default.ts`.
- `theme.isCompact` remains the spacing algorithm and is independent of `compactTheme`.

Usage:

```tsx
import { ConfigProvider, defaultTheme, compactTheme } from '@oceanbase/design';

// Auto by locale (unchanged)
<ConfigProvider locale={zhCN} />

// Override: zh with compact / en with default
<ConfigProvider locale={zhCN} theme={compactTheme} />
<ConfigProvider locale={enUS} theme={defaultTheme} />

// Combine with isDark
<ConfigProvider locale={enUS} theme={{ ...compactTheme, isDark: true }} />
```

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - ConfigProvider<br/>&nbsp;&nbsp;- 🆕 Export `defaultTheme` and `compactTheme` locale typography presets; auto-applied by `locale` when `theme` is omitted, or pass via `theme` to override.<br/>&nbsp;&nbsp;- 🐞 Fix custom `token.fontFamily` on English locales not being preserved.<br/>&nbsp;&nbsp;- 💡 `compactTheme` is locale typography; `theme.isCompact` is spacing compaction — they are independent. |
| 🇨🇳 Chinese | - ConfigProvider<br/>&nbsp;&nbsp;- 🆕 导出 `defaultTheme` 与 `compactTheme` locale 排版 preset；未传 `theme` 时仍随 `locale` 自动应用，也可通过 `theme` 手动覆盖。<br/>&nbsp;&nbsp;- 🐞 修复英文 locale 下自定义 `token.fontFamily` 被 locale 补丁覆盖的问题。<br/>&nbsp;&nbsp;- 💡 `compactTheme` 为 locale 排版 preset，与 `theme.isCompact`（间距算法）无关。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
