### PR TITLE
fix(root): narrow theme-plugin tsc scope to unblock dumi dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:design": "pnpm --filter \"@oceanbase/design\" build",
     "ci": "npm run tsc && npm run lint && npm run lint:demo-locale && npm run test",
     "deploy": "npm run site:build && npm run site:deploy",
-    "dev": "tsc --skipLibCheck --jsx react-jsx --esModuleInterop packages/design/src/theme/*.ts --outDir ./.dumi/tmp/plugin-theme-less && cross-env DUMI_ENV=theme dumi dev",
+    "dev": "tsc -p tsconfig.theme-plugin.json && cross-env DUMI_ENV=theme dumi dev",
     "start": "npm run dev",
     "prepare": "husky install && dumi setup",
     "prepublishOnly": "npm run build",

--- a/packages/design/src/theme/localeTypography.ts
+++ b/packages/design/src/theme/localeTypography.ts
@@ -1,6 +1,6 @@
 import { merge } from 'lodash';
+import type { Locale as AntLocale } from 'antd/es/locale';
 import type { ThemeConfig } from '../config-provider/context';
-import type { Locale } from '../locale';
 import type { AliasToken, GlobalToken } from './interface';
 import seedTheme, {
   fontFamilyEn,
@@ -15,6 +15,8 @@ import seedTheme, {
   isEnLikeLocale,
   tableCellFontSizeEn,
 } from './default';
+
+type LocaleCodeCarrier = Pick<AntLocale, 'locale'>;
 
 const OB_TYPOGRAPHY_PRESET_KEY = '__obTypographyPreset' as const;
 
@@ -76,7 +78,7 @@ export function isTypographyThemeLocked(theme?: ThemeConfig): boolean {
 
 const getLocaleTokenValue = (
   mergedThemeToken: GlobalToken,
-  locale: Locale,
+  locale: LocaleCodeCarrier,
   tokenKey: string,
   tokenValue: string | number,
   tokenValueEn: string | number,
@@ -96,7 +98,7 @@ const getLocaleTokenValue = (
 
 const getLocaleTokenValueCn = (
   mergedThemeToken: GlobalToken,
-  locale: Locale,
+  locale: LocaleCodeCarrier,
   tokenKey: string,
   tokenValue: string | number | undefined,
   tokenValueEn: number,
@@ -113,7 +115,7 @@ const getLocaleTokenValueCn = (
  * Locale font-family and font-weight patch (always applied; follows locale).
  */
 function resolveLocaleFontPatch(
-  mergedLocale: Locale,
+  mergedLocale: LocaleCodeCarrier,
   mergedTheme: ThemeConfig,
   resolvedTokens: LocaleFontTokens
 ): ThemeConfig {
@@ -158,7 +160,7 @@ function resolveLocaleFontPatch(
 }
 
 /** Table locale alignment patch (always applied; follows locale). */
-function getLocaleTableLocalePatch(mergedLocale: Locale): ThemeConfig {
+function getLocaleTableLocalePatch(mergedLocale: LocaleCodeCarrier): ThemeConfig {
   if (!isEnLikeLocale(mergedLocale.locale)) {
     return {};
   }
@@ -176,7 +178,7 @@ function getLocaleTableLocalePatch(mergedLocale: Locale): ThemeConfig {
  * font and table locale alignment always follow locale.
  */
 export function resolveLocaleTypographyPatch(
-  mergedLocale: Locale,
+  mergedLocale: LocaleCodeCarrier,
   mergedTheme: ThemeConfig,
   resolvedFontSize: number | undefined,
   resolvedTokens: LocaleFontTokens,
@@ -193,7 +195,7 @@ export function resolveLocaleTypographyPatch(
 }
 
 function getLocaleFontSizeThemePatch(
-  mergedLocale: Locale,
+  mergedLocale: LocaleCodeCarrier,
   mergedTheme: ThemeConfig,
   resolvedFontSize: number | undefined
 ): ThemeConfig {

--- a/tsconfig.theme-plugin.json
+++ b/tsconfig.theme-plugin.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "outDir": "./.dumi/tmp/plugin-theme-less"
+  },
+  "include": [
+    "packages/design/src/theme/index.ts",
+    "packages/design/src/theme/default.ts",
+    "packages/design/src/theme/dark.ts",
+    "packages/design/src/theme/aliyun.ts"
+  ]
+}


### PR DESCRIPTION
### 📦 Modified package

- [ ] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [x] Other (about what?) — root dev script / theme-plugin tsc

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

After #1516 (`localeTypography.ts`), `pnpm run dev` failed at the theme-plugin `tsc` step:

1. `theme/*.ts` glob pulled `localeTypography` → `locale` → heavy component modules (`global.tsx` woff2, `useDefaultPagination`, etc.).
2. The bare `tsc` CLI did not inherit root `tsconfig.json` lib targets.

**Fix (minimal):**

- Add `tsconfig.theme-plugin.json` that extends root config and only includes the four theme entries used by `plugin-theme-less.ts` (`index`, `default`, `dark`, `aliyun`).
- Point `dev` script at `tsc -p tsconfig.theme-plugin.json`.
- Narrow `localeTypography` to `Pick<AntLocale, 'locale'>` — it only reads `locale.locale`, so it no longer imports `../locale`.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | No user-facing changes |
| 🇨🇳 Chinese | 无用户可感知变更 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
