### PR TITLE
feat(design): add outerBordered prop to Table

### DIFF
--- a/metadata/components/ProTable.json
+++ b/metadata/components/ProTable.json
@@ -5,7 +5,7 @@
   "extendsAntd": null,
   "obOnly": true,
   "delegateAntd": false,
-  "addedProps": ["innerBordered"],
+  "addedProps": ["innerBordered", "outerBordered"],
   "constraints": ["table-over-protable"],
   "keywords": ["protable", "table", "request", "search"],
   "importFrom": "@oceanbase/ui",

--- a/metadata/components/Table.json
+++ b/metadata/components/Table.json
@@ -6,6 +6,7 @@
   "delegateAntd": true,
   "addedProps": [
     "innerBordered",
+    "outerBordered",
     "cancelText",
     "collapseText",
     "openText",

--- a/metadata/constraints.yaml
+++ b/metadata/constraints.yaml
@@ -27,7 +27,7 @@ constraints:
   - id: card-table-inner-bordered
     module: "03"
     severity: warn
-    rule: When Card uses bodyStyle padding 0 with Table inside, Table must set innerBordered
+    rule: When Card uses bodyStyle padding 0 with Table inside, Table must set innerBordered (or use Table outerBordered instead of the Card wrapper)
     appliesTo: [Card, Table]
     antiPattern: Card bodyStyle={{ padding: 0 }} without Table innerBordered
 

--- a/packages/cli/src/metadata/components.json
+++ b/packages/cli/src/metadata/components.json
@@ -236,7 +236,7 @@
     "extendsAntd": null,
     "obOnly": true,
     "delegateAntd": false,
-    "addedProps": ["innerBordered"],
+    "addedProps": ["innerBordered", "outerBordered"],
     "constraints": ["table-over-protable"],
     "keywords": ["protable", "table", "request", "search"],
     "importFrom": "@oceanbase/ui",
@@ -290,6 +290,7 @@
     "delegateAntd": true,
     "addedProps": [
       "innerBordered",
+      "outerBordered",
       "cancelText",
       "collapseText",
       "openText",

--- a/packages/cli/src/metadata/constraints.yaml
+++ b/packages/cli/src/metadata/constraints.yaml
@@ -27,7 +27,7 @@ constraints:
   - id: card-table-inner-bordered
     module: "03"
     severity: warn
-    rule: When Card uses bodyStyle padding 0 with Table inside, Table must set innerBordered
+    rule: When Card uses bodyStyle padding 0 with Table inside, Table must set innerBordered (or use Table outerBordered instead of the Card wrapper)
     appliesTo: [Card, Table]
     antiPattern: Card bodyStyle={{ padding: 0 }} without Table innerBordered
 

--- a/packages/cli/src/metadata/extracted-props.json
+++ b/packages/cli/src/metadata/extracted-props.json
@@ -86,6 +86,7 @@
       "pagination",
       "spin",
       "table",
+      "form",
       "styleProviderProps",
       "appProps"
     ],
@@ -98,6 +99,7 @@
       "pagination",
       "spin",
       "table",
+      "form",
       "styleProviderProps",
       "appProps"
     ]
@@ -213,8 +215,8 @@
   },
   "ProTable": {
     "source": "packages/ui/src/ProTable/index.tsx",
-    "props": ["innerBordered"],
-    "allInterfaceProps": ["innerBordered"]
+    "props": ["innerBordered", "outerBordered"],
+    "allInterfaceProps": ["innerBordered", "outerBordered"]
   },
   "Result": {
     "source": "packages/design/src/result/index.tsx",
@@ -235,6 +237,7 @@
     "source": "packages/design/src/table/index.tsx",
     "props": [
       "innerBordered",
+      "outerBordered",
       "cancelText",
       "collapseText",
       "openText",
@@ -245,6 +248,7 @@
     ],
     "allInterfaceProps": [
       "innerBordered",
+      "outerBordered",
       "columns",
       "cancelText",
       "collapseText",

--- a/packages/design/src/table/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/design/src/table/__tests__/__snapshots__/index.test.tsx.snap
@@ -2488,6 +2488,1102 @@ exports[`Table > innerBordered should work 1`] = `
 </div>
 `;
 
+exports[`Table > outerBordered + innerBordered should work 1`] = `
+<div
+  class="ant-card ant-card-bordered ant-card-default ant-card-no-body-horizontal-padding ant-card-no-body-padding-bottom ant-table-outer-bordered"
+>
+  <div
+    class="ant-card-body"
+    style="padding: 0px;"
+  >
+    <div
+      class="ant-table-wrapper ant-table-inner-bordered"
+    >
+      <div
+        class="ant-spin-nested-loading"
+      >
+        <div
+          class="ant-spin-container"
+        >
+          <div
+            class="ant-table ant-table-bordered ant-table-scroll-horizontal"
+          >
+            <div
+              class="ant-table-container"
+            >
+              <div
+                class="ant-table-content"
+                style="overflow-x: auto; overflow-y: hidden;"
+              >
+                <table
+                  style="min-width: 100%; table-layout: auto;"
+                >
+                  <thead
+                    class="ant-table-thead"
+                  >
+                    <tr>
+                      <th
+                        class="ant-table-cell"
+                        scope="col"
+                      >
+                        Name
+                      </th>
+                      <th
+                        class="ant-table-cell"
+                        scope="col"
+                      >
+                        Age
+                      </th>
+                      <th
+                        class="ant-table-cell ant-table-cell-last-column"
+                        scope="col"
+                      >
+                        Address
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="ant-table-tbody"
+                  >
+                    <tr
+                      aria-hidden="true"
+                      class="ant-table-measure-row"
+                      tabindex="-1"
+                    >
+                      <th
+                        class="ant-table-measure-cell"
+                      >
+                        <div
+                          class="ant-table-measure-cell-content"
+                        >
+                          Name
+                        </div>
+                      </th>
+                      <th
+                        class="ant-table-measure-cell"
+                      >
+                        <div
+                          class="ant-table-measure-cell-content"
+                        >
+                          Age
+                        </div>
+                      </th>
+                      <th
+                        class="ant-table-measure-cell"
+                      >
+                        <div
+                          class="ant-table-measure-cell-content"
+                        >
+                          Address
+                        </div>
+                      </th>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="1"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 1
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        1 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="2"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 2
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        2 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="3"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 3
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        3 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="4"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 4
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        4 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="5"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 5
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        5 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="6"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 6
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        6 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="7"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 7
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        7 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="8"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 8
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        8 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="9"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 9
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        9 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="10"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 10
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        10 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+          <ul
+            class="ant-pagination ant-pagination-end ant-table-pagination"
+          >
+            <li
+              class="ant-pagination-total-text"
+            >
+              <span>
+                99 in Total
+              </span>
+            </li>
+            <li
+              aria-disabled="true"
+              class="ant-pagination-prev ant-pagination-disabled"
+              title="Previous Page"
+            >
+              <button
+                class="ant-pagination-item-link"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  aria-label="left"
+                  class="anticon anticon-left"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="left"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+              tabindex="0"
+              title="1"
+            >
+              <a
+                rel="nofollow"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-2"
+              tabindex="0"
+              title="2"
+            >
+              <a
+                rel="nofollow"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-3"
+              tabindex="0"
+              title="3"
+            >
+              <a
+                rel="nofollow"
+              >
+                3
+              </a>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-4"
+              tabindex="0"
+              title="4"
+            >
+              <a
+                rel="nofollow"
+              >
+                4
+              </a>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-5 ant-pagination-item-before-jump-next"
+              tabindex="0"
+              title="5"
+            >
+              <a
+                rel="nofollow"
+              >
+                5
+              </a>
+            </li>
+            <li
+              class="ant-pagination-jump-next ant-pagination-jump-next-custom-icon"
+              tabindex="0"
+              title="Next 5 Pages"
+            >
+              <a
+                class="ant-pagination-item-link"
+              >
+                <div
+                  class="ant-pagination-item-container"
+                >
+                  <span
+                    aria-label="double-right"
+                    class="anticon anticon-double-right ant-pagination-item-link-icon"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="double-right"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="ant-pagination-item-ellipsis"
+                  >
+                    •••
+                  </span>
+                </div>
+              </a>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-10"
+              tabindex="0"
+              title="10"
+            >
+              <a
+                rel="nofollow"
+              >
+                10
+              </a>
+            </li>
+            <li
+              aria-disabled="false"
+              class="ant-pagination-next"
+              tabindex="0"
+              title="Next Page"
+            >
+              <button
+                class="ant-pagination-item-link"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  aria-label="right"
+                  class="anticon anticon-right"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="right"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </li>
+            <li
+              class="ant-pagination-options"
+            >
+              <div
+                aria-label="Page Size"
+                class="ant-select ant-select-outlined ant-pagination-options-size-changer ant-select-single ant-select-show-arrow ant-select-show-search"
+              >
+                <div
+                  class="ant-select-selector"
+                >
+                  <span
+                    class="ant-select-selection-wrap"
+                  >
+                    <span
+                      class="ant-select-selection-search"
+                    >
+                      <input
+                        aria-autocomplete="list"
+                        aria-controls="rc_select_TEST_OR_SSR_list"
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-label="Page Size"
+                        aria-owns="rc_select_TEST_OR_SSR_list"
+                        autocomplete="off"
+                        class="ant-select-selection-search-input"
+                        id="rc_select_TEST_OR_SSR"
+                        role="combobox"
+                        type="search"
+                        value=""
+                      />
+                    </span>
+                    <span
+                      class="ant-select-selection-item"
+                      title="10 / page"
+                    >
+                      10 / page
+                    </span>
+                  </span>
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-arrow"
+                  style="user-select: none;"
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="down"
+                    class="anticon anticon-down ant-select-suffix"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="down"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Table > outerBordered should work 1`] = `
+<div
+  class="ant-card ant-card-bordered ant-card-default ant-card-no-body-horizontal-padding ant-card-no-body-padding-bottom ant-table-outer-bordered"
+>
+  <div
+    class="ant-card-body"
+    style="padding: 0px;"
+  >
+    <div
+      class="ant-table-wrapper"
+    >
+      <div
+        class="ant-spin-nested-loading"
+      >
+        <div
+          class="ant-spin-container"
+        >
+          <div
+            class="ant-table ant-table-scroll-horizontal"
+          >
+            <div
+              class="ant-table-container"
+            >
+              <div
+                class="ant-table-content"
+                style="overflow-x: auto; overflow-y: hidden;"
+              >
+                <table
+                  style="min-width: 100%; table-layout: auto;"
+                >
+                  <thead
+                    class="ant-table-thead"
+                  >
+                    <tr>
+                      <th
+                        class="ant-table-cell"
+                        scope="col"
+                      >
+                        Name
+                      </th>
+                      <th
+                        class="ant-table-cell"
+                        scope="col"
+                      >
+                        Age
+                      </th>
+                      <th
+                        class="ant-table-cell ant-table-cell-last-column"
+                        scope="col"
+                      >
+                        Address
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="ant-table-tbody"
+                  >
+                    <tr
+                      aria-hidden="true"
+                      class="ant-table-measure-row"
+                      tabindex="-1"
+                    >
+                      <th
+                        class="ant-table-measure-cell"
+                      >
+                        <div
+                          class="ant-table-measure-cell-content"
+                        >
+                          Name
+                        </div>
+                      </th>
+                      <th
+                        class="ant-table-measure-cell"
+                      >
+                        <div
+                          class="ant-table-measure-cell-content"
+                        >
+                          Age
+                        </div>
+                      </th>
+                      <th
+                        class="ant-table-measure-cell"
+                      >
+                        <div
+                          class="ant-table-measure-cell-content"
+                        >
+                          Address
+                        </div>
+                      </th>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="1"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 1
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        1 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="2"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 2
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        2 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="3"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 3
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        3 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="4"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 4
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        4 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="5"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 5
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        5 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="6"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 6
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        6 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="7"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 7
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        7 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="8"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 8
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        8 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="9"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 9
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        9 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="10"
+                    >
+                      <td
+                        class="ant-table-cell"
+                      >
+                        John 10
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell ant-table-cell-last-column"
+                      >
+                        10 Road, Hangzhou, Zhejiang Province
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+          <ul
+            class="ant-pagination ant-pagination-end ant-table-pagination"
+          >
+            <li
+              class="ant-pagination-total-text"
+            >
+              <span>
+                99 in Total
+              </span>
+            </li>
+            <li
+              aria-disabled="true"
+              class="ant-pagination-prev ant-pagination-disabled"
+              title="Previous Page"
+            >
+              <button
+                class="ant-pagination-item-link"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  aria-label="left"
+                  class="anticon anticon-left"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="left"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+              tabindex="0"
+              title="1"
+            >
+              <a
+                rel="nofollow"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-2"
+              tabindex="0"
+              title="2"
+            >
+              <a
+                rel="nofollow"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-3"
+              tabindex="0"
+              title="3"
+            >
+              <a
+                rel="nofollow"
+              >
+                3
+              </a>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-4"
+              tabindex="0"
+              title="4"
+            >
+              <a
+                rel="nofollow"
+              >
+                4
+              </a>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-5 ant-pagination-item-before-jump-next"
+              tabindex="0"
+              title="5"
+            >
+              <a
+                rel="nofollow"
+              >
+                5
+              </a>
+            </li>
+            <li
+              class="ant-pagination-jump-next ant-pagination-jump-next-custom-icon"
+              tabindex="0"
+              title="Next 5 Pages"
+            >
+              <a
+                class="ant-pagination-item-link"
+              >
+                <div
+                  class="ant-pagination-item-container"
+                >
+                  <span
+                    aria-label="double-right"
+                    class="anticon anticon-double-right ant-pagination-item-link-icon"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="double-right"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="ant-pagination-item-ellipsis"
+                  >
+                    •••
+                  </span>
+                </div>
+              </a>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-10"
+              tabindex="0"
+              title="10"
+            >
+              <a
+                rel="nofollow"
+              >
+                10
+              </a>
+            </li>
+            <li
+              aria-disabled="false"
+              class="ant-pagination-next"
+              tabindex="0"
+              title="Next Page"
+            >
+              <button
+                class="ant-pagination-item-link"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  aria-label="right"
+                  class="anticon anticon-right"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="right"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </li>
+            <li
+              class="ant-pagination-options"
+            >
+              <div
+                aria-label="Page Size"
+                class="ant-select ant-select-outlined ant-pagination-options-size-changer ant-select-single ant-select-show-arrow ant-select-show-search"
+              >
+                <div
+                  class="ant-select-selector"
+                >
+                  <span
+                    class="ant-select-selection-wrap"
+                  >
+                    <span
+                      class="ant-select-selection-search"
+                    >
+                      <input
+                        aria-autocomplete="list"
+                        aria-controls="rc_select_TEST_OR_SSR_list"
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-label="Page Size"
+                        aria-owns="rc_select_TEST_OR_SSR_list"
+                        autocomplete="off"
+                        class="ant-select-selection-search-input"
+                        id="rc_select_TEST_OR_SSR"
+                        role="combobox"
+                        type="search"
+                        value=""
+                      />
+                    </span>
+                    <span
+                      class="ant-select-selection-item"
+                      title="10 / page"
+                    >
+                      10 / page
+                    </span>
+                  </span>
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-arrow"
+                  style="user-select: none;"
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="down"
+                    class="anticon anticon-down ant-select-suffix"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="down"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Table > render 1`] = `
 <div
   class="ant-table-wrapper"

--- a/packages/design/src/table/__tests__/index.test.tsx
+++ b/packages/design/src/table/__tests__/index.test.tsx
@@ -118,4 +118,26 @@ describe('Table', () => {
     expect(container.querySelector('.ant-table-inner-bordered .ant-table-bordered')).toBeTruthy();
     expect(asFragment().firstChild).toMatchSnapshot();
   });
+
+  it('outerBordered should work', () => {
+    const { container, asFragment } = render(<TableTest outerBordered={true} />);
+    // 外层 Card 边框
+    expect(container.querySelector('.ant-card-bordered')).toBeTruthy();
+    expect(container.querySelector('.ant-table-outer-bordered')).toBeTruthy();
+    // 内部表格保持无边框样式
+    expect(container.querySelector('.ant-table-outer-bordered .ant-table-bordered')).toBeFalsy();
+    // 分页器在 Card 内（外框包含分页器）
+    expect(container.querySelector('.ant-card-body .ant-pagination')).toBeTruthy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('outerBordered + innerBordered should work', () => {
+    const { container, asFragment } = render(
+      <TableTest outerBordered={true} innerBordered={true} />
+    );
+    // 外框 + 内部全网格
+    expect(container.querySelector('.ant-card-bordered')).toBeTruthy();
+    expect(container.querySelector('.ant-table-outer-bordered .ant-table-bordered')).toBeTruthy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
 });

--- a/packages/design/src/table/demo/outer-bordered.tsx
+++ b/packages/design/src/table/demo/outer-bordered.tsx
@@ -52,8 +52,8 @@ const App: React.FC = () => {
   const { token } = theme.useToken();
   return (
     <>
-      <Table columns={columns} dataSource={data} innerBordered />
-      <Divider>with Card</Divider>
+      <Table columns={columns} dataSource={data} outerBordered />
+      <Divider>等价于 Card bordered + bodyStyle padding 0 + Table</Divider>
       <div
         style={{
           padding: 24,
@@ -62,11 +62,9 @@ const App: React.FC = () => {
         }}
       >
         <Card bordered={true} bodyStyle={{ padding: 0 }}>
-          <Table columns={columns} dataSource={data} innerBordered />
+          <Table columns={columns} dataSource={data} />
         </Card>
       </div>
-      <Divider>outerBordered + innerBordered</Divider>
-      <Table columns={columns} dataSource={data} outerBordered innerBordered />
     </>
   );
 };

--- a/packages/design/src/table/index.en-US.md
+++ b/packages/design/src/table/index.en-US.md
@@ -21,8 +21,9 @@ markdown: |
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx" title="Basic"></code>
-<code src="./demo/bordered.tsx" title="Bordered" description="Add table borders."></code>
-<code src="./demo/inner-bordered.tsx" title="Inner Bordered" description="Borders only inside table, often with bordered Card."></code>
+<code src="./demo/bordered.tsx" title="Bordered" description="Add table borders. Note: bordered has no outer frame, unlike outerBordered + innerBordered."></code>
+<code src="./demo/outer-bordered.tsx" title="Outer Bordered" description="Border only around the table (pagination included), interior keeps borderless style; a replacement for Card bordered + bodyStyle padding 0 + Table."></code>
+<code src="./demo/inner-bordered.tsx" title="Inner Bordered" description="Borders only inside table, often with bordered Card to avoid a duplicated outer border; can be stacked with outerBordered for an outer frame plus full grid."></code>
 <code src="./demo/ellipsis.tsx" title="Cell Ellipsis" description="`column.ellipsis` enables auto-ellipsis with Tooltip. Note: column header ellipsis does not support sort/filter yet."></code>
 <code src="./demo/column-tooltip.tsx" title="Column Header Tooltip" description="Use `column.tooltip` for column header help. Works with sort and filter."></code>
 <code src="./demo/fixed-columns-header-tables.tsx" title="Fixed Header and Columns"></code>
@@ -48,6 +49,7 @@ markdown: |
 | Property | Description | Type | Default | Version |
 | :-- | :-- | :-- | :-- | :-- |
 | innerBordered | Inner borders | boolean | - | - |
+| outerBordered | Outer border (pagination included), interior keeps borderless style; a replacement for Card bordered + bodyStyle padding 0 + Table | boolean | - | - |
 | pagination | Pagination config | ReactNode | {} | - |
 | cancelText | Cancel button text in selection | ReactNode | - | - |
 | collapseText | Collapse button text in selection | ReactNode | - | - |

--- a/packages/design/src/table/index.md
+++ b/packages/design/src/table/index.md
@@ -21,8 +21,9 @@ markdown: |
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx" title="基本"></code>
-<code src="./demo/bordered.tsx" title="带边框" description="添加表格边框线。"></code>
-<code src="./demo/inner-bordered.tsx" title="带内部边框" description="仅表格内部添加边框线，常和带边框的 Card 一起使用，以避免外部边框重复。"></code>
+<code src="./demo/bordered.tsx" title="带边框" description="添加表格边框线。注意：带边框（bordered）不含外层边框，与 outerBordered + innerBordered 不同。"></code>
+<code src="./demo/outer-bordered.tsx" title="带外部边框" description="仅外围添加边框（分页器包含在边框内），内部保持无边框样式，可代替 Card bordered + bodyStyle padding 0 + Table 的组合。"></code>
+<code src="./demo/inner-bordered.tsx" title="带内部边框" description="仅表格内部添加边框线，常和带边框的 Card 一起使用，以避免外部边框重复；可与 outerBordered 叠加实现外框 + 全网格。"></code>
 <code src="./demo/ellipsis.tsx" title="单元格自动省略" description="设置 `column.ellipsis` 可以让单元格内容根据宽度自动省略，并使用 Tooltip 展示全部内容。`说明`: 列头缩略暂不支持和排序筛选一起使用。"></code>
 <code src="./demo/column-tooltip.tsx" title="列头帮助提示" description="通过 `column.tooltip` 在列头展示帮助说明，可与排序、筛选一起使用。"></code>
 <code src="./demo/fixed-columns-header-tables.tsx" title="固定头和列"></code>
@@ -48,6 +49,7 @@ markdown: |
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | :-- | :-- | :-- | :-- | :-- |
 | innerBordered | 带内部边框 | boolean | - | - |
+| outerBordered | 设置外围边框（分页器包含在边框内），内部保持无边框样式，可代替 Card bordered + bodyStyle padding 0 + Table 的组合 | boolean | - | - |
 | pagination | 分页配置 | ReactNode | {} | - |
 | cancelText | 选择表格中 `取消` 按钮文案 | ReactNode | - | - |
 | collapseText | 选择表格中 `收起` 按钮文案 | ReactNode | - | - |

--- a/packages/design/src/table/index.tsx
+++ b/packages/design/src/table/index.tsx
@@ -12,6 +12,7 @@ import { FilterOutlined, SwapLeftOutlined, SwapRightOutlined } from '@oceanbase/
 import ConfigProvider from '../config-provider';
 import Typography from '../typography';
 import Empty from '../empty';
+import Card from '../card';
 import useStyle from './style';
 import type { AnyObject } from '../_util/type';
 import useDefaultPagination from './hooks/useDefaultPagination';
@@ -155,6 +156,8 @@ export interface TableLocale extends AntTableLocale {
 
 export interface TableProps<T> extends AntTableProps<T> {
   innerBordered?: boolean;
+  /** 设置外围边框（分页器包含在边框内），内部保持无边框样式，可代替 Card bordered + bodyStyle padding 0 + Table 的组合 */
+  outerBordered?: boolean;
   columns?: TableColumnsType<T>;
   cancelText?: string;
   collapseText?: string;
@@ -167,11 +170,13 @@ export interface TableProps<T> extends AntTableProps<T> {
 }
 
 function Table<T extends Record<string, any>>(props: TableProps<T>, ref: React.Ref<Reference>) {
+  const { style, id, ...tableSpread } = props;
   const {
     locale: customLocale,
     size,
     bordered,
     innerBordered,
+    outerBordered,
     dataSource,
     columns,
     footer,
@@ -285,7 +290,8 @@ function Table<T extends Record<string, any>>(props: TableProps<T>, ref: React.R
       [`${prefixCls}-has-empty`]: noData,
       [`${prefixCls}-virtual`]: !!virtual,
     },
-    className
+    // outerBordered 时用户 className 挂外层 Card，内部 wrapper 仅保留功能 class
+    outerBordered ? undefined : className
   );
 
   const [openPopover, setOpenPopover] = useState<boolean>(false);
@@ -462,9 +468,9 @@ function Table<T extends Record<string, any>>(props: TableProps<T>, ref: React.R
     );
   };
 
-  return wrapCSSVar(
+  const tableNode = (
     <AntTable
-      {...props}
+      {...tableSpread}
       ref={ref}
       prefixCls={customizePrefixCls}
       className={tableCls}
@@ -480,6 +486,9 @@ function Table<T extends Record<string, any>>(props: TableProps<T>, ref: React.R
       bordered={bordered || innerBordered}
       dataSource={dataSource}
       columns={newColumns}
+      // outerBordered 时 style/id 挂外层 Card，内部不重复挂载
+      style={outerBordered ? undefined : style}
+      id={outerBordered ? undefined : id}
       rowClassName={(...args) => {
         return classNames(
           typeof rowClassName === 'function' ? rowClassName(...args) : rowClassName,
@@ -539,6 +548,23 @@ function Table<T extends Record<string, any>>(props: TableProps<T>, ref: React.R
       }
     />
   );
+
+  const outerNode = outerBordered ? (
+    <Card
+      bordered
+      bodyStyle={{ padding: 0 }}
+      size={size === 'small' ? 'small' : 'default'}
+      className={classNames(className, `${prefixCls}-outer-bordered`)}
+      style={style}
+      id={id}
+    >
+      {tableNode}
+    </Card>
+  ) : (
+    tableNode
+  );
+
+  return wrapCSSVar(outerNode);
 }
 
 const ForwardTable = React.forwardRef(Table) as <RecordType extends AnyObject = AnyObject>(

--- a/packages/ui/src/ProTable/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/ProTable/__tests__/__snapshots__/index.test.tsx.snap
@@ -2869,6 +2869,2845 @@ exports[`ProTable > innerBordered should work 1`] = `
 </div>
 `;
 
+exports[`ProTable > outerBordered + innerBordered should work 1`] = `
+<div
+  class="ant-pro-table"
+>
+  <div
+    class="ant-pro-card ant-pro-card-border ant-pro-card-bordered ant-pro-table-search ant-pro-table-search-query-filter"
+  >
+    <div
+      class="ant-pro-query-filter-container "
+    >
+      <form
+        autocomplete="off"
+        class="ant-form ant-form-horizontal ant-form-hide-required-mark ant-pro-query-filter ant-pro-form"
+      >
+        <input
+          style="display: none;"
+          type="text"
+        />
+        <div
+          class="ant-row ant-row-start ant-pro-query-filter-row"
+          style="margin-left: -12px; margin-right: -12px;"
+        >
+          <div
+            class="ant-col ant-col-8 ant-pro-query-filter-row-split"
+            style="padding-left: 12px; padding-right: 12px;"
+          >
+            <div
+              class="ant-form-item ant-form-item-horizontal"
+              style="flex-wrap: nowrap;"
+            >
+              <div
+                class="ant-row ant-form-item-row"
+              >
+                <div
+                  class="ant-col ant-form-item-label"
+                  style="flex: 0 0 80px;"
+                >
+                  <label
+                    class="ant-form-item-required-mark-hidden"
+                    for="name"
+                    title="Name"
+                  >
+                    Name
+                  </label>
+                </div>
+                <div
+                  class="ant-col ant-form-item-control"
+                  style="max-width: calc(100% - 80px);"
+                >
+                  <div
+                    class="ant-form-item-control-input"
+                  >
+                    <div
+                      class="ant-form-item-control-input-content"
+                    >
+                      <span
+                        class="ant-input-affix-wrapper ant-input-outlined"
+                        style="width: 100%;"
+                      >
+                        <input
+                          class="ant-input"
+                          id="name"
+                          placeholder="请输入"
+                          type="text"
+                          value=""
+                        />
+                        <span
+                          class="ant-input-suffix"
+                        >
+                          <button
+                            class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                            tabindex="-1"
+                            type="button"
+                          >
+                            <span
+                              aria-label="close-circle"
+                              class="anticon anticon-close-circle"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="close-circle"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                                />
+                              </svg>
+                            </span>
+                          </button>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-col ant-col-8 ant-pro-query-filter-row-split"
+            style="padding-left: 12px; padding-right: 12px;"
+          >
+            <div
+              class="ant-form-item ant-form-item-horizontal"
+              style="flex-wrap: nowrap;"
+            >
+              <div
+                class="ant-row ant-form-item-row"
+              >
+                <div
+                  class="ant-col ant-form-item-label"
+                  style="flex: 0 0 80px;"
+                >
+                  <label
+                    class="ant-form-item-required-mark-hidden"
+                    for="age"
+                    title="Age"
+                  >
+                    Age
+                  </label>
+                </div>
+                <div
+                  class="ant-col ant-form-item-control"
+                  style="max-width: calc(100% - 80px);"
+                >
+                  <div
+                    class="ant-form-item-control-input"
+                  >
+                    <div
+                      class="ant-form-item-control-input-content"
+                    >
+                      <span
+                        class="ant-input-affix-wrapper ant-input-outlined"
+                        style="width: 100%;"
+                      >
+                        <input
+                          class="ant-input"
+                          id="age"
+                          placeholder="请输入"
+                          type="text"
+                          value=""
+                        />
+                        <span
+                          class="ant-input-suffix"
+                        >
+                          <button
+                            class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                            tabindex="-1"
+                            type="button"
+                          >
+                            <span
+                              aria-label="close-circle"
+                              class="anticon anticon-close-circle"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="close-circle"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                                />
+                              </svg>
+                            </span>
+                          </button>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-form-item ant-form-item-hidden ant-form-item-horizontal"
+            style="flex-wrap: nowrap;"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+                style="flex: 0 0 80px;"
+              >
+                <label
+                  class="ant-form-item-required-mark-hidden"
+                  for="address"
+                  title="Address"
+                >
+                  Address
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+                style="max-width: calc(100% - 80px);"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <span
+                      class="ant-input-affix-wrapper ant-input-outlined"
+                      style="width: 100%;"
+                    >
+                      <input
+                        class="ant-input"
+                        id="address"
+                        placeholder="请输入"
+                        type="text"
+                        value=""
+                      />
+                      <span
+                        class="ant-input-suffix"
+                      >
+                        <button
+                          class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <span
+                            aria-label="close-circle"
+                            class="anticon anticon-close-circle"
+                            role="img"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              data-icon="close-circle"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                              focusable="false"
+                              height="1em"
+                              viewBox="64 64 896 896"
+                              width="1em"
+                            >
+                              <path
+                                d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-col ant-col-8"
+            style="padding-left: 12px; padding-right: 12px; text-align: end;"
+          >
+            <div
+              class="ant-form-item ant-pro-query-filter-actions ant-form-item-horizontal"
+            >
+              <div
+                class="ant-row ant-form-item-row"
+              >
+                <div
+                  class="ant-col ant-form-item-label"
+                >
+                  <label
+                    class="ant-form-item-required-mark-hidden ant-form-item-no-colon"
+                    title=" "
+                  >
+                     
+                  </label>
+                </div>
+                <div
+                  class="ant-col ant-form-item-control"
+                >
+                  <div
+                    class="ant-form-item-control-input"
+                  >
+                    <div
+                      class="ant-form-item-control-input-content"
+                    >
+                      <div
+                        class="ant-space ant-space-horizontal ant-space-align-center"
+                        style="column-gap: 16px; row-gap: 16px;"
+                      >
+                        <div
+                          class="ant-space-item"
+                        >
+                          <div
+                            style="display: flex; gap: 8px; align-items: center;"
+                          >
+                            <button
+                              class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+                              type="button"
+                            >
+                              <span>
+                                重 置
+                              </span>
+                            </button>
+                            <button
+                              class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+                              type="button"
+                            >
+                              <span>
+                                查 询
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                        <div
+                          class="ant-space-item"
+                        >
+                          <a
+                            class="ant-pro-query-filter-collapse-button"
+                          >
+                            展开
+                            <span
+                              aria-label="down"
+                              class="anticon anticon-down"
+                              role="img"
+                              style="margin-inline-start: 0.5em; transition: 0.3s all; transform: rotate(0turn);"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="down"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                                />
+                              </svg>
+                            </span>
+                          </a>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div
+    class="ant-pro-card ant-pro-card-has-title ant-pro-card-no-divider ant-pro-card-no-padding ant-pro-card-border"
+  >
+    <div
+      class="ant-pro-card-body"
+      style="padding-block: 0;"
+    >
+      <div
+        class="ant-pro-table-list-toolbar"
+      >
+        <div
+          class="ant-pro-table-list-toolbar-container"
+        >
+          <div
+            class="ant-pro-table-list-toolbar-left"
+          />
+          <div
+            class="ant-pro-table-list-toolbar-right"
+            style="align-items: center;"
+          >
+            <div
+              class="ant-pro-table-list-toolbar-setting-items"
+            >
+              <div
+                class="ant-pro-table-list-toolbar-setting-item"
+              >
+                <span>
+                  <span
+                    aria-describedby="test-id"
+                    aria-label="reload"
+                    class="anticon anticon-reload"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="reload"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M909.1 209.3l-56.4 44.1C775.8 155.1 656.2 92 521.9 92 290 92 102.3 279.5 102 511.5 101.7 743.7 289.8 932 521.9 932c181.3 0 335.8-115 394.6-276.1 1.5-4.2-.7-8.9-4.9-10.3l-56.7-19.5a8 8 0 00-10.1 4.8c-1.8 5-3.8 10-5.9 14.9-17.3 41-42.1 77.8-73.7 109.4A344.77 344.77 0 01655.9 829c-42.3 17.9-87.4 27-133.8 27-46.5 0-91.5-9.1-133.8-27A341.5 341.5 0 01279 755.2a342.16 342.16 0 01-73.7-109.4c-17.9-42.4-27-87.4-27-133.9s9.1-91.5 27-133.9c17.3-41 42.1-77.8 73.7-109.4 31.6-31.6 68.4-56.4 109.3-73.8 42.3-17.9 87.4-27 133.8-27 46.5 0 91.5 9.1 133.8 27a341.5 341.5 0 01109.3 73.8c9.9 9.9 19.2 20.4 27.8 31.4l-60.2 47a8 8 0 003 14.1l175.6 43c5 1.2 9.9-2.6 9.9-7.7l.8-180.9c-.1-6.6-7.8-10.3-13-6.2z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <div
+                class="ant-pro-table-list-toolbar-setting-item"
+              >
+                <span>
+                  <span
+                    aria-describedby="test-id"
+                    aria-label="column-height"
+                    class="anticon anticon-column-height ant-dropdown-trigger"
+                    role="img"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="column-height"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M840 836H184c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h656c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8zm0-724H184c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h656c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8zM610.8 378c6 0 9.4-7 5.7-11.7L515.7 238.7a7.14 7.14 0 00-11.3 0L403.6 366.3a7.23 7.23 0 005.7 11.7H476v268h-62.8c-6 0-9.4 7-5.7 11.7l100.8 127.5c2.9 3.7 8.5 3.7 11.3 0l100.8-127.5c3.7-4.7.4-11.7-5.7-11.7H548V378h62.8z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <div
+                class="ant-pro-table-list-toolbar-setting-item"
+              >
+                <span
+                  aria-describedby="test-id"
+                  aria-label="setting"
+                  class="anticon anticon-setting"
+                  role="img"
+                  tabindex="-1"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="setting"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-table-wrapper ant-table-inner-bordered"
+      >
+        <div
+          class="ant-spin-nested-loading"
+        >
+          <div
+            class="ant-spin-container"
+          >
+            <div
+              class="ant-table ant-table-bordered"
+            >
+              <div
+                class="ant-table-container"
+              >
+                <div
+                  class="ant-table-content"
+                >
+                  <table
+                    style="table-layout: auto;"
+                  >
+                    <thead
+                      class="ant-table-thead"
+                    >
+                      <tr>
+                        <th
+                          class="ant-table-cell"
+                          scope="col"
+                        >
+                          Name
+                        </th>
+                        <th
+                          class="ant-table-cell"
+                          scope="col"
+                        >
+                          Age
+                        </th>
+                        <th
+                          class="ant-table-cell"
+                          scope="col"
+                        >
+                          Address
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody
+                      class="ant-table-tbody"
+                    >
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="1"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 1
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          1 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="2"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 2
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          2 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="3"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 3
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          3 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="4"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 4
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          4 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="5"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 5
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          5 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="6"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 6
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          6 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="7"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 7
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          7 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="8"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 8
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          8 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="9"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 9
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          9 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="10"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 10
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          10 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+            <ul
+              class="ant-pagination ant-pagination-end ant-table-pagination"
+            >
+              <li
+                class="ant-pagination-total-text"
+              >
+                99 in Total
+              </li>
+              <li
+                aria-disabled="true"
+                class="ant-pagination-prev ant-pagination-disabled"
+                title="上一页"
+              >
+                <button
+                  class="ant-pagination-item-link"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    aria-label="left"
+                    class="anticon anticon-left"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="left"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+                tabindex="0"
+                title="1"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  1
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-2"
+                tabindex="0"
+                title="2"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  2
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-3"
+                tabindex="0"
+                title="3"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  3
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-4"
+                tabindex="0"
+                title="4"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  4
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-5 ant-pagination-item-before-jump-next"
+                tabindex="0"
+                title="5"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  5
+                </a>
+              </li>
+              <li
+                class="ant-pagination-jump-next ant-pagination-jump-next-custom-icon"
+                tabindex="0"
+                title="向后 5 页"
+              >
+                <a
+                  class="ant-pagination-item-link"
+                >
+                  <div
+                    class="ant-pagination-item-container"
+                  >
+                    <span
+                      aria-label="double-right"
+                      class="anticon anticon-double-right ant-pagination-item-link-icon"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="double-right"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="ant-pagination-item-ellipsis"
+                    >
+                      •••
+                    </span>
+                  </div>
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-10"
+                tabindex="0"
+                title="10"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  10
+                </a>
+              </li>
+              <li
+                aria-disabled="false"
+                class="ant-pagination-next"
+                tabindex="0"
+                title="下一页"
+              >
+                <button
+                  class="ant-pagination-item-link"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    aria-label="right"
+                    class="anticon anticon-right"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="right"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+              <li
+                class="ant-pagination-options"
+              >
+                <div
+                  aria-label="页码"
+                  class="ant-select ant-select-outlined ant-pagination-options-size-changer ant-select-single ant-select-show-arrow ant-select-show-search"
+                >
+                  <div
+                    class="ant-select-selector"
+                  >
+                    <span
+                      class="ant-select-selection-wrap"
+                    >
+                      <span
+                        class="ant-select-selection-search"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="rc_select_TEST_OR_SSR_list"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-label="页码"
+                          aria-owns="rc_select_TEST_OR_SSR_list"
+                          autocomplete="off"
+                          class="ant-select-selection-search-input"
+                          id="rc_select_TEST_OR_SSR"
+                          role="combobox"
+                          type="search"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="ant-select-selection-item"
+                        title="10 条/页"
+                      >
+                        10 条/页
+                      </span>
+                    </span>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="ant-select-arrow"
+                    style="user-select: none;"
+                    unselectable="on"
+                  >
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down ant-select-suffix"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ProTable > outerBordered should work 1`] = `
+<div
+  class="ant-pro-table"
+>
+  <div
+    class="ant-pro-card ant-pro-card-border ant-pro-card-bordered ant-pro-table-search ant-pro-table-search-query-filter"
+  >
+    <div
+      class="ant-pro-query-filter-container "
+    >
+      <form
+        autocomplete="off"
+        class="ant-form ant-form-horizontal ant-form-hide-required-mark ant-pro-query-filter ant-pro-form"
+      >
+        <input
+          style="display: none;"
+          type="text"
+        />
+        <div
+          class="ant-row ant-row-start ant-pro-query-filter-row"
+          style="margin-left: -12px; margin-right: -12px;"
+        >
+          <div
+            class="ant-col ant-col-8 ant-pro-query-filter-row-split"
+            style="padding-left: 12px; padding-right: 12px;"
+          >
+            <div
+              class="ant-form-item ant-form-item-horizontal"
+              style="flex-wrap: nowrap;"
+            >
+              <div
+                class="ant-row ant-form-item-row"
+              >
+                <div
+                  class="ant-col ant-form-item-label"
+                  style="flex: 0 0 80px;"
+                >
+                  <label
+                    class="ant-form-item-required-mark-hidden"
+                    for="name"
+                    title="Name"
+                  >
+                    Name
+                  </label>
+                </div>
+                <div
+                  class="ant-col ant-form-item-control"
+                  style="max-width: calc(100% - 80px);"
+                >
+                  <div
+                    class="ant-form-item-control-input"
+                  >
+                    <div
+                      class="ant-form-item-control-input-content"
+                    >
+                      <span
+                        class="ant-input-affix-wrapper ant-input-outlined"
+                        style="width: 100%;"
+                      >
+                        <input
+                          class="ant-input"
+                          id="name"
+                          placeholder="请输入"
+                          type="text"
+                          value=""
+                        />
+                        <span
+                          class="ant-input-suffix"
+                        >
+                          <button
+                            class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                            tabindex="-1"
+                            type="button"
+                          >
+                            <span
+                              aria-label="close-circle"
+                              class="anticon anticon-close-circle"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="close-circle"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                                />
+                              </svg>
+                            </span>
+                          </button>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-col ant-col-8 ant-pro-query-filter-row-split"
+            style="padding-left: 12px; padding-right: 12px;"
+          >
+            <div
+              class="ant-form-item ant-form-item-horizontal"
+              style="flex-wrap: nowrap;"
+            >
+              <div
+                class="ant-row ant-form-item-row"
+              >
+                <div
+                  class="ant-col ant-form-item-label"
+                  style="flex: 0 0 80px;"
+                >
+                  <label
+                    class="ant-form-item-required-mark-hidden"
+                    for="age"
+                    title="Age"
+                  >
+                    Age
+                  </label>
+                </div>
+                <div
+                  class="ant-col ant-form-item-control"
+                  style="max-width: calc(100% - 80px);"
+                >
+                  <div
+                    class="ant-form-item-control-input"
+                  >
+                    <div
+                      class="ant-form-item-control-input-content"
+                    >
+                      <span
+                        class="ant-input-affix-wrapper ant-input-outlined"
+                        style="width: 100%;"
+                      >
+                        <input
+                          class="ant-input"
+                          id="age"
+                          placeholder="请输入"
+                          type="text"
+                          value=""
+                        />
+                        <span
+                          class="ant-input-suffix"
+                        >
+                          <button
+                            class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                            tabindex="-1"
+                            type="button"
+                          >
+                            <span
+                              aria-label="close-circle"
+                              class="anticon anticon-close-circle"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="close-circle"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                                />
+                              </svg>
+                            </span>
+                          </button>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-form-item ant-form-item-hidden ant-form-item-horizontal"
+            style="flex-wrap: nowrap;"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+                style="flex: 0 0 80px;"
+              >
+                <label
+                  class="ant-form-item-required-mark-hidden"
+                  for="address"
+                  title="Address"
+                >
+                  Address
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+                style="max-width: calc(100% - 80px);"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <span
+                      class="ant-input-affix-wrapper ant-input-outlined"
+                      style="width: 100%;"
+                    >
+                      <input
+                        class="ant-input"
+                        id="address"
+                        placeholder="请输入"
+                        type="text"
+                        value=""
+                      />
+                      <span
+                        class="ant-input-suffix"
+                      >
+                        <button
+                          class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <span
+                            aria-label="close-circle"
+                            class="anticon anticon-close-circle"
+                            role="img"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              data-icon="close-circle"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                              focusable="false"
+                              height="1em"
+                              viewBox="64 64 896 896"
+                              width="1em"
+                            >
+                              <path
+                                d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-col ant-col-8"
+            style="padding-left: 12px; padding-right: 12px; text-align: end;"
+          >
+            <div
+              class="ant-form-item ant-pro-query-filter-actions ant-form-item-horizontal"
+            >
+              <div
+                class="ant-row ant-form-item-row"
+              >
+                <div
+                  class="ant-col ant-form-item-label"
+                >
+                  <label
+                    class="ant-form-item-required-mark-hidden ant-form-item-no-colon"
+                    title=" "
+                  >
+                     
+                  </label>
+                </div>
+                <div
+                  class="ant-col ant-form-item-control"
+                >
+                  <div
+                    class="ant-form-item-control-input"
+                  >
+                    <div
+                      class="ant-form-item-control-input-content"
+                    >
+                      <div
+                        class="ant-space ant-space-horizontal ant-space-align-center"
+                        style="column-gap: 16px; row-gap: 16px;"
+                      >
+                        <div
+                          class="ant-space-item"
+                        >
+                          <div
+                            style="display: flex; gap: 8px; align-items: center;"
+                          >
+                            <button
+                              class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+                              type="button"
+                            >
+                              <span>
+                                重 置
+                              </span>
+                            </button>
+                            <button
+                              class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+                              type="button"
+                            >
+                              <span>
+                                查 询
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                        <div
+                          class="ant-space-item"
+                        >
+                          <a
+                            class="ant-pro-query-filter-collapse-button"
+                          >
+                            展开
+                            <span
+                              aria-label="down"
+                              class="anticon anticon-down"
+                              role="img"
+                              style="margin-inline-start: 0.5em; transition: 0.3s all; transform: rotate(0turn);"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="down"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                                />
+                              </svg>
+                            </span>
+                          </a>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div
+    class="ant-pro-card ant-pro-card-has-title ant-pro-card-no-divider ant-pro-card-no-padding ant-pro-card-border"
+  >
+    <div
+      class="ant-pro-card-body"
+      style="padding-block: 0;"
+    >
+      <div
+        class="ant-pro-table-list-toolbar"
+      >
+        <div
+          class="ant-pro-table-list-toolbar-container"
+        >
+          <div
+            class="ant-pro-table-list-toolbar-left"
+          />
+          <div
+            class="ant-pro-table-list-toolbar-right"
+            style="align-items: center;"
+          >
+            <div
+              class="ant-pro-table-list-toolbar-setting-items"
+            >
+              <div
+                class="ant-pro-table-list-toolbar-setting-item"
+              >
+                <span>
+                  <span
+                    aria-describedby="test-id"
+                    aria-label="reload"
+                    class="anticon anticon-reload"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="reload"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M909.1 209.3l-56.4 44.1C775.8 155.1 656.2 92 521.9 92 290 92 102.3 279.5 102 511.5 101.7 743.7 289.8 932 521.9 932c181.3 0 335.8-115 394.6-276.1 1.5-4.2-.7-8.9-4.9-10.3l-56.7-19.5a8 8 0 00-10.1 4.8c-1.8 5-3.8 10-5.9 14.9-17.3 41-42.1 77.8-73.7 109.4A344.77 344.77 0 01655.9 829c-42.3 17.9-87.4 27-133.8 27-46.5 0-91.5-9.1-133.8-27A341.5 341.5 0 01279 755.2a342.16 342.16 0 01-73.7-109.4c-17.9-42.4-27-87.4-27-133.9s9.1-91.5 27-133.9c17.3-41 42.1-77.8 73.7-109.4 31.6-31.6 68.4-56.4 109.3-73.8 42.3-17.9 87.4-27 133.8-27 46.5 0 91.5 9.1 133.8 27a341.5 341.5 0 01109.3 73.8c9.9 9.9 19.2 20.4 27.8 31.4l-60.2 47a8 8 0 003 14.1l175.6 43c5 1.2 9.9-2.6 9.9-7.7l.8-180.9c-.1-6.6-7.8-10.3-13-6.2z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <div
+                class="ant-pro-table-list-toolbar-setting-item"
+              >
+                <span>
+                  <span
+                    aria-describedby="test-id"
+                    aria-label="column-height"
+                    class="anticon anticon-column-height ant-dropdown-trigger"
+                    role="img"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="column-height"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M840 836H184c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h656c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8zm0-724H184c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h656c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8zM610.8 378c6 0 9.4-7 5.7-11.7L515.7 238.7a7.14 7.14 0 00-11.3 0L403.6 366.3a7.23 7.23 0 005.7 11.7H476v268h-62.8c-6 0-9.4 7-5.7 11.7l100.8 127.5c2.9 3.7 8.5 3.7 11.3 0l100.8-127.5c3.7-4.7.4-11.7-5.7-11.7H548V378h62.8z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <div
+                class="ant-pro-table-list-toolbar-setting-item"
+              >
+                <span
+                  aria-describedby="test-id"
+                  aria-label="setting"
+                  class="anticon anticon-setting"
+                  role="img"
+                  tabindex="-1"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="setting"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-table-wrapper"
+      >
+        <div
+          class="ant-spin-nested-loading"
+        >
+          <div
+            class="ant-spin-container"
+          >
+            <div
+              class="ant-table"
+            >
+              <div
+                class="ant-table-container"
+              >
+                <div
+                  class="ant-table-content"
+                >
+                  <table
+                    style="table-layout: auto;"
+                  >
+                    <thead
+                      class="ant-table-thead"
+                    >
+                      <tr>
+                        <th
+                          class="ant-table-cell"
+                          scope="col"
+                        >
+                          Name
+                        </th>
+                        <th
+                          class="ant-table-cell"
+                          scope="col"
+                        >
+                          Age
+                        </th>
+                        <th
+                          class="ant-table-cell"
+                          scope="col"
+                        >
+                          Address
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody
+                      class="ant-table-tbody"
+                    >
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="1"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 1
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          1 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="2"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 2
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          2 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="3"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 3
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          3 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="4"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 4
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          4 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="5"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 5
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          5 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="6"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 6
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          6 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="7"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 7
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          7 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="8"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 8
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          8 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="9"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 9
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          9 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="10"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 10
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          32
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          10 Road, Hangzhou, Zhejiang Province
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+            <ul
+              class="ant-pagination ant-pagination-end ant-table-pagination"
+            >
+              <li
+                class="ant-pagination-total-text"
+              >
+                99 in Total
+              </li>
+              <li
+                aria-disabled="true"
+                class="ant-pagination-prev ant-pagination-disabled"
+                title="上一页"
+              >
+                <button
+                  class="ant-pagination-item-link"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    aria-label="left"
+                    class="anticon anticon-left"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="left"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+                tabindex="0"
+                title="1"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  1
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-2"
+                tabindex="0"
+                title="2"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  2
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-3"
+                tabindex="0"
+                title="3"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  3
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-4"
+                tabindex="0"
+                title="4"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  4
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-5 ant-pagination-item-before-jump-next"
+                tabindex="0"
+                title="5"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  5
+                </a>
+              </li>
+              <li
+                class="ant-pagination-jump-next ant-pagination-jump-next-custom-icon"
+                tabindex="0"
+                title="向后 5 页"
+              >
+                <a
+                  class="ant-pagination-item-link"
+                >
+                  <div
+                    class="ant-pagination-item-container"
+                  >
+                    <span
+                      aria-label="double-right"
+                      class="anticon anticon-double-right ant-pagination-item-link-icon"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="double-right"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="ant-pagination-item-ellipsis"
+                    >
+                      •••
+                    </span>
+                  </div>
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-10"
+                tabindex="0"
+                title="10"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  10
+                </a>
+              </li>
+              <li
+                aria-disabled="false"
+                class="ant-pagination-next"
+                tabindex="0"
+                title="下一页"
+              >
+                <button
+                  class="ant-pagination-item-link"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    aria-label="right"
+                    class="anticon anticon-right"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="right"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+              <li
+                class="ant-pagination-options"
+              >
+                <div
+                  aria-label="页码"
+                  class="ant-select ant-select-outlined ant-pagination-options-size-changer ant-select-single ant-select-show-arrow ant-select-show-search"
+                >
+                  <div
+                    class="ant-select-selector"
+                  >
+                    <span
+                      class="ant-select-selection-wrap"
+                    >
+                      <span
+                        class="ant-select-selection-search"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="rc_select_TEST_OR_SSR_list"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-label="页码"
+                          aria-owns="rc_select_TEST_OR_SSR_list"
+                          autocomplete="off"
+                          class="ant-select-selection-search-input"
+                          id="rc_select_TEST_OR_SSR"
+                          role="combobox"
+                          type="search"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="ant-select-selection-item"
+                        title="10 条/页"
+                      >
+                        10 条/页
+                      </span>
+                    </span>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="ant-select-arrow"
+                    style="user-select: none;"
+                    unselectable="on"
+                  >
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down ant-select-suffix"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ProTable > outerBordered with column tooltip should keep single outer border 1`] = `
+<div
+  class="ant-pro-table"
+>
+  <div
+    class="ant-pro-card ant-pro-card-border ant-pro-card-bordered ant-pro-table-search ant-pro-table-search-query-filter"
+  >
+    <div
+      class="ant-pro-query-filter-container "
+    >
+      <form
+        autocomplete="off"
+        class="ant-form ant-form-horizontal ant-form-hide-required-mark ant-pro-query-filter ant-pro-form"
+      >
+        <input
+          style="display: none;"
+          type="text"
+        />
+        <div
+          class="ant-row ant-row-start ant-pro-query-filter-row"
+          style="margin-left: -12px; margin-right: -12px;"
+        >
+          <div
+            class="ant-col ant-col-8 ant-pro-query-filter-row-split"
+            style="padding-left: 12px; padding-right: 12px;"
+          >
+            <div
+              class="ant-form-item ant-form-item-horizontal"
+              style="flex-wrap: nowrap;"
+            >
+              <div
+                class="ant-row ant-form-item-row"
+              >
+                <div
+                  class="ant-col ant-form-item-label"
+                  style="flex: 0 0 80px;"
+                >
+                  <label
+                    class="ant-form-item-required-mark-hidden"
+                    for="name"
+                    title="Name"
+                  >
+                    Name
+                  </label>
+                </div>
+                <div
+                  class="ant-col ant-form-item-control"
+                  style="max-width: calc(100% - 80px);"
+                >
+                  <div
+                    class="ant-form-item-control-input"
+                  >
+                    <div
+                      class="ant-form-item-control-input-content"
+                    >
+                      <span
+                        class="ant-input-affix-wrapper ant-input-outlined"
+                        style="width: 100%;"
+                      >
+                        <input
+                          class="ant-input"
+                          id="name"
+                          placeholder="请输入"
+                          type="text"
+                          value=""
+                        />
+                        <span
+                          class="ant-input-suffix"
+                        >
+                          <button
+                            class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                            tabindex="-1"
+                            type="button"
+                          >
+                            <span
+                              aria-label="close-circle"
+                              class="anticon anticon-close-circle"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="close-circle"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                                />
+                              </svg>
+                            </span>
+                          </button>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-col ant-col-8 ant-pro-query-filter-row-split"
+            style="padding-left: 12px; padding-right: 12px;"
+          >
+            <div
+              class="ant-form-item ant-form-item-horizontal"
+              style="flex-wrap: nowrap;"
+            >
+              <div
+                class="ant-row ant-form-item-row"
+              >
+                <div
+                  class="ant-col ant-form-item-label"
+                  style="flex: 0 0 80px;"
+                >
+                  <label
+                    class="ant-form-item-required-mark-hidden"
+                    for="age"
+                    title="Age"
+                  >
+                    Age
+                  </label>
+                </div>
+                <div
+                  class="ant-col ant-form-item-control"
+                  style="max-width: calc(100% - 80px);"
+                >
+                  <div
+                    class="ant-form-item-control-input"
+                  >
+                    <div
+                      class="ant-form-item-control-input-content"
+                    >
+                      <span
+                        class="ant-input-affix-wrapper ant-input-outlined"
+                        style="width: 100%;"
+                      >
+                        <input
+                          class="ant-input"
+                          id="age"
+                          placeholder="请输入"
+                          type="text"
+                          value=""
+                        />
+                        <span
+                          class="ant-input-suffix"
+                        >
+                          <button
+                            class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                            tabindex="-1"
+                            type="button"
+                          >
+                            <span
+                              aria-label="close-circle"
+                              class="anticon anticon-close-circle"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="close-circle"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                                />
+                              </svg>
+                            </span>
+                          </button>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-col ant-col-8"
+            style="padding-left: 12px; padding-right: 12px; text-align: end;"
+          >
+            <div
+              class="ant-form-item ant-pro-query-filter-actions ant-form-item-horizontal"
+            >
+              <div
+                class="ant-row ant-form-item-row"
+              >
+                <div
+                  class="ant-col ant-form-item-label"
+                >
+                  <label
+                    class="ant-form-item-required-mark-hidden ant-form-item-no-colon"
+                    title=" "
+                  >
+                     
+                  </label>
+                </div>
+                <div
+                  class="ant-col ant-form-item-control"
+                >
+                  <div
+                    class="ant-form-item-control-input"
+                  >
+                    <div
+                      class="ant-form-item-control-input-content"
+                    >
+                      <div
+                        class="ant-space ant-space-horizontal ant-space-align-center"
+                        style="column-gap: 16px; row-gap: 16px;"
+                      >
+                        <div
+                          class="ant-space-item"
+                        >
+                          <div
+                            style="display: flex; gap: 8px; align-items: center;"
+                          >
+                            <button
+                              class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+                              type="button"
+                            >
+                              <span>
+                                重 置
+                              </span>
+                            </button>
+                            <button
+                              class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+                              type="button"
+                            >
+                              <span>
+                                查 询
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div
+    class="ant-pro-card ant-pro-card-has-title ant-pro-card-no-divider ant-pro-card-no-padding ant-pro-card-border"
+  >
+    <div
+      class="ant-pro-card-body"
+      style="padding-block: 0;"
+    >
+      <div
+        class="ant-pro-table-list-toolbar"
+      >
+        <div
+          class="ant-pro-table-list-toolbar-container"
+        >
+          <div
+            class="ant-pro-table-list-toolbar-left"
+          />
+          <div
+            class="ant-pro-table-list-toolbar-right"
+            style="align-items: center;"
+          >
+            <div
+              class="ant-pro-table-list-toolbar-setting-items"
+            >
+              <div
+                class="ant-pro-table-list-toolbar-setting-item"
+              >
+                <span>
+                  <span
+                    aria-describedby="test-id"
+                    aria-label="reload"
+                    class="anticon anticon-reload"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="reload"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M909.1 209.3l-56.4 44.1C775.8 155.1 656.2 92 521.9 92 290 92 102.3 279.5 102 511.5 101.7 743.7 289.8 932 521.9 932c181.3 0 335.8-115 394.6-276.1 1.5-4.2-.7-8.9-4.9-10.3l-56.7-19.5a8 8 0 00-10.1 4.8c-1.8 5-3.8 10-5.9 14.9-17.3 41-42.1 77.8-73.7 109.4A344.77 344.77 0 01655.9 829c-42.3 17.9-87.4 27-133.8 27-46.5 0-91.5-9.1-133.8-27A341.5 341.5 0 01279 755.2a342.16 342.16 0 01-73.7-109.4c-17.9-42.4-27-87.4-27-133.9s9.1-91.5 27-133.9c17.3-41 42.1-77.8 73.7-109.4 31.6-31.6 68.4-56.4 109.3-73.8 42.3-17.9 87.4-27 133.8-27 46.5 0 91.5 9.1 133.8 27a341.5 341.5 0 01109.3 73.8c9.9 9.9 19.2 20.4 27.8 31.4l-60.2 47a8 8 0 003 14.1l175.6 43c5 1.2 9.9-2.6 9.9-7.7l.8-180.9c-.1-6.6-7.8-10.3-13-6.2z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <div
+                class="ant-pro-table-list-toolbar-setting-item"
+              >
+                <span>
+                  <span
+                    aria-describedby="test-id"
+                    aria-label="column-height"
+                    class="anticon anticon-column-height ant-dropdown-trigger"
+                    role="img"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="column-height"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M840 836H184c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h656c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8zm0-724H184c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h656c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8zM610.8 378c6 0 9.4-7 5.7-11.7L515.7 238.7a7.14 7.14 0 00-11.3 0L403.6 366.3a7.23 7.23 0 005.7 11.7H476v268h-62.8c-6 0-9.4 7-5.7 11.7l100.8 127.5c2.9 3.7 8.5 3.7 11.3 0l100.8-127.5c3.7-4.7.4-11.7-5.7-11.7H548V378h62.8z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <div
+                class="ant-pro-table-list-toolbar-setting-item"
+              >
+                <span
+                  aria-describedby="test-id"
+                  aria-label="setting"
+                  class="anticon anticon-setting"
+                  role="img"
+                  tabindex="-1"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="setting"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-table-wrapper"
+      >
+        <div
+          class="ant-spin-nested-loading"
+        >
+          <div
+            class="ant-spin-container"
+          >
+            <div
+              class="ant-table ant-table-scroll-horizontal"
+            >
+              <div
+                class="ant-table-container"
+              >
+                <div
+                  class="ant-table-content"
+                  style="overflow-x: auto; overflow-y: hidden;"
+                >
+                  <table
+                    style="min-width: 100%; table-layout: auto;"
+                  >
+                    <thead
+                      class="ant-table-thead"
+                    >
+                      <tr>
+                        <th
+                          class="ant-table-cell"
+                          scope="col"
+                        >
+                          <div
+                            class="ant-space ant-space-horizontal ant-space-align-center ant-space-not-support-gap"
+                            style="column-gap: 4px; row-gap: 4px;"
+                          >
+                            <div
+                              class="ant-space-item"
+                            >
+                              Name
+                            </div>
+                            <div
+                              class="ant-space-item"
+                            >
+                              <span
+                                aria-describedby="test-id"
+                                aria-label="question-circle"
+                                class="anticon anticon-question-circle ant-table-column-title-tooltip-icon"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  data-icon="question-circle"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height="1em"
+                                  viewBox="64 64 896 896"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                                  />
+                                  <path
+                                    d="M623.6 316.7C593.6 290.4 554 276 512 276s-81.6 14.5-111.6 40.7C369.2 344 352 380.7 352 420v7.6c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V420c0-44.1 43.1-80 96-80s96 35.9 96 80c0 31.1-22 59.6-56.1 72.7-21.2 8.1-39.2 22.3-52.1 40.9-13.1 19-19.9 41.8-19.9 64.9V620c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8v-22.7a48.3 48.3 0 0130.9-44.8c59-22.7 97.1-74.7 97.1-132.5.1-39.3-17.1-76-48.3-103.3zM472 732a40 40 0 1080 0 40 40 0 10-80 0z"
+                                  />
+                                </svg>
+                              </span>
+                            </div>
+                          </div>
+                        </th>
+                        <th
+                          class="ant-table-cell ant-table-cell-last-column"
+                          scope="col"
+                        >
+                          Age
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody
+                      class="ant-table-tbody"
+                    >
+                      <tr
+                        aria-hidden="true"
+                        class="ant-table-measure-row"
+                        tabindex="-1"
+                      >
+                        <th
+                          class="ant-table-measure-cell"
+                        >
+                          <div
+                            class="ant-table-measure-cell-content"
+                          >
+                            <div
+                              class="ant-space ant-space-horizontal ant-space-align-center ant-space-not-support-gap"
+                              style="column-gap: 4px; row-gap: 4px;"
+                            >
+                              <div
+                                class="ant-space-item"
+                              >
+                                Name
+                              </div>
+                              <div
+                                class="ant-space-item"
+                              >
+                                <span
+                                  aria-describedby="test-id"
+                                  aria-label="question-circle"
+                                  class="anticon anticon-question-circle ant-table-column-title-tooltip-icon"
+                                  role="img"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    data-icon="question-circle"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height="1em"
+                                    viewBox="64 64 896 896"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                                    />
+                                    <path
+                                      d="M623.6 316.7C593.6 290.4 554 276 512 276s-81.6 14.5-111.6 40.7C369.2 344 352 380.7 352 420v7.6c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V420c0-44.1 43.1-80 96-80s96 35.9 96 80c0 31.1-22 59.6-56.1 72.7-21.2 8.1-39.2 22.3-52.1 40.9-13.1 19-19.9 41.8-19.9 64.9V620c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8v-22.7a48.3 48.3 0 0130.9-44.8c59-22.7 97.1-74.7 97.1-132.5.1-39.3-17.1-76-48.3-103.3zM472 732a40 40 0 1080 0 40 40 0 10-80 0z"
+                                    />
+                                  </svg>
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </th>
+                        <th
+                          class="ant-table-measure-cell"
+                        >
+                          <div
+                            class="ant-table-measure-cell-content"
+                          >
+                            Age
+                          </div>
+                        </th>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="1"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 1
+                        </td>
+                        <td
+                          class="ant-table-cell ant-table-cell-last-column"
+                        >
+                          32
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="2"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 2
+                        </td>
+                        <td
+                          class="ant-table-cell ant-table-cell-last-column"
+                        >
+                          32
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="3"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 3
+                        </td>
+                        <td
+                          class="ant-table-cell ant-table-cell-last-column"
+                        >
+                          32
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="4"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 4
+                        </td>
+                        <td
+                          class="ant-table-cell ant-table-cell-last-column"
+                        >
+                          32
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="5"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 5
+                        </td>
+                        <td
+                          class="ant-table-cell ant-table-cell-last-column"
+                        >
+                          32
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="6"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 6
+                        </td>
+                        <td
+                          class="ant-table-cell ant-table-cell-last-column"
+                        >
+                          32
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="7"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 7
+                        </td>
+                        <td
+                          class="ant-table-cell ant-table-cell-last-column"
+                        >
+                          32
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="8"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 8
+                        </td>
+                        <td
+                          class="ant-table-cell ant-table-cell-last-column"
+                        >
+                          32
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="9"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 9
+                        </td>
+                        <td
+                          class="ant-table-cell ant-table-cell-last-column"
+                        >
+                          32
+                        </td>
+                      </tr>
+                      <tr
+                        class="ant-table-row ant-table-row-level-0"
+                        data-row-key="10"
+                      >
+                        <td
+                          class="ant-table-cell"
+                        >
+                          John 10
+                        </td>
+                        <td
+                          class="ant-table-cell ant-table-cell-last-column"
+                        >
+                          32
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+            <ul
+              class="ant-pagination ant-pagination-end ant-table-pagination"
+            >
+              <li
+                class="ant-pagination-total-text"
+              >
+                <span>
+                  99 in Total
+                </span>
+              </li>
+              <li
+                aria-disabled="true"
+                class="ant-pagination-prev ant-pagination-disabled"
+                title="上一页"
+              >
+                <button
+                  class="ant-pagination-item-link"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    aria-label="left"
+                    class="anticon anticon-left"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="left"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+                tabindex="0"
+                title="1"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  1
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-2"
+                tabindex="0"
+                title="2"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  2
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-3"
+                tabindex="0"
+                title="3"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  3
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-4"
+                tabindex="0"
+                title="4"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  4
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-5 ant-pagination-item-before-jump-next"
+                tabindex="0"
+                title="5"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  5
+                </a>
+              </li>
+              <li
+                class="ant-pagination-jump-next ant-pagination-jump-next-custom-icon"
+                tabindex="0"
+                title="向后 5 页"
+              >
+                <a
+                  class="ant-pagination-item-link"
+                >
+                  <div
+                    class="ant-pagination-item-container"
+                  >
+                    <span
+                      aria-label="double-right"
+                      class="anticon anticon-double-right ant-pagination-item-link-icon"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="double-right"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="ant-pagination-item-ellipsis"
+                    >
+                      •••
+                    </span>
+                  </div>
+                </a>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-10"
+                tabindex="0"
+                title="10"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  10
+                </a>
+              </li>
+              <li
+                aria-disabled="false"
+                class="ant-pagination-next"
+                tabindex="0"
+                title="下一页"
+              >
+                <button
+                  class="ant-pagination-item-link"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    aria-label="right"
+                    class="anticon anticon-right"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="right"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+              <li
+                class="ant-pagination-options"
+              >
+                <div
+                  aria-label="页码"
+                  class="ant-select ant-select-outlined ant-pagination-options-size-changer ant-select-single ant-select-show-arrow ant-select-show-search"
+                >
+                  <div
+                    class="ant-select-selector"
+                  >
+                    <span
+                      class="ant-select-selection-wrap"
+                    >
+                      <span
+                        class="ant-select-selection-search"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="rc_select_TEST_OR_SSR_list"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-label="页码"
+                          aria-owns="rc_select_TEST_OR_SSR_list"
+                          autocomplete="off"
+                          class="ant-select-selection-search-input"
+                          id="rc_select_TEST_OR_SSR"
+                          role="combobox"
+                          type="search"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="ant-select-selection-item"
+                        title="10 条/页"
+                      >
+                        10 条/页
+                      </span>
+                    </span>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="ant-select-arrow"
+                    style="user-select: none;"
+                    unselectable="on"
+                  >
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down ant-select-suffix"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ProTable > render 1`] = `
 <div
   class="ant-pro-table"

--- a/packages/ui/src/ProTable/__tests__/index.test.tsx
+++ b/packages/ui/src/ProTable/__tests__/index.test.tsx
@@ -88,4 +88,36 @@ describe('ProTable', () => {
     expect(container.querySelector('.ant-table-inner-bordered .ant-table-bordered')).toBeTruthy();
     expect(asFragment().firstChild).toMatchSnapshot();
   });
+
+  it('outerBordered should work', () => {
+    const { container, asFragment } = render(<ProTableTest outerBordered={true} />);
+    // outerBordered 即 ProCard 边框
+    expect(container.querySelector('.ant-pro-card-border')).toBeTruthy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('outerBordered + innerBordered should work', () => {
+    const { container, asFragment } = render(
+      <ProTableTest outerBordered={true} innerBordered={true} />
+    );
+    // 外框 + 内部全网格
+    expect(container.querySelector('.ant-pro-card-border')).toBeTruthy();
+    expect(container.querySelector('.ant-table-inner-bordered .ant-table-bordered')).toBeTruthy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('outerBordered with column tooltip should keep single outer border', () => {
+    const tooltipColumns = [
+      { title: 'Name', dataIndex: 'name', tooltip: 'the name column' },
+      { title: 'Age', dataIndex: 'age' },
+    ];
+    const { container, asFragment } = render(
+      <ProTableTest columns={tooltipColumns} outerBordered={true} />
+    );
+    // tooltip 列走 tableViewRender 渲染内部 Table，外层边框仍由 ProCard 提供
+    expect(container.querySelector('.ant-pro-card-border')).toBeTruthy();
+    // 内部不再自包 Card，避免双边框
+    expect(container.querySelector('.ant-card-bordered')).toBeFalsy();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
 });

--- a/packages/ui/src/ProTable/index.en-US.md
+++ b/packages/ui/src/ProTable/index.en-US.md
@@ -24,9 +24,10 @@ nav:
 
 ## API
 
-| Property      | Description  | Type                           | Default | Version |
-| :------------ | :----------- | :----------------------------- | :------ | :------ |
-| defaultSize   | Default size | `large` \| `middle` \| `small` | `large` | -       |
-| innerBordered | Inner border | boolean                        | -       | -       |
+| Property | Description | Type | Default | Version |
+| :-- | :-- | :-- | :-- | :-- |
+| defaultSize | Default size | `large` \| `middle` \| `small` | `large` | - |
+| innerBordered | Inner border | boolean | - | - |
+| outerBordered | Outer border (the ProCard border, pagination included), interior keeps borderless style | boolean | - | - |
 
 - More API: https://procomponents.ant.design/components/table

--- a/packages/ui/src/ProTable/index.md
+++ b/packages/ui/src/ProTable/index.md
@@ -24,9 +24,10 @@ nav:
 
 ## API
 
-| 参数          | 说明       | 类型                           | 默认值  | 版本 |
-| :------------ | :--------- | :----------------------------- | :------ | :--- |
-| defaultSize   | 默认尺寸   | `large` \| `middle` \| `small` | `large` | -    |
-| innerBordered | 带内部边框 | boolean                        | -       | -    |
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| :-- | :-- | :-- | :-- | :-- |
+| defaultSize | 默认尺寸 | `large` \| `middle` \| `small` | `large` | - |
+| innerBordered | 带内部边框 | boolean | - | - |
+| outerBordered | 设置外围边框（即 ProCard 边框，分页器包含在边框内），内部保持无边框样式 | boolean | - | - |
 
 - 更多 API 详见 pro-components ProTable 文档: https://procomponents.ant.design/components/table

--- a/packages/ui/src/ProTable/index.tsx
+++ b/packages/ui/src/ProTable/index.tsx
@@ -11,6 +11,8 @@ import { createObTableViewRender } from './obTableViewRender';
 
 export interface ProTableProps<T, U, ValueType> extends AntProTableProps<T, U, ValueType> {
   innerBordered?: boolean;
+  /** 设置外围边框（即 ProCard 边框，分页器包含在边框内），内部保持无边框样式 */
+  outerBordered?: boolean;
 }
 
 // type CompoundedComponent = React.FC<ProTableProps<T, U, ValueType>> & typeof AntProTable;
@@ -25,6 +27,7 @@ function ProTable<T, U, ValueType>({
   size,
   bordered,
   innerBordered,
+  outerBordered,
   cardBordered,
   expandable,
   rowSelection,
@@ -120,7 +123,10 @@ function ProTable<T, U, ValueType>({
           size={size}
           bordered={bordered || innerBordered}
           cardBordered={
-            cardBordered ?? (contextCard?.variant ? contextCard?.variant === 'outlined' : undefined)
+            outerBordered
+              ? true
+              : (cardBordered ??
+                (contextCard?.variant ? contextCard?.variant === 'outlined' : undefined))
           }
           form={{
             // query form should remove required mark

--- a/packages/ui/src/ProTable/obTableViewRender.tsx
+++ b/packages/ui/src/ProTable/obTableViewRender.tsx
@@ -33,6 +33,7 @@ export function createObTableViewRender<T, U, ValueType>({
         {...props}
         columns={mergeTooltip ? mergeColumnTooltip(props.columns, columns) : props.columns}
         innerBordered={innerBordered}
+        // 外层边框由 ProCard（cardBordered）提供，内部 Table 不再自包边框，避免 tooltip 列场景双边框
         className={classNames(tableCls, props.className)}
         pagination={pagination}
         locale={{

--- a/skills/oceanbase-design/references/generated/props-index.md
+++ b/skills/oceanbase-design/references/generated/props-index.md
@@ -19,11 +19,11 @@
 | LightFilter | @oceanbase/ui | D | filterAriaLabel | filter-not-select-for-bar |
 | Modal | @oceanbase/design | B | extra, document | — |
 | PageContainer | @oceanbase/ui | D | header, locale | — |
-| ProTable | @oceanbase/ui | D | innerBordered | table-over-protable |
+| ProTable | @oceanbase/ui | D | innerBordered, outerBordered | table-over-protable |
 | Result | @oceanbase/design | C | status | — |
 | Select | @oceanbase/design | A | — | filter-not-select-for-bar |
 | Spin | @oceanbase/design | C | gray | — |
-| Table | @oceanbase/design | B | innerBordered, cancelText, collapseText, openText, hiddenCancelBtn, toolOptionsRender, toolAlertRender, toolSelectedContent | card-table-inner-bordered, table-over-protable, table-batch-tool-options |
+| Table | @oceanbase/design | B | innerBordered, outerBordered, cancelText, collapseText, openText, hiddenCancelBtn, toolOptionsRender, toolAlertRender, toolSelectedContent | card-table-inner-bordered, table-over-protable, table-batch-tool-options |
 
 ## diffLevel legend
 


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [x] @oceanbase/ui

### 🤔 This is a ...

- [x] New feature

### 🔗 Related issue link

N/A

### 💡 Background and solution

`<Card bordered bodyStyle={{ padding: 0 }}><Table /></Card>` 是常见的外框 + 贴边表格组合，但需要手动维护 Card 包裹、padding 归零与首尾列对齐细节。新增 `outerBordered` 在组件层封装这一组合：

- **Table**：`outerBordered` 时组件层包裹 Card（`bordered` + `bodyStyle={{ padding: 0 }}`），自动命中 Card 的 `no-body-horizontal-padding`（首尾列对齐、rowspan 纠偏）与 `no-body-padding-bottom`（无分页双线修复）分支；分页器包含在边框内；`className`/`style`/`id` 挂外层 Card；`ref` 仍指向内部 rc-table。
- **ProTable**：同步支持，外框由外层 ProCard 提供（强制 `cardBordered`），与内部透传链路一致。
- **组合语义**：`outerBordered + innerBordered` = 外框 + 全网格；`bordered` 为纯内部全网格、不含外框（demo 中已说明差异）。

```tsx
// before
<Card bordered bodyStyle={{ padding: 0 }}>
  <Table columns={columns} dataSource={data} />
</Card>

// after
<Table columns={columns} dataSource={data} outerBordered />

// 外框 + 全网格
<Table columns={columns} dataSource={data} outerBordered innerBordered />
```

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `outerBordered` to Table and ProTable: an outer border (pagination included) while the interior keeps the borderless style; a replacement for `Card bordered` + `bodyStyle={{ padding: 0 }}` + Table, often stacked with `innerBordered` for an outer frame plus full grid. |
| 🇨🇳 Chinese | Table 与 ProTable 新增 `outerBordered`：仅外围添加边框（分页器包含在边框内），内部保持无边框样式，可代替 Card bordered + bodyStyle padding 0 + Table 的组合；可与 `innerBordered` 叠加实现外框 + 全网格。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed