### PR TITLE
fix(design): add units to Typography editable padding and margins

### DIFF
--- a/packages/design/src/typography/style/index.ts
+++ b/packages/design/src/typography/style/index.ts
@@ -13,7 +13,7 @@ export const genTypographyStyle: GenerateStyle<TypographyToken> = (
     .sub(calc(fontSize).mul(lineHeight).equal())
     .div(2)
     .equal();
-  const paddingTop = calc(marginOffset).sub(token.lineWidth).equal();
+  const paddingBlock = calc(marginOffset).sub(token.lineWidth).equal();
   const paddingInline = calc(token.paddingSM).sub(token.lineWidth).equal();
   const negativeMarginOffset = calc(marginOffset).mul(-1).equal();
 
@@ -42,22 +42,22 @@ export const genTypographyStyle: GenerateStyle<TypographyToken> = (
         borderRadius: token.borderRadius,
         position: 'relative',
         insetInlineStart: calc(token.paddingSM).mul(-1).equal(),
-        padding: `${paddingTop} ${paddingInline}`,
+        paddingBlock,
+        paddingInline,
       },
       'div&:hover': {
-        height: token.controlHeight,
         marginTop: negativeMarginOffset,
-        marginBottom: calc('1em').sub(marginOffset).equal(),
+        // should use css calc instead token calc
+        marginBottom: `calc(1em - ${marginOffset}px)`,
       },
       'span&:hover:not(${componentCls}-block)': {
         display: 'inline-block',
-        height: token.controlHeight,
         marginTop: negativeMarginOffset,
         marginBottom: negativeMarginOffset,
       },
       'h1&:hover, h2&:hover, h3&:hover, h4&:hover, h5&:hover': {
-        marginTop: `${negativeMarginOffset} !important`,
-        marginBottom: `${negativeMarginOffset} !important`,
+        marginTop: `${unit(negativeMarginOffset)} !important`,
+        marginBottom: `${unit(negativeMarginOffset)} !important`,
       },
     },
     [`${componentCls}${componentCls}-edit-content`]: {
@@ -65,7 +65,8 @@ export const genTypographyStyle: GenerateStyle<TypographyToken> = (
         insetInlineStart: calc(token.paddingSM).mul(-1).equal(),
         insetBlockStart: 0,
         marginTop: negativeMarginOffset,
-        marginBottom: calc('1em').sub(marginOffset).equal(),
+        // should use css calc instead token calc
+        marginBottom: `calc(1em - ${marginOffset}px)`,
       },
       [`${componentCls}-span&`]: {
         insetInlineStart: calc(token.paddingSM).mul(-1).equal(),
@@ -77,8 +78,8 @@ export const genTypographyStyle: GenerateStyle<TypographyToken> = (
         {
           insetInlineStart: calc(token.paddingSM).mul(-1).equal(),
           insetBlockStart: 0,
-          marginTop: `${negativeMarginOffset} !important`,
-          marginBottom: `${negativeMarginOffset} !important`,
+          marginTop: `${unit(negativeMarginOffset)} !important`,
+          marginBottom: `${unit(negativeMarginOffset)} !important`,
         },
     },
   };


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Editable Typography hover/edit styles generated unit-less CSS values (`padding: "4.000200000000001 11"`, `margin: "-5.000200000000001 !important"`) because `calc(...).equal()` returns bare numbers that were interpolated into template literals without a unit. Browsers drop such invalid declarations, so the editable hover ring and edit-mode offset were not applied.

Fix: pass `unit()` around interpolated calc results, split `padding` into `paddingBlock`/`paddingInline`, and use native CSS `calc(1em - Npx)` for margins mixing `em` with computed px offsets.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Typography<br/>&nbsp;&nbsp;- 🐞 Fixed editable text hover ring and edit-mode offset not rendering due to missing units in generated styles. |
| 🇨🇳 Chinese | - Typography<br/>&nbsp;&nbsp;- 🐞 修复 Typography 可编辑文本 hover 描边与编辑态偏移因样式缺少单位而失效的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed