### PR TITLE
fix(design): restore baseline alignment of Radio and Checkbox wrappers

### DIFF
--- a/packages/design/src/checkbox/style/index.ts
+++ b/packages/design/src/checkbox/style/index.ts
@@ -11,7 +11,6 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token: CheckboxTo
   const marginTop = calc(fontSize).mul(lineHeight).sub(controlInteractiveSize).div(2).equal();
   return {
     [`${componentCls}-wrapper`]: {
-      alignItems: 'flex-start',
       [`${componentCls}`]: {
         alignSelf: 'flex-start',
         lineHeight: 'inherit',

--- a/packages/design/src/radio/style/index.ts
+++ b/packages/design/src/radio/style/index.ts
@@ -15,7 +15,6 @@ export const genRadioStyle: GenerateStyle<RadioToken> = (token: RadioToken): CSS
     .equal();
   return {
     [`${componentCls}-wrapper`]: {
-      alignItems: 'flex-start',
       [`${componentCls}`]: {
         alignSelf: 'flex-start',
         lineHeight: 'inherit',


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

Regression introduced by #1522.

### 💡 Background and solution

#1522 set `align-items: flex-start` on the Radio/Checkbox wrapper to top-align the control with multi-line labels. This overrides the wrapper's default baseline alignment, so when the wrapper sits in a flex row with other elements (e.g. Form items, toolbars), the whole wrapper loses its baseline alignment and vertical centering against adjacent elements breaks.

This fix keeps the top-align mechanism scoped to the control itself (`align-self: flex-start` + token-based `margin-top`) and removes the wrapper-level `align-items` override, so multi-line labels still top-align while the wrapper keeps its default baseline alignment in parent flex contexts.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Radio / Checkbox<br/>&nbsp;&nbsp;- 🐞 Restored baseline alignment of Radio and Checkbox wrappers in flex layouts. |
| 🇨🇳 Chinese | - Radio / Checkbox<br/>&nbsp;&nbsp;- 🐞 恢复 Radio、Checkbox 在外层 flex 布局中与相邻元素的基线对齐。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed