### PR TITLE
fix(design): preserve Button icon color inside Upload

### DIFF
--- a/packages/design/src/checkbox/demo/group.tsx
+++ b/packages/design/src/checkbox/demo/group.tsx
@@ -21,8 +21,6 @@ const optionsWithDisabled = [
 const App: React.FC = () => (
   <>
     <Checkbox.Group options={options} defaultValue={['Pear']} onChange={onChange} />
-    <br />
-    <br />
     <Checkbox.Group
       options={optionsWithDisabled}
       disabled

--- a/packages/design/src/radio/index.en-US.md
+++ b/packages/design/src/radio/index.en-US.md
@@ -15,9 +15,9 @@ demo:
 
 <!-- prettier-ignore -->
 <code src="./demo/radio.tsx" title="Radio"></code>
+<code src="./demo/over-length.tsx" title="Over-length Content"></code>
 <code src="./demo/radio-button.tsx" title="Radio Button"></code>
 <code src="./demo/radio-button-icon.tsx" title="Radio Button with Icon"></code>
-<code src="./demo/over-length.tsx" title="Over-length Content"></code>
 
 ## API
 

--- a/packages/design/src/radio/index.md
+++ b/packages/design/src/radio/index.md
@@ -15,9 +15,9 @@ demo:
 
 <!-- prettier-ignore -->
 <code src="./demo/radio.tsx" title="单选"></code>
+<code src="./demo/over-length.tsx" title="超长内容"></code>
 <code src="./demo/radio-button.tsx" title="单选按钮"></code>
 <code src="./demo/radio-button-icon.tsx" title="带图标的单选按钮"></code>
-<code src="./demo/over-length.tsx" title="超长内容"></code>
 
 ## API
 

--- a/packages/design/src/style/global.tsx
+++ b/packages/design/src/style/global.tsx
@@ -191,10 +191,13 @@ const genGlobalStyle = (
             color: token.colorIcon,
           },
         },
-      // handle upload icon style
+      // handle upload icon style, exclude icons inside Button trigger
       [`${uploadComponentCls}`]: {
         [`${iconCls}`]: {
           color: token.colorIcon,
+        },
+        [`${buttonComponentCls} ${iconCls}`]: {
+          color: 'inherit',
         },
       },
     },

--- a/packages/design/src/upload/demo/file-list.tsx
+++ b/packages/design/src/upload/demo/file-list.tsx
@@ -39,7 +39,9 @@ const App: React.FC = () => {
   };
   return (
     <Upload {...props} fileList={fileList}>
-      <Button icon={<UploadOutlined />}>Upload</Button>
+      <Button type="primary" icon={<UploadOutlined />}>
+        Upload
+      </Button>
     </Upload>
   );
 };


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Global Upload icon styles were applying `colorIcon` to all icons inside `.ant-upload`, including icons within a Button used as the upload trigger. This caused Button trigger icons (e.g. primary Upload button) to display the wrong color.

**Solution:** Keep the global Upload icon color rule, then override `.ant-upload .ant-btn .anticon` with `color: inherit` so Button retains its own icon styling. Also updated the file-list demo to use a primary Button trigger and minor demo/doc ordering tweaks.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - 🐛 Fixed Upload global icon color incorrectly overriding Button trigger icons. |
| 🇨🇳 Chinese | - 🐛 修复 Upload 全局图标颜色错误覆盖 Button 触发器内图标的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed


Made with [Cursor](https://cursor.com)