### PR TITLE
feat(design): add block prop to Typography Text and Link

### DIFF
--- a/packages/design/src/typography/Link.tsx
+++ b/packages/design/src/typography/Link.tsx
@@ -9,7 +9,9 @@ const { Link: AntLink } = AntTypography;
 
 export * from 'antd/es/typography/Link';
 
-export interface LinkProps extends AntLinkProps {}
+export interface LinkProps extends AntLinkProps {
+  block?: boolean;
+}
 
 type CompoundedComponent = React.ForwardRefExoticComponent<
   LinkProps & React.RefAttributes<HTMLElement>
@@ -19,11 +21,11 @@ type CompoundedComponent = React.ForwardRefExoticComponent<
 };
 
 const Link = React.forwardRef<HTMLElement, LinkProps>(
-  ({ editable, prefixCls: customizePrefixCls, className, children, ...restProps }, ref) => {
+  ({ editable, block, prefixCls: customizePrefixCls, className, children, ...restProps }, ref) => {
     const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
     const prefixCls = getPrefixCls('typography', customizePrefixCls);
     const [wrapCSSVar] = useStyle(prefixCls);
-    const typographyCls = useClassName(prefixCls, className, editable);
+    const typographyCls = useClassName(prefixCls, className, editable, undefined, block);
 
     return wrapCSSVar(
       <AntLink

--- a/packages/design/src/typography/Text.tsx
+++ b/packages/design/src/typography/Text.tsx
@@ -11,6 +11,7 @@ export * from 'antd/es/typography/Text';
 
 export interface TextProps extends AntTextProps {
   caption?: boolean;
+  block?: boolean;
 }
 
 type CompoundedComponent = React.ForwardRefExoticComponent<
@@ -22,13 +23,13 @@ type CompoundedComponent = React.ForwardRefExoticComponent<
 
 const Text = React.forwardRef<HTMLSpanElement, TextProps>(
   (
-    { editable, caption, prefixCls: customizePrefixCls, className, children, ...restProps },
+    { editable, caption, block, prefixCls: customizePrefixCls, className, children, ...restProps },
     ref
   ) => {
     const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
     const prefixCls = getPrefixCls('typography', customizePrefixCls);
     const [wrapCSSVar] = useStyle(prefixCls);
-    const typographyCls = useClassName(prefixCls, className, editable, caption);
+    const typographyCls = useClassName(prefixCls, className, editable, caption, block);
 
     return wrapCSSVar(
       <AntText

--- a/packages/design/src/typography/demo/text-block.tsx
+++ b/packages/design/src/typography/demo/text-block.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { Segmented, Typography } from '@oceanbase/design';
+
+const { Text, Link } = Typography;
+
+const textStyle: React.CSSProperties = {
+  padding: '0px 8px',
+  background: 'var(--ob-color-bg-secondary)',
+  borderRadius: 'var(--ob-radius-sm)',
+};
+
+const rowStyle: React.CSSProperties = {
+  marginBottom: 12,
+};
+
+const App: React.FC = () => {
+  const [block, setBlock] = useState<'inline' | 'block'>('inline');
+
+  return (
+    <div>
+      <div style={rowStyle}>
+        <Segmented
+          value={block}
+          onChange={value => setBlock(value as 'inline' | 'block')}
+          options={['inline', 'block']}
+        />
+      </div>
+      <div style={rowStyle}>
+        <Text style={textStyle} block={block === 'block'}>
+          Typography.Text
+        </Text>
+      </div>
+      <div style={rowStyle}>
+        <Link
+          style={textStyle}
+          block={block === 'block'}
+          href="https://design.oceanbase.com"
+          target="_blank"
+        >
+          Typography.Link
+        </Link>
+      </div>
+      <div>
+        <Text style={textStyle} block={block === 'block'} caption>
+          Typography.Text with caption
+        </Text>
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/packages/design/src/typography/hooks/useClassName.ts
+++ b/packages/design/src/typography/hooks/useClassName.ts
@@ -6,13 +6,15 @@ const useClassName = (
   prefixCls: string,
   className: string,
   editable?: BlockProps['editable'],
-  caption?: boolean
+  caption?: boolean,
+  block?: boolean
 ) => {
   const typographyCls = classNames(
     {
       [`${prefixCls}-editable-text`]:
         typeof editable === 'object' && editable?.triggerType?.includes('text'),
       [`${prefixCls}-caption`]: caption,
+      [`${prefixCls}-block`]: block,
     },
     className
   );

--- a/packages/design/src/typography/index.en-US.md
+++ b/packages/design/src/typography/index.en-US.md
@@ -8,6 +8,7 @@ nav:
 - 🔥 Fully inherits antd [Typography](https://ant.design/components/typography-cn) capabilities and API, seamless migration.
 - 💄 Custom theme and styles, aligned with OceanBase Design specification.
 - 🆕 Typography.Text adds `caption` prop for auxiliary description.
+- 🆕 Typography.Text and Typography.Link add `block` prop for occupying a whole line.
 - 📢 Typography.Text and Typography.Paragraph default font color and line height inherit from parent instead of always `token.colorText` and `token.lineHeight`, for easier composition.
 
 ## Code Examples
@@ -16,6 +17,7 @@ nav:
 <code src="./demo/title.tsx" title="Title"></code>
 <code src="./demo/text.tsx" title="Text and Link"></code>
 <code src="./demo/text-caption.tsx" title="Caption" description="Set via `caption` for auxiliary description. Font size 12px, weight auto by locale."></code>
+<code src="./demo/text-block.tsx" title="Block Text" description="Set via `block` to occupy a whole line."></code>
 <code src="./demo/copyable.tsx" title="Copyable"></code>
 <code src="./demo/editable.tsx" title="Editable"></code>
 <code src="./demo/editable-modal.tsx" title="Edit in Modal"></code>
@@ -29,5 +31,12 @@ nav:
 | Property | Description           | Type    | Default | Version |
 | :------- | :-------------------- | :------ | :------ | :------ |
 | caption  | Auxiliary description | boolean | false   | -       |
+| block    | Occupy a whole line   | boolean | false   | -       |
+
+### Typography.Link
+
+| Property | Description         | Type    | Default | Version |
+| :------- | :------------------ | :------ | :------ | :------ |
+| block    | Occupy a whole line | boolean | false   | -       |
 
 - See antd Typography docs for more API: https://ant.design/components/typography-cn

--- a/packages/design/src/typography/index.md
+++ b/packages/design/src/typography/index.md
@@ -8,6 +8,7 @@ nav:
 - 🔥 完全继承 antd [Typography](https://ant.design/components/typography-cn) 的能力和 API，可无缝切换。
 - 💄 定制主题和样式，符合 OceanBase Design 设计规范。
 - 🆕 Typography.Text 新增 `caption` 属性，用于辅助描述的场景。
+- 🆕 Typography.Text 和 Typography.Link 新增 `block` 属性，用于占据一整行的场景。
 - 📢 Typography.Text 和 Typography.Paragraph 的默认字体颜色和行高，会继承父元素的设置，而不总是 `token.colorText` 和 `token.lineHeight`，便于和其他组件组合使用。
 
 ## 代码演示
@@ -16,6 +17,7 @@ nav:
 <code src="./demo/title.tsx" title="标题"></code>
 <code src="./demo/text.tsx" title="文本与超链接"></code>
 <code src="./demo/text-caption.tsx" title="描述文本" description="通过 `caption` 进行设置，用于辅助描述的场景。字体大小为 12px，字重会根据中英文自动设置。"></code>
+<code src="./demo/text-block.tsx" title="整行文本" description="通过 `block` 进行设置，用于占据一整行的场景。"></code>
 <code src="./demo/copyable.tsx" title="可复制"></code>
 <code src="./demo/editable.tsx" title="可编辑"></code>
 <code src="./demo/editable-modal.tsx" title="在 Modal 中编辑"></code>
@@ -26,8 +28,15 @@ nav:
 
 ### Typography.Text
 
-| 参数    | 说明     | 类型    | 默认值 | 版本 |
-| :------ | :------- | :------ | :----- | :--- |
-| caption | 辅助藐视 | boolean | false  |      |
+| 参数    | 说明       | 类型    | 默认值 | 版本 |
+| :------ | :--------- | :------ | :----- | :--- |
+| caption | 辅助藐视   | boolean | false  |      |
+| block   | 占据一整行 | boolean | false  |      |
+
+### Typography.Link
+
+| 参数  | 说明       | 类型    | 默认值 | 版本 |
+| :---- | :--------- | :------ | :----- | :--- |
+| block | 占据一整行 | boolean | false  |      |
 
 - 更多 API详见 antd Typography 文档: https://ant.design/components/typography-cn

--- a/packages/design/src/typography/style/index.ts
+++ b/packages/design/src/typography/style/index.ts
@@ -32,6 +32,9 @@ export const genTypographyStyle: GenerateStyle<TypographyToken> = (
       lineHeight: token.lineHeightSM,
       fontWeight: token.fontWeightWeak,
     },
+    [`${componentCls}-block`]: {
+      display: 'block',
+    },
     [`${componentCls}${componentCls}-editable-text:not(${componentCls}-edit-content)`]: {
       '&:hover': {
         background: token.colorBgContainer,
@@ -46,7 +49,7 @@ export const genTypographyStyle: GenerateStyle<TypographyToken> = (
         marginTop: negativeMarginOffset,
         marginBottom: calc('1em').sub(marginOffset).equal(),
       },
-      'span&:hover': {
+      'span&:hover:not(${componentCls}-block)': {
         display: 'inline-block',
         height: token.controlHeight,
         marginTop: negativeMarginOffset,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

antd Typography 的行内组件 `Text`（span）与 `Link`（a）没有 `block` 属性，无法让行内文本占据整行。本 PR 按现有 `caption` 的扩展模式为二者新增 `block?: boolean`：为真时输出 `ant-typography-block` 类名并应用 `display: block`（order -900，覆盖 antd `span&-ellipsis` 的 `inline-block`），且不透传给底层组件，避免 DOM 残留 `block="true"`。

editable（`triggerType` 含 `'text'`）叠加 `block` 时，hover 保持 `display: block`：editable 的 hover 规则追加 `:not(.ant-typography-block)`，不对 block 元素套用行内元素的高度修正。

```tsx
<Text block>This text occupies a full line</Text>
<Link block href="https://...">This link occupies a full line</Link>
```

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Typography<br/>&nbsp;&nbsp;- 🆕 Added `block` prop to `Typography.Text` and `Typography.Link` so inline text can occupy a full line. |
| 🇨🇳 Chinese | - Typography<br/>&nbsp;&nbsp;- 🆕 `Typography.Text` / `Typography.Link` 新增 `block` 属性，行内文本可占据整行。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed