### PR TITLE
fix(design): render Password as text input to suppress saved-password dropdown

### DIFF
--- a/packages/design/src/input/Password.tsx
+++ b/packages/design/src/input/Password.tsx
@@ -1,7 +1,11 @@
 import React, { forwardRef, useContext, useEffect, useState } from 'react';
 import { Input as AntInput } from 'antd';
+import type { InputRef } from 'antd';
 import type { PasswordProps as AntPasswordProps } from 'antd/es/input/Password';
-import type { InputLocale, InputRef } from './Input';
+import DisabledContext from 'antd/es/config-provider/DisabledContext';
+import { EyeInvisibleOutlined, EyeOutlined } from '@oceanbase/icons';
+import classNames from 'classnames';
+import type { InputLocale } from './Input';
 import ConfigProvider from '../config-provider';
 import type { ConfigConsumerProps } from '../config-provider';
 import defaultLocale from '../locale/en-US';
@@ -18,6 +22,14 @@ function isNewPasswordField(autoComplete?: string): boolean {
   return autoComplete === 'new-password';
 }
 
+const defaultIconRender = (visible: boolean) =>
+  visible ? <EyeOutlined /> : <EyeInvisibleOutlined />;
+
+const actionMap = {
+  click: 'onClick',
+  hover: 'onMouseOver',
+} as const;
+
 const Password = forwardRef<InputRef, PasswordProps>(
   (
     {
@@ -25,9 +37,13 @@ const Password = forwardRef<InputRef, PasswordProps>(
       locale: customLocale,
       showCount,
       autoComplete,
-      readOnly,
-      onFocus,
-      onBlur,
+      action = 'click',
+      visibilityToggle = true,
+      iconRender = defaultIconRender,
+      suffix,
+      className,
+      size,
+      disabled: customDisabled,
       ...restProps
     },
     ref
@@ -35,10 +51,9 @@ const Password = forwardRef<InputRef, PasswordProps>(
     const { getPrefixCls, locale: contextLocale } = useContext<ConfigConsumerProps>(
       ConfigProvider.ConfigContext
     );
-    const prefixCls = getPrefixCls('input', customizePrefixCls);
-    const [wrapCSSVar] = useStyle(prefixCls);
-    const preventSavedPasswordDropdown = isNewPasswordField(autoComplete);
-    const [autofillLocked, setAutofillLocked] = useState(preventSavedPasswordDropdown);
+    const inputPrefixCls = getPrefixCls('input', customizePrefixCls);
+    const prefixCls = getPrefixCls('input-password', customizePrefixCls);
+    const [wrapCSSVar] = useStyle(inputPrefixCls);
     const inputLocale: InputLocale = {
       placeholder:
         contextLocale?.global?.inputPlaceholder || defaultLocale.global?.inputPlaceholder,
@@ -47,35 +62,78 @@ const Password = forwardRef<InputRef, PasswordProps>(
       ...customLocale,
     };
 
+    // 以 type="text" + -webkit-text-security 呈现密码遮蔽，
+    // 避免浏览器识别为原生密码框而弹出密码保存/填充下拉
+    const disabled = useContext(DisabledContext);
+    const mergedDisabled = customDisabled ?? disabled;
+
+    const visibilityControlled =
+      typeof visibilityToggle === 'object' && visibilityToggle.visible !== undefined;
+    const [visible, setVisible] = useState<boolean>(() =>
+      visibilityControlled ? (visibilityToggle.visible ?? false) : false
+    );
+
     useEffect(() => {
-      setAutofillLocked(preventSavedPasswordDropdown);
-    }, [preventSavedPasswordDropdown]);
-
-    const handleFocus: AntPasswordProps['onFocus'] = e => {
-      if (preventSavedPasswordDropdown) {
-        setAutofillLocked(false);
+      if (visibilityControlled) {
+        setVisible(visibilityToggle.visible ?? false);
       }
-      onFocus?.(e);
+    }, [visibilityControlled, visibilityToggle]);
+
+    const onVisibleChange = () => {
+      if (mergedDisabled) {
+        return;
+      }
+      const nextVisible = !visible;
+      setVisible(nextVisible);
+      if (typeof visibilityToggle === 'object') {
+        visibilityToggle.onVisibleChange?.(nextVisible);
+      }
     };
 
-    const handleBlur: AntPasswordProps['onBlur'] = e => {
-      if (preventSavedPasswordDropdown) {
-        setAutofillLocked(true);
-      }
-      onBlur?.(e);
+    const getIcon = (iconPrefixCls: string) => {
+      const icon = iconRender(visible);
+      const iconTrigger = actionMap[action];
+      const iconProps = {
+        className: `${iconPrefixCls}-icon`,
+        key: 'passwordIcon',
+        onMouseDown: (e: React.MouseEvent<HTMLElement>) => {
+          // 防止点击图标时输入框失焦
+          e.preventDefault();
+        },
+        onMouseUp: (e: React.MouseEvent<HTMLElement>) => {
+          // 防止光标位置变化
+          e.preventDefault();
+        },
+        [iconTrigger]: onVisibleChange,
+      };
+      return React.cloneElement(React.isValidElement(icon) ? icon : <span>{icon}</span>, iconProps);
     };
+
+    const inputClassName = classNames(prefixCls, className, {
+      [`${prefixCls}-${size}`]: !!size,
+    });
+
+    const suffixIcon = visibilityToggle && getIcon(prefixCls);
 
     return wrapCSSVar(
-      <AntInput.Password
+      <AntInput
         ref={ref}
+        type="text"
         prefixCls={customizePrefixCls}
+        className={inputClassName}
+        size={size}
         placeholder={inputLocale.placeholder}
         showCount={showCount === true ? { formatter: showCountFormatter } : showCount}
         autoComplete={autoComplete}
-        readOnly={readOnly ?? (preventSavedPasswordDropdown && autofillLocked)}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        {...(preventSavedPasswordDropdown
+        disabled={customDisabled}
+        suffix={
+          <>
+            {suffixIcon}
+            {suffix}
+          </>
+        }
+        classNames={{ input: visible ? undefined : `${inputPrefixCls}-text-security` }}
+        {...(isNewPasswordField(autoComplete)
           ? {
               'data-lpignore': 'true',
               'data-1p-ignore': 'true',

--- a/packages/design/src/input/__tests__/password.test.tsx
+++ b/packages/design/src/input/__tests__/password.test.tsx
@@ -2,32 +2,37 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { Input } from '@oceanbase/design';
 
-describe('Input.Password autoComplete="new-password"', () => {
-  it('does not lock input by default', () => {
+describe('Input.Password', () => {
+  it('renders as text input masked by -webkit-text-security', () => {
     const { container } = render(<Input.Password />);
     const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
+    expect(input.getAttribute('type')).toBe('text');
+    expect(input.classList.contains('ant-input-text-security')).toBe(true);
     expect(input.readOnly).toBe(false);
-    expect(input.getAttribute('autocomplete')).toBeNull();
   });
 
-  it('applies saved-password dropdown mitigation for new-password', () => {
+  it('reveals plain text when visibility toggled', () => {
+    const { container } = render(<Input.Password defaultValue="password" />);
+    const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
+    expect(input.classList.contains('ant-input-text-security')).toBe(true);
+
+    fireEvent.click(container.querySelector('.ant-input-password-icon') as HTMLElement);
+    expect(input.classList.contains('ant-input-text-security')).toBe(false);
+
+    fireEvent.click(container.querySelector('.ant-input-password-icon') as HTMLElement);
+    expect(input.classList.contains('ant-input-text-security')).toBe(true);
+  });
+
+  it('keeps third-party password manager ignore attrs for new-password', () => {
     const { container } = render(<Input.Password autoComplete="new-password" />);
     const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
-    expect(input.readOnly).toBe(true);
     expect(input.getAttribute('autocomplete')).toBe('new-password');
     expect(input.getAttribute('data-lpignore')).toBe('true');
-
-    fireEvent.focus(input);
-    expect(input.readOnly).toBe(false);
-
-    fireEvent.blur(input);
-    expect(input.readOnly).toBe(true);
   });
 
   it('does not apply mitigation for current-password', () => {
     const { container } = render(<Input.Password autoComplete="current-password" />);
     const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
-    expect(input.readOnly).toBe(false);
     expect(input.getAttribute('data-lpignore')).toBeNull();
   });
 });

--- a/packages/design/src/input/index.en-US.md
+++ b/packages/design/src/input/index.en-US.md
@@ -16,7 +16,7 @@ demo:
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx" title="Basic" description="Default `placeholder` filled."></code>
 <code src="./demo/search.tsx" title="Search"></code>
-<code src="./demo/password.tsx" title="Password" description='Use `autoComplete="new-password"` for new-password fields; Input.Password applies extra hints to reduce saved-password dropdown overlap. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete).'></code>
+<code src="./demo/password.tsx" title="Password" description='For new-password fields, set `autoComplete="new-password"` to disable browser autofill, password manager, and saved-password dropdown prompts. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete).'></code>
 <code src="./demo/presuffix.tsx" title="Prefix and Suffix" description="Add prefix or suffix icon to input."></code>
 <code src="./demo/showCount.tsx" title="Character Count" description="Cannot input beyond max length."></code>
 <code src="./demo/allowClear.tsx" title="Clear Icon" description="One-click clear input."></code>
@@ -27,4 +27,4 @@ demo:
 
 ### Input.Password extensions
 
-When `autoComplete="new-password"`, the component also uses readOnly-until-focus and password-manager `data-*` hints to reduce saved-password dropdown overlap beyond the standard autocomplete value.
+The password is rendered as a text input masked with text-security, so browsers do not treat it as a password field and no saved-password dropdown appears on focus. When `autoComplete="new-password"`, the component also attaches password-manager `data-*` hints to avoid misdetection by third-party password managers.

--- a/packages/design/src/input/index.md
+++ b/packages/design/src/input/index.md
@@ -16,7 +16,7 @@ demo:
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx" title="基本使用" description="默认填充 `placeholder`。"></code>
 <code src="./demo/search.tsx" title="搜索框"></code>
-<code src="./demo/password.tsx" title="密码输入框" description='新密码请设 `autoComplete="new-password"`，组件会减轻浏览器已保存密码下拉遮挡；详见 [MDN](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Attributes/autocomplete)。'></code>
+<code src="./demo/password.tsx" title="密码输入框" description='新密码请设 `autoComplete="new-password"`，会禁用浏览器的自动填充、密码管理器和已保存密码的下拉提示，详见 [MDN](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Attributes/autocomplete)。'></code>
 <code src="./demo/presuffix.tsx" title="前缀和后缀" description="在输入框上添加前缀或后缀图标。"></code>
 <code src="./demo/showCount.tsx" title="字数提示" description="超出字数长度后无法输入。"></code>
 <code src="./demo/allowClear.tsx" title="清除图标" description="用于一键清除输入内容。"></code>
@@ -27,4 +27,4 @@ demo:
 
 ### Input.Password 扩展
 
-`autoComplete="new-password"` 时，除标准语义外还会：失焦前 `readOnly`、聚焦解锁，并附加密码管理器 `data-*` hint，减轻已保存密码下拉遮挡 UI。
+密码框以 text 型输入 + text-security 遮蔽呈现，浏览器不会将其识别为密码框，focus 时不会弹出已保存密码下拉。`autoComplete="new-password"` 时，组件会附加密码管理器 `data-*` hint，进一步避免第三方密码管理器误识别。

--- a/packages/design/src/input/style/index.ts
+++ b/packages/design/src/input/style/index.ts
@@ -20,6 +20,10 @@ export const genInputStyle: GenerateStyle<InputToken> = (token: InputToken): CSS
         },
       },
     },
+    // 密码以 text 型输入呈现，借助 text-security 遮蔽文本，浏览器不将其识别为密码框
+    [`${componentCls}-text-security`]: {
+      WebkitTextSecurity: 'disc',
+    },
   };
 };
 

--- a/packages/ui/src/Password/__tests__/rememberHint.test.tsx
+++ b/packages/ui/src/Password/__tests__/rememberHint.test.tsx
@@ -11,7 +11,7 @@ describe('Password remember hint in Form.Item', () => {
   it('shows remember hint in Form.Item explain after valid blur', async () => {
     const user = userEvent.setup();
 
-    render(
+    const { container } = render(
       <Form>
         <Form.Item name="password" label="Password">
           <Password />
@@ -19,8 +19,11 @@ describe('Password remember hint in Form.Item', () => {
       </Form>
     );
 
-    const passwordInput = document.querySelector('input[type="password"]') as HTMLInputElement;
+    const passwordInput = container.querySelector('.ant-input-password input') as HTMLInputElement;
     expect(passwordInput).toBeTruthy();
+    // 密码以 text 型输入 + text-security 遮蔽呈现，浏览器不将其识别为密码框
+    expect(passwordInput.getAttribute('type')).toBe('text');
+    expect(passwordInput.classList.contains('ant-input-text-security')).toBe(true);
 
     await user.type(passwordInput, VALID_PASSWORD);
     await user.tab();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

`Input.Password` previously rendered a native `type="password"` input. Browsers treat such fields as password fields and show the saved-password dropdown on focus; the earlier `readOnly`-until-focus workaround (PR #1524) was reverted (#1526) and did not fully remove the dropdown for all autocomplete values.

This PR switches the underlying input to `type="text"` masked with `-webkit-text-security: disc`, so the browser no longer recognizes it as a password field:

- The browser saved-password / autofill dropdown no longer appears on focus (for any `autoComplete` value, including `current-password`).
- Password visibility toggle, `visibilityToggle` (controlled + uncontrolled), `iconRender`, `action`, `suffix`, `size`, `disabled` (incl. `DisabledContext`), `showCount`, `autoComplete` and `readOnly` all keep the previous public API and behavior.
- Third-party password manager `data-*` hints (`data-lpignore`, etc.) are kept for `autoComplete="new-password"`.

Note: browsers will no longer offer to save the password for `current-password` fields — that is the intended trade-off of this approach.

Tests updated in `@oceanbase/design` (Password) and `@oceanbase/ui` (remember hint); all pass, including axe a11y smoke tests.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Input.Password<br/>&nbsp;&nbsp;- 🐞 No longer shows the browser's saved-password dropdown on focus; the input is masked with text-security instead of a native password field. |
| 🇨🇳 Chinese | - Input.Password<br/>&nbsp;&nbsp;- 🐞 聚焦时不再弹出浏览器已保存密码的下拉提示，密码改用 text-security 方式遮蔽，不再使用原生密码框。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed