### PR TITLE
fix(design): suppress saved-password dropdown until user interacts with Password

### DIFF
--- a/packages/design/src/input/Password.tsx
+++ b/packages/design/src/input/Password.tsx
@@ -28,6 +28,8 @@ const Password = forwardRef<InputRef, PasswordProps>(
       readOnly,
       onFocus,
       onBlur,
+      onClick,
+      onKeyDown,
       ...restProps
     },
     ref
@@ -51,10 +53,9 @@ const Password = forwardRef<InputRef, PasswordProps>(
       setAutofillLocked(preventSavedPasswordDropdown);
     }, [preventSavedPasswordDropdown]);
 
+    // 保持锁定直到用户真正开始交互。若在 focus 阶段就移除 readonly，Chrome 会在
+    // 焦点处理完成后仍把该字段视为密码字段并弹出已保存密码下拉。
     const handleFocus: AntPasswordProps['onFocus'] = e => {
-      if (preventSavedPasswordDropdown) {
-        setAutofillLocked(false);
-      }
       onFocus?.(e);
     };
 
@@ -63,6 +64,20 @@ const Password = forwardRef<InputRef, PasswordProps>(
         setAutofillLocked(true);
       }
       onBlur?.(e);
+    };
+
+    const handleClick: AntPasswordProps['onClick'] = e => {
+      if (preventSavedPasswordDropdown) {
+        setAutofillLocked(false);
+      }
+      onClick?.(e);
+    };
+
+    const handleKeyDown: AntPasswordProps['onKeyDown'] = e => {
+      if (preventSavedPasswordDropdown) {
+        setAutofillLocked(false);
+      }
+      onKeyDown?.(e);
     };
 
     return wrapCSSVar(
@@ -75,6 +90,8 @@ const Password = forwardRef<InputRef, PasswordProps>(
         readOnly={readOnly ?? (preventSavedPasswordDropdown && autofillLocked)}
         onFocus={handleFocus}
         onBlur={handleBlur}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
         {...(preventSavedPasswordDropdown
           ? {
               'data-lpignore': 'true',

--- a/packages/design/src/input/__tests__/password.test.tsx
+++ b/packages/design/src/input/__tests__/password.test.tsx
@@ -17,11 +17,27 @@ describe('Input.Password autoComplete="new-password"', () => {
     expect(input.getAttribute('autocomplete')).toBe('new-password');
     expect(input.getAttribute('data-lpignore')).toBe('true');
 
+    // 保持 readonly 直到用户真正交互，避免 focus 阶段移除后浏览器弹出已保存密码下拉
     fireEvent.focus(input);
+    expect(input.readOnly).toBe(true);
+
+    fireEvent.click(input);
     expect(input.readOnly).toBe(false);
 
     fireEvent.blur(input);
     expect(input.readOnly).toBe(true);
+  });
+
+  it('unlocks the field once user starts typing', () => {
+    const { container } = render(<Input.Password autoComplete="new-password" />);
+    const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
+    expect(input.readOnly).toBe(true);
+
+    fireEvent.focus(input);
+    expect(input.readOnly).toBe(true);
+
+    fireEvent.keyDown(input, { key: 'a' });
+    expect(input.readOnly).toBe(false);
   });
 
   it('does not apply mitigation for current-password', () => {

--- a/packages/ui/src/Password/__tests__/autofill.test.tsx
+++ b/packages/ui/src/Password/__tests__/autofill.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import Password from '../index';
+
+describe('Password browser saved-password dropdown suppression', () => {
+  it('keeps input readonly while focused and unlocks only after user interaction', () => {
+    const { container } = render(<Password />);
+    const input = container.querySelector('input[type="password"]') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    // 默认 autoComplete="new-password"，初始处于锁定态
+    expect(input.getAttribute('autocomplete')).toBe('new-password');
+    expect(input.readOnly).toBe(true);
+
+    // focus 阶段保持 readonly，浏览器不会弹出已保存密码下拉
+    fireEvent.focus(input);
+    expect(input.readOnly).toBe(true);
+
+    // 用户点击后才解除锁定，输入框变为可编辑
+    fireEvent.click(input);
+    expect(input.readOnly).toBe(false);
+  });
+});


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

1. **Problem**: `Input.Password` (and the `@oceanbase/ui` `Password` that reuses it with `autoComplete="new-password"`) still pops up the browser's saved-password dropdown on focus.
2. **Root cause**: The old readonly lock was released in `onFocus`. Chrome checks the field state *after* focus handling completes, at which point `readonly` has already been removed by React, so the field is treated as a normal password field again and the dropdown appears.
3. **Fix**: Keep the readonly lock until the user actually interacts (click or keydown), then unlock. antd has no special styling for readonly (the `not-allowed` cursor only applies to `disabled`), so appearance is unchanged. `user-event`'s `isEditable` checks `readOnly` on keypress, so unlocking happens before input via click/keydown.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Input.Password<br/>&nbsp;&nbsp;- 🐞 Suppressed the browser saved-password dropdown on focus; the field stays readonly until the user clicks or types, then unlocks as usual. |
| 🇨🇳 Chinese | - Input.Password<br/>&nbsp;&nbsp;- 🐞 修复聚焦时仍弹出浏览器已保存密码下拉的问题；字段保持 readonly，用户点击或输入后才解锁。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed