### PR TITLE
fix(design): top-align Radio and Checkbox for multi-line labels

### DIFF
--- a/packages/design/src/checkbox/style/index.ts
+++ b/packages/design/src/checkbox/style/index.ts
@@ -6,19 +6,18 @@ import { genStyleHooks } from '../../_util/genComponentStyleHook';
 export type CheckboxToken = FullToken<'Checkbox'>;
 
 export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token: CheckboxToken): CSSObject => {
-  const { componentCls, fontSize, lineHeight, lineWidth, controlInteractiveSize, calc } = token;
-  const translateY = calc(fontSize)
-    .mul(lineHeight)
-    .sub(controlInteractiveSize)
-    .sub(lineWidth)
-    .div(2)
-    .equal();
+  const { componentCls, fontSize, lineHeight, controlInteractiveSize, calc } = token;
+  const controlSize = unit(controlInteractiveSize);
+  const marginTop = calc(fontSize).mul(lineHeight).sub(controlInteractiveSize).div(2).equal();
   return {
     [`${componentCls}-wrapper`]: {
+      alignItems: 'flex-start',
       [`${componentCls}`]: {
-        alignSelf: 'baseline',
-        [`${componentCls}-inner`]: {
-          transform: `translate(0px, ${unit(translateY)})`,
+        alignSelf: 'flex-start',
+        lineHeight: 'inherit',
+        marginTop,
+        '@supports (height: 1lh)': {
+          marginTop: `calc((1lh - ${controlSize}) / 2)`,
         },
       },
       [`&:hover ${componentCls}:not(${componentCls}-disabled):not(${componentCls}-checked) ${componentCls}-inner`]:

--- a/packages/design/src/radio/style/index.ts
+++ b/packages/design/src/radio/style/index.ts
@@ -1,4 +1,5 @@
 import type { CSSObject } from '@ant-design/cssinjs';
+import { unit } from '@ant-design/cssinjs';
 import type { FullToken, GenerateStyle } from '../../theme/interface';
 import { genStyleHooks } from '../../_util/genComponentStyleHook';
 
@@ -6,17 +7,21 @@ export type RadioToken = FullToken<'Radio'>;
 
 export const genRadioStyle: GenerateStyle<RadioToken> = (token: RadioToken): CSSObject => {
   const { iconCls, componentCls, radioSize, fontSize, fontSizeLG, lineHeight, calc } = token;
-  const marginBottom = calc(calc(fontSize).mul(lineHeight).equal())
+  const controlSize = unit(radioSize || fontSizeLG);
+  const marginTop = calc(fontSize)
+    .mul(lineHeight)
     .sub(radioSize || fontSizeLG)
-    .div(-2)
-    .sub(1)
+    .div(2)
     .equal();
   return {
     [`${componentCls}-wrapper`]: {
+      alignItems: 'flex-start',
       [`${componentCls}`]: {
-        alignSelf: 'baseline',
-        [`${componentCls}-inner`]: {
-          marginBottom,
+        alignSelf: 'flex-start',
+        lineHeight: 'inherit',
+        marginTop,
+        '@supports (height: 1lh)': {
+          marginTop: `calc((1lh - ${controlSize}) / 2)`,
         },
       },
       [`&:hover ${componentCls}:not(${componentCls}-disabled):not(${componentCls}-checked) ${componentCls}-inner`]:


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Radio and Checkbox labels that wrap to multiple lines previously centered the control vertically against the full text block. The baseline + inner transform/margin approach also drifted in some font and line-height contexts.

This change uses `flex-start` alignment on the wrapper and control, with a token-based `margin-top` fallback and an `@supports (height: 1lh)` override so custom `line-height` can be respected in modern browsers without breaking older ones.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - 💄 Radio and Checkbox controls top-align with multi-line labels; custom `line-height` is respected when the browser supports `lh`. |
| 🇨🇳 Chinese | - 💄 Radio、Checkbox 多行文案时控件与首行顶部对齐；浏览器支持 `lh` 时跟随自定义 `line-height`。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed


Made with [Cursor](https://cursor.com)