### PR TITLE
feat(design): support ReactNode in Table column.tooltip

### DIFF
--- a/packages/design/src/index.ts
+++ b/packages/design/src/index.ts
@@ -57,7 +57,7 @@ export { default as List } from './list';
 export type { ListProps } from './list';
 
 export { default as Table } from './table';
-export type { TableProps } from './table';
+export type { TableProps, TableColumnsType } from './table';
 
 export { default as Tabs } from './tabs';
 export type { TabsProps } from './tabs';

--- a/packages/design/src/table/ColumnTitleWithTooltip.tsx
+++ b/packages/design/src/table/ColumnTitleWithTooltip.tsx
@@ -7,6 +7,11 @@ import type { TooltipProps } from '../tooltip';
 import type { WrapperTooltipProps } from '../form/FormItem';
 import { useTooltipTypeList } from '../tooltip/hooks/useTooltipTypeList';
 
+/**
+ * 列头帮助提示，语义与 Form.Item.tooltip 对齐：
+ * - ReactNode（含 JSX）作为 Tooltip 提示内容，触发图标默认为问号；
+ * - WrapperTooltipProps 通过 `title` 指定内容、`icon` 自定义触发图标。
+ */
 export type ColumnTooltipType = WrapperTooltipProps | ReactNode;
 
 export function getColumnTooltip(column: Record<string, any>): ColumnTooltipType | undefined {
@@ -19,7 +24,8 @@ export function isValidColumnTooltip(
   if (tooltip == null || tooltip === '') {
     return false;
   }
-  if (React.isValidElement(tooltip)) {
+  // 字符串、JSX、数组等 ReactNode 均视为有效提示内容
+  if (React.isValidElement(tooltip) || Array.isArray(tooltip)) {
     return true;
   }
   if (typeof tooltip === 'object') {
@@ -50,14 +56,12 @@ export const ColumnTitleWithTooltip: React.FC<ColumnTitleWithTooltipProps> = ({
   const iconCls = `${prefixCls}-column-title-tooltip-icon`;
 
   const renderTooltipTrigger = () => {
-    if (React.isValidElement(tooltip)) {
-      return tooltip;
-    }
-
     let tooltipProps: TooltipProps = { placement: 'top', title: '' };
     let icon: ReactNode = <QuestionCircleOutlined className={iconCls} />;
 
-    if (typeof tooltip === 'object') {
+    // 与 Form.Item.tooltip 语义对齐：只有普通对象按 WrapperTooltipProps 解析，
+    // 字符串、JSX 与数组一律作为 Tooltip 内容（title），而不是当作触发元素直接平铺渲染
+    if (typeof tooltip === 'object' && !React.isValidElement(tooltip) && !Array.isArray(tooltip)) {
       const {
         icon: customIcon,
         type,

--- a/packages/design/src/table/__tests__/column-tooltip.test.tsx
+++ b/packages/design/src/table/__tests__/column-tooltip.test.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
 import { ConfigProvider, Table } from '@oceanbase/design';
+import { waitFakeTimer, isTooltipOpen } from '../../../../../tests/util';
 import {
   ColumnTitleWithTooltip,
   isValidColumnTooltip,
   injectColumnTitleTooltip,
 } from '../ColumnTitleWithTooltip';
+import type { TableColumnsType } from '../index';
 
 const prefixCls = 'ant-table';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('ColumnTitleWithTooltip', () => {
   it('isValidColumnTooltip should validate tooltip content', () => {
@@ -37,6 +44,40 @@ describe('ColumnTitleWithTooltip', () => {
       </ConfigProvider>
     );
     expect(container.querySelector(`.${prefixCls}-column-title-tooltip-icon`)).toBeTruthy();
+  });
+
+  it('should render bare JSX tooltip as Tooltip content, not flat trigger', () => {
+    const { container } = render(
+      <ConfigProvider>
+        <ColumnTitleWithTooltip
+          prefixCls={prefixCls}
+          title="Status"
+          tooltip={<div data-testid="status-tip">Status help</div>}
+        />
+      </ConfigProvider>
+    );
+    expect(container.textContent).toContain('Status');
+    expect(container.querySelector(`.${prefixCls}-column-title-tooltip-icon`)).toBeTruthy();
+    // JSX 作为 Tooltip 内容，不直接平铺渲染在表头
+    expect(container.querySelector('[data-testid="status-tip"]')).toBeFalsy();
+  });
+
+  it('should show bare JSX tooltip as Tooltip content on hover', async () => {
+    vi.useFakeTimers();
+    const { container } = render(
+      <ConfigProvider>
+        <ColumnTitleWithTooltip
+          prefixCls={prefixCls}
+          title="Status"
+          tooltip={<div data-testid="status-tip">Status help</div>}
+        />
+      </ConfigProvider>
+    );
+    fireEvent.mouseEnter(container.querySelector(`.${prefixCls}-column-title-tooltip-icon`)!);
+    await waitFakeTimer();
+    expect(isTooltipOpen()).toBe(true);
+    // JSX 内容渲染在 Tooltip 弹出层中，而非表头平铺
+    expect(document.querySelector('.ant-tooltip [data-testid="status-tip"]')).toBeTruthy();
   });
 });
 
@@ -127,5 +168,72 @@ describe('Table column tooltip', () => {
     );
     expect(container.textContent).toContain('Age-ascend');
     expect(container.querySelector(`.${prefixCls}-column-title-tooltip-icon`)).toBeTruthy();
+  });
+
+  it('should render bare JSX tooltip as Tooltip content in column header', () => {
+    const columns: TableColumnsType<{ key: string; status: string }> = [
+      {
+        title: 'Status',
+        dataIndex: 'status',
+        tooltip: <div data-testid="status-tip">Status help</div>,
+      },
+    ];
+    const { container } = render(
+      <ConfigProvider>
+        <Table pagination={false} dataSource={[{ key: '1', status: 'active' }]} columns={columns} />
+      </ConfigProvider>
+    );
+    const header = container.querySelector('.ant-table-thead tr th:first-child');
+    expect(header?.textContent).toContain('Status');
+    expect(header?.querySelector(`.${prefixCls}-column-title-tooltip-icon`)).toBeTruthy();
+    // JSX 作为 Tooltip 内容，不直接平铺渲染在表头
+    expect(header?.querySelector('[data-testid="status-tip"]')).toBeFalsy();
+  });
+
+  it('should show bare JSX tooltip as Tooltip content on hover in table', async () => {
+    vi.useFakeTimers();
+    const columns: TableColumnsType<{ key: string; status: string }> = [
+      {
+        title: 'Status',
+        dataIndex: 'status',
+        tooltip: <div data-testid="status-tip">Status help</div>,
+      },
+    ];
+    const { container } = render(
+      <ConfigProvider>
+        <Table pagination={false} dataSource={[{ key: '1', status: 'active' }]} columns={columns} />
+      </ConfigProvider>
+    );
+    const header = container.querySelector('.ant-table-thead tr th:first-child');
+    fireEvent.mouseEnter(header!.querySelector(`.${prefixCls}-column-title-tooltip-icon`)!);
+    await waitFakeTimer();
+    expect(isTooltipOpen()).toBe(true);
+    // JSX 内容渲染在 Tooltip 弹出层中，而非表头平铺
+    expect(document.querySelector('.ant-tooltip [data-testid="status-tip"]')).toBeTruthy();
+  });
+
+  it('should support tooltip in grouped (nested children) columns', () => {
+    const columns: TableColumnsType<{ key: string; name: string; age: number }> = [
+      {
+        title: 'Group',
+        children: [
+          {
+            title: 'Name',
+            dataIndex: 'name',
+            tooltip: <span data-testid="group-tip">Name help</span>,
+          },
+          { title: 'Age', dataIndex: 'age' },
+        ],
+      },
+    ];
+    const { container } = render(
+      <ConfigProvider>
+        <Table pagination={false} dataSource={dataSource} columns={columns} />
+      </ConfigProvider>
+    );
+    const nameHeader = container.querySelector('.ant-table-thead tr:nth-child(2) th:first-child');
+    expect(nameHeader?.querySelector(`.${prefixCls}-column-title-tooltip-icon`)).toBeTruthy();
+    // JSX 作为 Tooltip 内容，不直接平铺在表头
+    expect(nameHeader?.querySelector('[data-testid="group-tip"]')).toBeFalsy();
   });
 });

--- a/packages/design/src/table/demo/column-tooltip.tsx
+++ b/packages/design/src/table/demo/column-tooltip.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Table } from '@oceanbase/design';
-import type { OBTableColumnsType } from '@oceanbase/design/es/table';
+import type { TableColumnsType } from '@oceanbase/design';
 
 interface DataType {
   key: React.Key;
@@ -16,7 +16,7 @@ const dataSource: DataType[] = [
   { key: '3', name: 'Jane', age: 28, amount: 800, address: '30 Baker Street' },
 ];
 
-const columns: OBTableColumnsType<DataType> = [
+const columns: TableColumnsType<DataType> = [
   {
     title: 'Name',
     dataIndex: 'name',
@@ -42,6 +42,11 @@ const columns: OBTableColumnsType<DataType> = [
   {
     title: 'Address',
     dataIndex: 'address',
+    tooltip: (
+      <div>
+        Address help, <b>ReactNode</b> is supported
+      </div>
+    ),
   },
 ];
 

--- a/packages/design/src/table/index.en-US.md
+++ b/packages/design/src/table/index.en-US.md
@@ -64,4 +64,6 @@ markdown: |
 | :------- | :------------------------- | :------------------ | :------ | :------ |
 | tooltip  | Column header help tooltip | `ColumnTooltipType` | -       | -       |
 
+- `tooltip` semantics align with `Form.Item.tooltip`: pass a `ReactNode` (incl. JSX) as tooltip content, or `{ title, icon }` to customize content and trigger icon.
+
 - See antd Table docs: https://ant.design/components/table-cn

--- a/packages/design/src/table/index.md
+++ b/packages/design/src/table/index.md
@@ -64,4 +64,6 @@ markdown: |
 | :------ | :----------- | :------------------ | :----- | :--- |
 | tooltip | 列头帮助提示 | `ColumnTooltipType` | -      | -    |
 
+- `tooltip` 语义与 `Form.Item.tooltip` 对齐：可直接传入 `ReactNode`（含 JSX）作为提示内容，也可传入 `{ title, icon }` 自定义内容与触发图标。
+
 - 详见 antd Table 文档: https://ant.design/components/table-cn

--- a/packages/design/src/table/index.tsx
+++ b/packages/design/src/table/index.tsx
@@ -1,6 +1,6 @@
 import { Popover, Space, Table as AntTable, theme } from 'antd';
 import type { TableProps as AntTableProps } from 'antd';
-import type { ColumnsType, ColumnType } from 'antd/es/table';
+import type { ColumnsType, ColumnGroupType, ColumnType } from 'antd/es/table';
 import type { RowSelectMethod, TableLocale as AntTableLocale } from 'antd/es/table/interface';
 import type { Reference } from 'rc-table';
 import type Summary from 'rc-table/es/Footer/Summary';
@@ -21,8 +21,15 @@ import { injectColumnTitleTooltip } from './ColumnTitleWithTooltip';
 import type { ColumnTooltipType } from './ColumnTitleWithTooltip';
 
 export type { ColumnTooltipType } from './ColumnTitleWithTooltip';
-export type OBColumnType<T> = ColumnType<T> & { tooltip?: ColumnTooltipType };
-export type OBTableColumnsType<T> = OBColumnType<T>[];
+
+// 内部辅助类型，对外只暴露 TableColumnsType（antd 无同名导出，不冲突）
+type TableColumnType<T> = ColumnType<T> & { tooltip?: ColumnTooltipType };
+type TableColumnGroupType<T> = Omit<ColumnGroupType<T>, 'children'> & {
+  children: TableColumnsType<T>;
+  tooltip?: ColumnTooltipType;
+};
+/** 与 antd ColumnsType 对齐的列配置数组类型，额外支持表头 tooltip（含分组列） */
+export type TableColumnsType<T = AnyObject> = (TableColumnGroupType<T> | TableColumnType<T>)[];
 
 export * from 'antd/es/table';
 
@@ -148,7 +155,7 @@ export interface TableLocale extends AntTableLocale {
 
 export interface TableProps<T> extends AntTableProps<T> {
   innerBordered?: boolean;
-  columns?: ColumnsType<T>;
+  columns?: TableColumnsType<T>;
   cancelText?: string;
   collapseText?: string;
   openText?: string;

--- a/packages/ui/src/ProTable/columnTooltip.ts
+++ b/packages/ui/src/ProTable/columnTooltip.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 type ColumnLike = Record<string, any>;
 
 function getColumnTooltip(column: ColumnLike) {
@@ -8,7 +10,11 @@ function isValidColumnTooltip(tooltip: unknown): boolean {
   if (tooltip == null || tooltip === '') {
     return false;
   }
-  if (typeof tooltip === 'object' && tooltip !== null && !Array.isArray(tooltip)) {
+  // 与 @oceanbase/design ColumnTitleWithTooltip 保持一致：JSX/数组等 ReactNode 视为有效内容
+  if (React.isValidElement(tooltip) || Array.isArray(tooltip)) {
+    return true;
+  }
+  if (typeof tooltip === 'object' && tooltip !== null) {
     const { title, icon } = tooltip as { title?: unknown; icon?: unknown };
     if (icon) {
       return true;

--- a/packages/ui/src/ProTable/demo/column-tooltip.tsx
+++ b/packages/ui/src/ProTable/demo/column-tooltip.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ProTable } from '@oceanbase/ui';
-import type { OBTableColumnsType } from '@oceanbase/design/es/table';
+import type { TableColumnsType } from '@oceanbase/design';
 
 interface DataType {
   key: React.Key;
@@ -16,7 +16,7 @@ const dataSource: DataType[] = [
   { key: '3', name: 'Jane', age: 28, amount: 800, address: '30 Baker Street' },
 ];
 
-const columns: OBTableColumnsType<DataType> = [
+const columns: TableColumnsType<DataType> = [
   {
     title: 'Name',
     dataIndex: 'name',


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [x] @oceanbase/ui

### 🤔 This is a ...

- [x] Enhancement feature
- [x] TypeScript definition update
- [x] Demo update
- [x] Test Case

### 🔗 Related issue link

None

### 💡 Background and solution

Table column `tooltip` previously treated a bare ReactNode (incl. JSX) as a custom trigger element, which rendered the JSX flatly into the table header. Now:

- Any ReactNode (string, JSX, array) passed to `column.tooltip` is used as the Tooltip content; the trigger icon defaults to `QuestionCircleOutlined`.
- The object form `{ title, icon }` still works for custom content and a custom trigger icon.
- Consumers using `tooltip: renderStatusTip()` (bare JSX) now render correctly without any change.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Table `column.tooltip` now accepts a ReactNode (incl. JSX) as the tooltip content with a default question-mark trigger icon, and `{ title, icon }` still customizes content and trigger icon. |
| 🇨🇳 Chinese | Table `column.tooltip` 现支持直接传 ReactNode（含 JSX）作为提示内容，默认问号触发图标，`{ title, icon }` 仍可自定义内容与触发图标。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed