### PR TITLE
chore(docs): Add changelog for @oceanbase/design@1.1.0, @oceanbase/ui@1.1.0, and @oceanbase/codemod@1.1.0

### DIFF
--- a/docs/codemod/codemod-CHANGELOG.md
+++ b/docs/codemod/codemod-CHANGELOG.md
@@ -8,6 +8,16 @@ group: Codemod
 
 ---
 
+## 1.1.0
+
+`2026-08-04`
+
+- 🆕 Default style migration outputs `obToken` and `var(--ob-*)` instead of antd tokens. [#1510](https://github.com/oceanbase/oceanbase-design/pull/1510)
+  - Added `token-to-obtoken` for upgrading existing `token.xxx` / `var(--ant-*)` code.
+  - `less-to-cssvar` / `sass-to-cssvar` included in the default pipeline.
+  - `--token-target=antd` restores legacy antd token output.
+- 🆕 Added `ob-css-tokens` transformer. [#1517](https://github.com/oceanbase/oceanbase-design/pull/1517)
+
 ## 1.0.0-alpha.10
 
 `2025-12-19`

--- a/docs/codemod/codemod-CHANGELOG.zh-CN.md
+++ b/docs/codemod/codemod-CHANGELOG.zh-CN.md
@@ -8,6 +8,16 @@ group: 自动化迁移工具
 
 ---
 
+## 1.1.0
+
+`2026-08-04`
+
+- 🆕 默认样式迁移输出 `obToken` 与 `var(--ob-*)`，替代 antd token。[#1510](https://github.com/oceanbase/oceanbase-design/pull/1510)
+  - 新增 `token-to-obtoken`，用于升级存量 `token.xxx` / `var(--ant-*)` 代码。
+  - `less-to-cssvar` / `sass-to-cssvar` 纳入默认流水线。
+  - `--token-target=antd` 可恢复 antd token 输出。
+- 🆕 新增 `ob-css-tokens` transformer。[#1517](https://github.com/oceanbase/oceanbase-design/pull/1517)
+
 ## 1.0.0-alpha.10
 
 `2025-12-19`

--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,44 @@ group: General
 
 ---
 
+## 1.1.0
+
+`2026-08-04`
+
+- AI / Agent
+  - 📖 Recommend global `ob-design` install for faster MCP startup. [#1499](https://github.com/oceanbase/oceanbase-design/pull/1499)
+  - ⭐️ Agent skill renamed to `oceanbase-design` (`npx skills add oceanbase/oceanbase-design`). [#1500](https://github.com/oceanbase/oceanbase-design/pull/1500)
+  - 🤖 `ob-design lint` validates `var(--ob-*)` in styles; `ob-design token` lists runtime CSS variables with `--json` and `--check`. [#1517](https://github.com/oceanbase/oceanbase-design/pull/1517)
+- 🤖 Figma Code Connect mappings bridge design and frontend workflows. [#1502](https://github.com/oceanbase/oceanbase-design/pull/1502)
+- 🌐 Bilingual documentation site with `/zh-CN` routing and homepage locale preference. [#1501](https://github.com/oceanbase/oceanbase-design/pull/1501)
+- Theme
+  - 🆕 Export `defaultTheme` and `compactTheme` locale typography presets. [#1516](https://github.com/oceanbase/oceanbase-design/pull/1516)
+  - 🐞 Fixed custom `token.fontFamily` on English locales not being preserved. [#1516](https://github.com/oceanbase/oceanbase-design/pull/1516)
+- Empty
+  - 💄 Updated illustrations. [#1504](https://github.com/oceanbase/oceanbase-design/pull/1504)
+  - 💄 Improved illustration sizing, description color, and title/description/footer spacing. [#1505](https://github.com/oceanbase/oceanbase-design/pull/1505)
+  - 💄 Horizontal layout adapts on narrow containers (stacks at ≤560px, hides illustration at ≤400px). [#1505](https://github.com/oceanbase/oceanbase-design/pull/1505)
+- Result
+  - 💄 Updated illustrations; added presets such as `PRESENTED_IMAGE_NOT_FOUND`, `PRESENTED_IMAGE_NETWORK_ERROR`, and `PRESENTED_IMAGE_VERSION_UPDATE`. [#1504](https://github.com/oceanbase/oceanbase-design/pull/1504)
+  - 🆕 `status` adds `normal` with its illustration. [#1504](https://github.com/oceanbase/oceanbase-design/pull/1504)
+  - 💄 Aligned icon size and spacing with Empty. [#1505](https://github.com/oceanbase/oceanbase-design/pull/1505)
+- Form
+  - 🆕 Added `validateMode` and `reValidateMode`; ConfigProvider global defaults supported. [#1512](https://github.com/oceanbase/oceanbase-design/pull/1512)
+  - 🆕 `Form.Item` explain shows built-in blur and hint feedback from child controls. [#1515](https://github.com/oceanbase/oceanbase-design/pull/1515)
+  - 💄 Aligned explain/extra padding with control height. [#1514](https://github.com/oceanbase/oceanbase-design/pull/1514)
+- Input
+  - 💄 Updated `Input.Search` styling and interaction. [#1508](https://github.com/oceanbase/oceanbase-design/pull/1508)
+- Message
+  - 🔄 Message API remains compatible but displays via Notification (including `useMessage`). [#1507](https://github.com/oceanbase/oceanbase-design/pull/1507)
+  - 📌 Message documented as deprecated; migrate to Notification. [#1507](https://github.com/oceanbase/oceanbase-design/pull/1507)
+- Notification
+  - 💄 Default bottom-left placement, fixed width 350px, linear icons with auto-close progress bar; links in title/description use type color. [#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
+  - 🆕 Added `notification.loading` for in-progress feedback. [#1507](https://github.com/oceanbase/oceanbase-design/pull/1507)
+  - 🆕 Added `errorDetails` with Markdown copy support. [#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
+  - 🆕 Added `dedupeKey` to deduplicate notifications. [#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
+- Table
+  - 🆕 Added `column.tooltip` for column header help. [#1509](https://github.com/oceanbase/oceanbase-design/pull/1509)
+
 ## 1.0.0
 
 `2026-07-17`

--- a/docs/design/design-CHANGELOG.zh-CN.md
+++ b/docs/design/design-CHANGELOG.zh-CN.md
@@ -8,6 +8,44 @@ group: 基础组件
 
 ---
 
+## 1.1.0
+
+`2026-08-04`
+
+- AI / Agent
+  - 📖 推荐全局安装 `ob-design` 以加速 MCP 启动。[#1499](https://github.com/oceanbase/oceanbase-design/pull/1499)
+  - ⭐️ Agent Skill 重命名为 `oceanbase-design`（`npx skills add oceanbase/oceanbase-design`）。[#1500](https://github.com/oceanbase/oceanbase-design/pull/1500)
+  - 🤖 `ob-design lint` 校验样式中的 `var(--ob-*)`；`ob-design token` 支持 `--json`、`--check` 查询运行时 CSS 变量。[#1517](https://github.com/oceanbase/oceanbase-design/pull/1517)
+- 🤖 Figma Code Connect 映射打通设计与前端工作流。[#1502](https://github.com/oceanbase/oceanbase-design/pull/1502)
+- 🌐 文档站点支持英文 (`/`) 与中文 (`/zh-CN`) 双语言，首页支持语言偏好。[#1501](https://github.com/oceanbase/oceanbase-design/pull/1501)
+- 主题
+  - 🆕 导出 `defaultTheme` 与 `compactTheme` locale 排版 preset。[#1516](https://github.com/oceanbase/oceanbase-design/pull/1516)
+  - 🐞 修复英文 locale 下自定义 `token.fontFamily` 被覆盖的问题。[#1516](https://github.com/oceanbase/oceanbase-design/pull/1516)
+- Empty
+  - 💄 更新插图。[#1504](https://github.com/oceanbase/oceanbase-design/pull/1504)
+  - 💄 优化插图尺寸、描述文本颜色与标题/描述/操作区间距。[#1505](https://github.com/oceanbase/oceanbase-design/pull/1505)
+  - 💄 窄容器下横向布局自适应（≤560px 纵向堆叠，≤400px 隐藏插图）。[#1505](https://github.com/oceanbase/oceanbase-design/pull/1505)
+- Result
+  - 💄 更新插图；新增 `PRESENTED_IMAGE_NOT_FOUND`、`PRESENTED_IMAGE_NETWORK_ERROR`、`PRESENTED_IMAGE_VERSION_UPDATE` 等场景预设。[#1504](https://github.com/oceanbase/oceanbase-design/pull/1504)
+  - 🆕 `status` 新增 `normal` 状态及其插图。[#1504](https://github.com/oceanbase/oceanbase-design/pull/1504)
+  - 💄 对齐与 Empty 一致的图标尺寸与间距。[#1505](https://github.com/oceanbase/oceanbase-design/pull/1505)
+- Form
+  - 🆕 新增 `validateMode` / `reValidateMode`；支持 ConfigProvider 全局配置。[#1512](https://github.com/oceanbase/oceanbase-design/pull/1512)
+  - 🆕 `Form.Item` explain 可展示子控件内置的失焦提示与辅助说明。[#1515](https://github.com/oceanbase/oceanbase-design/pull/1515)
+  - 💄 调整 explain/extra 内边距，与控件行高度对齐。[#1514](https://github.com/oceanbase/oceanbase-design/pull/1514)
+- Input
+  - 💄 更新 `Input.Search` 样式与交互。[#1508](https://github.com/oceanbase/oceanbase-design/pull/1508)
+- Message
+  - 🔄 Message API 保持兼容，展示效果改为 Notification（含 `useMessage`）。[#1507](https://github.com/oceanbase/oceanbase-design/pull/1507)
+  - 📌 Message 文档标注弃用，请迁移至 Notification。[#1507](https://github.com/oceanbase/oceanbase-design/pull/1507)
+- Notification
+  - 💄 默认左下角展示，固定宽度 350px，线性图标与自动关闭进度条；标题/描述内链接使用类型色。[#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
+  - 🆕 新增 `notification.loading` 用于进行中反馈。[#1507](https://github.com/oceanbase/oceanbase-design/pull/1507)
+  - 🆕 新增 `errorDetails`，支持复制为 Markdown。[#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
+  - 🆕 新增 `dedupeKey` 去除重复弹出。[#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
+- Table
+  - 🆕 新增 `column.tooltip`，在列头展示帮助说明。[#1509](https://github.com/oceanbase/oceanbase-design/pull/1509)
+
 ## 1.0.0
 
 `2026-07-17`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,21 @@ group: Biz Components
 
 ---
 
+## 1.1.0
+
+`2026-08-04`
+
+- Login
+  - ✨ RegisterForm uses Password component and shared cloud password validation. [#1513](https://github.com/oceanbase/oceanbase-design/pull/1513)
+- Password
+  - 💥 Default rules align with multi-cloud spec (8–20 chars, 3-of-4 types; was 8–32 and 2-of-4). [#1513](https://github.com/oceanbase/oceanbase-design/pull/1513)
+  - ✨ Change-password flow: `mode="plain"` for current password, blur feedback, and remember/copy hint. [#1513](https://github.com/oceanbase/oceanbase-design/pull/1513)
+  - 🆕 Blur validation and "remember your password" hint appear in `Form.Item` explain automatically. [#1515](https://github.com/oceanbase/oceanbase-design/pull/1515)
+  - 🆕 Defaults `autoComplete="new-password"` (strength on focus); use `current-password` for current-password fields. [#1515](https://github.com/oceanbase/oceanbase-design/pull/1515)
+  - 🌐 Updated validation messages (zh-CN, en-US, zh-TW, ja-JP). [#1513](https://github.com/oceanbase/oceanbase-design/pull/1513)
+- ProTable
+  - 🆕 Supports `column.tooltip` with the same header help icon as Table. [#1509](https://github.com/oceanbase/oceanbase-design/pull/1509)
+
 ## 1.0.0-alpha.20
 
 `2026-06-14`

--- a/docs/ui/ui-CHANGELOG.zh-CN.md
+++ b/docs/ui/ui-CHANGELOG.zh-CN.md
@@ -8,6 +8,21 @@ group: 业务组件
 
 ---
 
+## 1.1.0
+
+`2026-08-04`
+
+- Login
+  - ✨ 接入 Password 组件与多云密码校验。[#1513](https://github.com/oceanbase/oceanbase-design/pull/1513)
+- Password
+  - 💥 默认规则对齐多云规范（8–20 位、四类至少 3 种；原为 8–32、各类至少 2 种）。[#1513](https://github.com/oceanbase/oceanbase-design/pull/1513)
+  - ✨ 修改密码场景：`mode="plain"` 当前密码、失焦反馈与牢记/复制提示。[#1513](https://github.com/oceanbase/oceanbase-design/pull/1513)
+  - 🆕 失焦校验与「请牢记密码」提示自动写入 `Form.Item` explain。[#1515](https://github.com/oceanbase/oceanbase-design/pull/1515)
+  - 🆕 默认 `autoComplete="new-password"`（聚焦展示强度气泡）；当前密码使用 `current-password`。[#1515](https://github.com/oceanbase/oceanbase-design/pull/1515)
+  - 🌐 更新四语言校验文案。[#1513](https://github.com/oceanbase/oceanbase-design/pull/1513)
+- ProTable
+  - 🆕 支持 `column.tooltip`，列头帮助图标与 Table 一致。[#1509](https://github.com/oceanbase/oceanbase-design/pull/1509)
+
 ## 1.0.0-alpha.20
 
 `2026-06-14`


### PR DESCRIPTION
## @oceanbase/design@1.1.0

`2026-08-04`

- AI / Agent
  - 📖 推荐全局安装 `ob-design` 以加速 MCP 启动。[#1499](https://github.com/oceanbase/oceanbase-design/pull/1499)
  - ⭐️ Agent Skill 重命名为 `oceanbase-design`（`npx skills add oceanbase/oceanbase-design`）。[#1500](https://github.com/oceanbase/oceanbase-design/pull/1500)
  - 🤖 `ob-design lint` 校验样式中的 `var(--ob-*)`；`ob-design token` 支持 `--json`、`--check` 查询运行时 CSS 变量。[#1517](https://github.com/oceanbase/oceanbase-design/pull/1517)
- 🤖 Figma Code Connect 映射打通设计与前端工作流。[#1502](https://github.com/oceanbase/oceanbase-design/pull/1502)
- 🌐 文档站点支持英文 (`/`) 与中文 (`/zh-CN`) 双语言，首页支持语言偏好。[#1501](https://github.com/oceanbase/oceanbase-design/pull/1501)
- 主题
  - 🆕 导出 `defaultTheme` 与 `compactTheme` locale 排版 preset。[#1516](https://github.com/oceanbase/oceanbase-design/pull/1516)
  - 🐞 修复英文 locale 下自定义 `token.fontFamily` 被覆盖的问题。[#1516](https://github.com/oceanbase/oceanbase-design/pull/1516)
- Empty
  - 💄 更新插图。[#1504](https://github.com/oceanbase/oceanbase-design/pull/1504)
  - 💄 优化插图尺寸、描述文本颜色与标题/描述/操作区间距。[#1505](https://github.com/oceanbase/oceanbase-design/pull/1505)
  - 💄 窄容器下横向布局自适应（≤560px 纵向堆叠，≤400px 隐藏插图）。[#1505](https://github.com/oceanbase/oceanbase-design/pull/1505)
- Result
  - 💄 更新插图；新增 `PRESENTED_IMAGE_NOT_FOUND`、`PRESENTED_IMAGE_NETWORK_ERROR`、`PRESENTED_IMAGE_VERSION_UPDATE` 等场景预设。[#1504](https://github.com/oceanbase/oceanbase-design/pull/1504)
  - 🆕 `status` 新增 `normal` 状态及其插图。[#1504](https://github.com/oceanbase/oceanbase-design/pull/1504)
  - 💄 对齐与 Empty 一致的图标尺寸与间距。[#1505](https://github.com/oceanbase/oceanbase-design/pull/1505)
- Form
  - 🆕 新增 `validateMode` / `reValidateMode`；支持 ConfigProvider 全局配置。[#1512](https://github.com/oceanbase/oceanbase-design/pull/1512)
  - 🆕 `Form.Item` explain 可展示子控件内置的失焦提示与辅助说明。[#1515](https://github.com/oceanbase/oceanbase-design/pull/1515)
  - 💄 调整 explain/extra 内边距，与控件行高度对齐。[#1514](https://github.com/oceanbase/oceanbase-design/pull/1514)
- Input
  - 💄 更新 `Input.Search` 样式与交互。[#1508](https://github.com/oceanbase/oceanbase-design/pull/1508)
- Message
  - 🔄 Message API 保持兼容，展示效果改为 Notification（含 `useMessage`）。[#1507](https://github.com/oceanbase/oceanbase-design/pull/1507)
  - 📌 Message 文档标注弃用，请迁移至 Notification。[#1507](https://github.com/oceanbase/oceanbase-design/pull/1507)
- Notification
  - 💄 默认左下角展示，固定宽度 350px，线性图标与自动关闭进度条；标题/描述内链接使用类型色。[#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
  - 🆕 新增 `notification.loading` 用于进行中反馈。[#1507](https://github.com/oceanbase/oceanbase-design/pull/1507)
  - 🆕 新增 `errorDetails`，支持复制为 Markdown。[#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
  - 🆕 新增 `dedupeKey` 去除重复弹出。[#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
- Table
  - 🆕 新增 `column.tooltip`，在列头展示帮助说明。[#1509](https://github.com/oceanbase/oceanbase-design/pull/1509)

---

## @oceanbase/ui@1.1.0

`2026-08-04`

- Login
  - ✨ 接入 Password 组件与多云密码校验。[#1513](https://github.com/oceanbase/oceanbase-design/pull/1513)
- Password
  - 💥 默认规则对齐多云规范（8–20 位、四类至少 3 种；原为 8–32、各类至少 2 种）。[#1513](https://github.com/oceanbase/oceanbase-design/pull/1513)
  - ✨ 修改密码场景：`mode="plain"` 当前密码、失焦反馈与牢记/复制提示。[#1513](https://github.com/oceanbase/oceanbase-design/pull/1513)
  - 🆕 失焦校验与「请牢记密码」提示自动写入 `Form.Item` explain。[#1515](https://github.com/oceanbase/oceanbase-design/pull/1515)
  - 🆕 默认 `autoComplete="new-password"`（聚焦展示强度气泡）；当前密码使用 `current-password`。[#1515](https://github.com/oceanbase/oceanbase-design/pull/1515)
  - 🌐 更新四语言校验文案。[#1513](https://github.com/oceanbase/oceanbase-design/pull/1513)
- ProTable
  - 🆕 支持 `column.tooltip`，列头帮助图标与 Table 一致。[#1509](https://github.com/oceanbase/oceanbase-design/pull/1509)

---

## @oceanbase/codemod@1.1.0

`2026-08-04`

- 🆕 默认样式迁移输出 `obToken` 与 `var(--ob-*)`，替代 antd token。[#1510](https://github.com/oceanbase/oceanbase-design/pull/1510)
  - 新增 `token-to-obtoken`，用于升级存量 `token.xxx` / `var(--ant-*)` 代码。
  - `less-to-cssvar` / `sass-to-cssvar` 纳入默认流水线。
  - `--token-target=antd` 可恢复 antd token 输出。
- 🆕 新增 `ob-css-tokens` transformer。[#1517](https://github.com/oceanbase/oceanbase-design/pull/1517)
