### PR TITLE
test(design): add unit tests for Alert ghost/mini/banner variants

### DIFF
--- a/packages/design/src/alert/__tests__/index.test.tsx
+++ b/packages/design/src/alert/__tests__/index.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Alert, ConfigProvider } from '@oceanbase/design';
+
+describe('Alert', () => {
+  it('should use warning type by default when banner is set without type', () => {
+    const { container } = render(
+      <ConfigProvider>
+        <Alert banner message="Banner message" />
+      </ConfigProvider>
+    );
+    expect(container.querySelector('.ant-alert-warning')).toBeTruthy();
+  });
+
+  it('should keep the explicit type when banner is set with type', () => {
+    const { container } = render(
+      <ConfigProvider>
+        <Alert banner type="error" message="Banner message" />
+      </ConfigProvider>
+    );
+    expect(container.querySelector('.ant-alert-error')).toBeTruthy();
+    expect(container.querySelector('.ant-alert-warning')).toBeFalsy();
+  });
+
+  it('should render ghost className when ghost is true', () => {
+    const { container } = render(
+      <ConfigProvider>
+        <Alert ghost message="Ghost message" />
+      </ConfigProvider>
+    );
+    expect(container.querySelector('.ant-alert.ant-alert-ghost')).toBeTruthy();
+  });
+
+  it('should render mini className when mini is true', () => {
+    const { container } = render(
+      <ConfigProvider>
+        <Alert mini message="Mini message" />
+      </ConfigProvider>
+    );
+    expect(container.querySelector('.ant-alert.ant-alert-mini')).toBeTruthy();
+  });
+
+  it('should render action className when action is provided', () => {
+    const { container } = render(
+      <ConfigProvider>
+        <Alert message="With action" action={<button type="button">Action</button>} />
+      </ConfigProvider>
+    );
+    expect(container.querySelector('.ant-alert.ant-alert-with-action')).toBeTruthy();
+  });
+
+  it('should render closable className when closable is true', () => {
+    const { container } = render(
+      <ConfigProvider>
+        <Alert message="Closable message" closable />
+      </ConfigProvider>
+    );
+    expect(container.querySelector('.ant-alert.ant-alert-closable')).toBeTruthy();
+  });
+
+  it('should render correct message content', () => {
+    const { getByText } = render(
+      <ConfigProvider>
+        <Alert message="Hello OceanBase" />
+      </ConfigProvider>
+    );
+    expect(getByText('Hello OceanBase')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [ ] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.

| Before | After |
| :--- | :--- |
| [Image] | [Image] |
-->

### 📝 Changelog

<!--
User-perceivable only (one short sentence per language). Omit file paths, CI, and internal tooling.
See .cursor/skills/github-pr-submit/SKILL.md (Changelog). Pure internal work: "No user-facing changes" / "无用户可感知变更".
List breaking changes or risks if any.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Tests is updated/provided or not needed
- [ ] Changelog is provided or not needed
