### PR TITLE
feat(design): add lightweight css ellipsis mode for Tag

### DIFF
--- a/packages/design/src/tag/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/design/src/tag/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,18 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Tag > css ellipsis renders lightweight structure without typography 1`] = `
+<span
+  class="ant-tag ant-tag-ellipsis-css"
+  title="Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess."
+>
+  <span
+    class="ant-tag-ellipsis-css-content"
+  >
+    Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.
+  </span>
+</span>
+`;
+
 exports[`Tag > custom ellipsis 1`] = `
 <span
   class="ant-tag ant-tag-ellipsis"

--- a/packages/design/src/tag/__tests__/index.test.tsx
+++ b/packages/design/src/tag/__tests__/index.test.tsx
@@ -55,4 +55,42 @@ describe('Tag', () => {
     expect(container.querySelector('.ant-tag-ellipsis')).toBeFalsy();
     expect(asFragment().firstChild).toMatchSnapshot();
   });
+
+  it('css ellipsis renders lightweight structure without typography', async () => {
+    const { container, asFragment } = render(
+      <Tag ellipsis="css">
+        Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for
+        excess.Show ellipsis for excess.
+      </Tag>
+    );
+    expect(container.querySelector('.ant-typography')).toBeFalsy();
+    expect(container.querySelector('.ant-typography-ellipsis')).toBeFalsy();
+    expect(container.querySelector('.ant-tag-ellipsis')).toBeFalsy();
+    expect(container.querySelector('.ant-tag-ellipsis-css')).toBeTruthy();
+    expect(container.querySelector('.ant-tag-ellipsis-css-content')).toBeTruthy();
+    // 字符串 children 自动派生原生 title
+    const tag = container.querySelector('.ant-tag');
+    expect(tag?.getAttribute('title')).toBe(
+      'Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.'
+    );
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('css ellipsis prefers explicit title prop', async () => {
+    const { container } = render(
+      <Tag ellipsis="css" title="Explicit Title">
+        Show ellipsis for excess.Show ellipsis for excess.
+      </Tag>
+    );
+    expect(container.querySelector('.ant-tag')?.getAttribute('title')).toBe('Explicit Title');
+  });
+
+  it('css ellipsis does not derive title from structured children', async () => {
+    const { container } = render(
+      <Tag ellipsis="css">
+        <span>Structured</span>
+      </Tag>
+    );
+    expect(container.querySelector('.ant-tag')?.getAttribute('title')).toBeNull();
+  });
 });

--- a/packages/design/src/tag/demo/ellipsis-css.tsx
+++ b/packages/design/src/tag/demo/ellipsis-css.tsx
@@ -1,0 +1,34 @@
+import { CheckCircleOutlined } from '@oceanbase/icons';
+import { Space, Tag } from '@oceanbase/design';
+import React from 'react';
+
+const App: React.FC = () => (
+  <Space direction="vertical" style={{ width: '100%' }}>
+    <Tag ellipsis="css">
+      Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for
+      excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show
+      ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for
+      excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.
+    </Tag>
+    <Tag ellipsis="css" icon={<CheckCircleOutlined />} closable>
+      Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for
+      excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show
+      ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for
+      excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.
+    </Tag>
+    <Tag
+      ellipsis="css"
+      title="This is custom title"
+      style={{
+        width: 400,
+      }}
+    >
+      Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for
+      excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show
+      ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for
+      excess.Show ellipsis for excess.Show ellipsis for excess.Show ellipsis for excess.
+    </Tag>
+  </Space>
+);
+
+export default App;

--- a/packages/design/src/tag/index.en-US.md
+++ b/packages/design/src/tag/index.en-US.md
@@ -10,6 +10,7 @@ nav:
 - 🆕 New `critical` status color for severe scenarios (e.g. critical alert level).
 - 🆕 New `pill` prop for pill-style tag.
 - 🆕 New `ellipsis` prop for overflow ellipsis and Tooltip.
+- 🆕 New `ellipsis="css"` lightweight mode: pure CSS truncation + native `title` (auto-derived from string children), zero measuring/Tooltip overhead, for tag-dense scenes such as detail pages and tables.
 
 ## Code Examples
 
@@ -22,13 +23,14 @@ nav:
 <code src="./demo/icon.tsx" title="Custom Icon and Color"></code>
 <code src="./demo/borderless.tsx" title="Borderless"></code>
 <code src="./demo/checkable.tsx" title="Checkable Tag"></code>
-<code src="./demo/ellipsis.tsx" title="Over-length Ellipsis"></code>
+<code src="./demo/ellipsis.tsx" title="Over-length Ellipsis" description="Default mode based on overflow detection with Tooltip; for few tags, or when custom Tooltip content / placement is needed."></code>
+<code src="./demo/ellipsis-css.tsx" title="Lightweight Ellipsis" description="`ellipsis='css'` uses pure CSS truncation + native `title`, no measuring or Tooltip overhead, ideal for tag-dense detail pages and tables. A width-constrained parent (e.g. `max-width`, flex layout) is required for the ellipsis to appear, and the hint must be plain text."></code>
 
 ## API
 
 | Property | Description | Type | Default |
 | :-- | :-- | :-- | :-- |
 | pill | Whether pill style | `boolean` | false |
-| ellipsis | Auto-ellipsis when over-length | `boolean` \| [EllipsisConfig](https://ant-design.antgroup.com/components/typography-cn#ellipsis) | true |
+| ellipsis | Auto-ellipsis when over-length. `"css"` is the lightweight mode: pure CSS single-line truncation + native `title` (auto-derived from string children), no Tooltip and no measuring overhead, but a width-constrained parent (e.g. `max-width`, flex layout) is required for the ellipsis to appear; ideal for tag-dense scenes. `true` or an [EllipsisConfig](https://ant-design.antgroup.com/components/typography-cn#ellipsis) is the full mode: overflow detection + Tooltip, custom tooltip content and multi-line ellipsis supported | `boolean` \| [EllipsisConfig](https://ant-design.antgroup.com/components/typography-cn#ellipsis) \| `"css"` | true |
 
 - See antd Tag docs: https://ant.design/components/tag-cn/

--- a/packages/design/src/tag/index.md
+++ b/packages/design/src/tag/index.md
@@ -10,6 +10,7 @@ nav:
 - 🆕 新增 `critical` 状态色，用于表示严重的场景，比如告警等级-严重。
 - 🆕 新增 `pill` 属性，用于设置胶囊标签样式。
 - 🆕 新增 `ellipsis` 属性，用于配置内容溢出时的省略和 Tooltip 提示。
+- 🆕 新增 `ellipsis="css"` 轻量省略模式：纯 CSS 截断 + 原生 `title`（字符串内容自动派生），不引入测量和 Tooltip 开销，适合标签数量多的场景，如详情页、表格。
 
 ## 代码演示
 
@@ -22,13 +23,14 @@ nav:
 <code src="./demo/icon.tsx" title="自定义图标和颜色"></code>
 <code src="./demo/borderless.tsx" title="无边框模式"></code>
 <code src="./demo/checkable.tsx" title="可选择标签"></code>
-<code src="./demo/ellipsis.tsx" title="内容超长自动省略"></code>
+<code src="./demo/ellipsis.tsx" title="内容超长自动省略" description="默认模式基于溢出检测与 Tooltip 提示，适合少量标签；需要自定义 Tooltip 内容或 placement 时使用。"></code>
+<code src="./demo/ellipsis-css.tsx" title="轻量级省略" description="`ellipsis='css'` 走纯 CSS 截断 + 原生 title，无测量与 Tooltip 开销，适合标签数量多的详情页、表格；需要父容器有宽度约束（如 `max-width`、flex 布局）才会出现省略号，提示内容需为纯文本。"></code>
 
 ## API
 
 | 参数 | 说明 | 类型 | 默认值 |
 | :-- | :-- | :-- | :-- |
 | pill | 是否使用胶囊标签样式 | `boolean` | false |
-| ellipsis | 内容超长时是否自动省略 | `boolean` \| [EllipsisConfig](https://ant-design.antgroup.com/components/typography-cn#ellipsis) | true |
+| ellipsis | 内容超长时是否自动省略。`"css"` 为轻量模式：纯 CSS 单行截断 + 原生 `title`（字符串内容自动派生），无 Tooltip、无测量开销，但需要父容器有宽度约束（如 `max-width`、flex 布局）才会出现省略号，适合标签密集场景；`true` 或 [EllipsisConfig](https://ant-design.antgroup.com/components/typography-cn#ellipsis) 为完整模式：溢出检测 + Tooltip，支持自定义提示内容与多行省略 | `boolean` \| [EllipsisConfig](https://ant-design.antgroup.com/components/typography-cn#ellipsis) \| `"css"` | true |
 
 - 详见 antd Tag 文档: https://ant.design/components/tag-cn/

--- a/packages/design/src/tag/index.tsx
+++ b/packages/design/src/tag/index.tsx
@@ -11,7 +11,7 @@ import type { Ellipsis } from '../_util/getEllipsisConfig';
 export * from 'antd/es/tag';
 
 export interface TagProps extends AntTagProps {
-  ellipsis?: Ellipsis;
+  ellipsis?: Ellipsis | 'css';
   pill?: boolean;
 }
 
@@ -30,6 +30,7 @@ const Tag = React.forwardRef<HTMLSpanElement, TagProps>(
       },
       pill,
       className,
+      title,
       ...restProps
     },
     ref
@@ -38,12 +39,15 @@ const Tag = React.forwardRef<HTMLSpanElement, TagProps>(
     const prefixCls = getPrefixCls('tag', customizePrefixCls);
     const [wrapCSSVar] = useStyle(prefixCls);
     const isCritical = colorProp === 'critical';
+    // css 模式走纯 CSS 截断 + 原生 title，不包 Typography.Text，避免每个 Tag 都挂测量与 Tooltip 逻辑
+    const isCssEllipsis = ellipsis === 'css';
 
-    const ellipsisConfig = getEllipsisConfig(ellipsis, children);
+    const ellipsisConfig = isCssEllipsis ? undefined : getEllipsisConfig(ellipsis, children);
     const tagCls = classNames(
       {
         [`${prefixCls}-closable`]: !!closable,
         [`${prefixCls}-ellipsis`]: !!ellipsisConfig,
+        [`${prefixCls}-ellipsis-css`]: isCssEllipsis,
         [`${prefixCls}-pill`]: pill,
         [`${prefixCls}-critical`]: isCritical,
       },
@@ -52,18 +56,29 @@ const Tag = React.forwardRef<HTMLSpanElement, TagProps>(
 
     const realIcon = icon ? <span className={`${prefixCls}-icon`}>{icon}</span> : null;
 
+    // 原生 title 仅支持纯文本，字符串 children 自动派生；结构化 children 需业务显式传 title
+    const mergedTitle =
+      title !== undefined
+        ? title
+        : isCssEllipsis && typeof children === 'string'
+          ? children
+          : title;
+
     return wrapCSSVar(
       <AntTag
         ref={ref}
         prefixCls={customizePrefixCls}
         className={tagCls}
-        icon={ellipsisConfig ? null : icon}
+        title={mergedTitle}
+        icon={isCssEllipsis ? icon : ellipsisConfig ? null : icon}
         // treat critical as preset status, avoid being treated as custom color
         color={isCritical ? undefined : colorProp}
         closable={closable}
         {...restProps}
       >
-        {ellipsisConfig ? (
+        {isCssEllipsis ? (
+          <span className={`${prefixCls}-ellipsis-css-content`}>{children}</span>
+        ) : ellipsisConfig ? (
           <Typography.Text ellipsis={ellipsisConfig}>
             {/* Typography.Text 存在 ellipsis 配置时 ，将 icon 放在 Typography.Text 内部，避免溢出时与 icon 发生样式冲突。这里保留 Typography.Text 主要为了使用 Typography.Text 的判断内容溢出展示 Tooltip 的能力，自定义实现成本过大 */}
             {realIcon}

--- a/packages/design/src/tag/style/index.ts
+++ b/packages/design/src/tag/style/index.ts
@@ -69,6 +69,25 @@ export const genTagStyle = (token: TagToken): CSSObject => {
           maxWidth: `calc(100% - ${unit(token.marginSM)})`,
         },
       },
+      [`&${componentCls}-ellipsis-css`]: {
+        maxWidth: '100%',
+        overflow: 'hidden',
+        verticalAlign: 'bottom',
+        [`${componentCls}-ellipsis-css-content`]: {
+          display: 'inline-block',
+          maxWidth: '100%',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          verticalAlign: 'bottom',
+        },
+      },
+      [`&${componentCls}-closable${componentCls}-ellipsis-css`]: {
+        [`${componentCls}-ellipsis-css-content`]: {
+          // maxWidth should match (close icon left margin + tag right padding)
+          maxWidth: `calc(100% - ${unit(token.marginSM)})`,
+        },
+      },
       ['&-checkable']: {
         borderColor: 'transparent',
       },


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [x] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Tag currently enables ellipsis by default (`ellipsis = { tooltip: { title: children } }`), which mounts a `Typography.Text` + overflow measuring + Tooltip on every Tag. In tag-dense scenes such as semantic-model detail pages and tables (dozens to hundreds of tags), this measuring/Tooltip overhead becomes a visible rendering cost.

This PR adds a new `ellipsis="css"` string mode:

- **Pure CSS single-line truncation** (`text-overflow: ellipsis`) — zero JS measuring, zero Tooltip, flat DOM (no `Typography.Text` wrapper).
- **Native `title` auto-derived from string children**; an explicit `title` prop always wins; structured children need an explicit `title`.
- Requires a width-constrained parent (e.g. `max-width`, flex layout) for the ellipsis to appear; the hint is plain text only.
- **Non-breaking**: the default `ellipsis` (Typography + Tooltip) behavior is unchanged.

Usage:

```tsx
<Tag ellipsis="css">some long label that exceeds the container width...</Tag>
```

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Tag<br/>&nbsp;&nbsp;- 🆕 New `ellipsis="css"` lightweight mode: pure CSS single-line truncation with native `title` (auto-derived from string children), no measuring or Tooltip overhead, ideal for tag-dense scenes such as detail pages and tables. |
| 🇨🇳 Chinese | - Tag<br/>&nbsp;&nbsp;- 🆕 新增 `ellipsis="css"` 轻量省略模式：纯 CSS 单行截断 + 原生 `title`（字符串内容自动派生），无测量与 Tooltip 开销，适合详情页、表格等标签密集场景。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed