### PR TITLE
[v0] improve(ui): support ja-JP in locale dropdown for Login and BasicLayout

### DIFF
--- a/packages/ui/src/BasicLayout/index.md
+++ b/packages/ui/src/BasicLayout/index.md
@@ -114,6 +114,7 @@ const App = () => {
 | docsPath | 帮助文档首页对应的 path 路径，为空则不展示文档菜单 | string | - | - |
 | pdfPath | 帮助文档下载对应的 path 路径，默认优先使用路径中的文件名 | string | - | - |
 | showLocale | 是否展示国际化切换入口 | boolean | false | - |
+| locales | 自定义语言列表 | Locale[] | - | - |
 | username | 用户名 | string | - | - |
 | userMenu | 用户下拉菜单 | ReactNode | - | - |
 | appData | 产品信息 | [AppData](basic-layout#appdata) | - | - |

--- a/packages/ui/src/Login/index.md
+++ b/packages/ui/src/Login/index.md
@@ -37,6 +37,8 @@ nav:
 | showOtherLoginButton | 是否显示第三方登录按钮 | boolean | - | - |
 | authCodeImg | 验证码图片 URL 地址 | string | - | - |
 | onAuthCodeImgChange | 刷新验证码回调 | function | - | - |
+| showLocale | 是否展示语言切换入口 | boolean | - | - |
+| locales | 自定义语言列表 | Locale[] | - | - |
 | isMobile | 是否为移动端 | boolean | false | - |
 
 ### LoginProps

--- a/packages/ui/src/constant/index.ts
+++ b/packages/ui/src/constant/index.ts
@@ -20,4 +20,10 @@ export const LOCALE_LIST = [
     shortLabel: '繁体',
     minLabel: '繁',
   },
+  {
+    value: 'ja-JP',
+    label: '日本語',
+    shortLabel: '日本語',
+    minLabel: '日',
+  },
 ];

--- a/packages/ui/src/interface.ts
+++ b/packages/ui/src/interface.ts
@@ -1,1 +1,1 @@
-export type Locale = 'zh-TW' | 'zh-CN' | 'en-US';
+export type Locale = 'en-US' | 'ja-JP' | 'zh-CN' | 'zh-TW';


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/ui

### 🤔 This is a ...

- [x] Enhancement feature
- [x] Internationalization

### 🔗 Related issue link

### 💡 Background and solution

The locale dropdown in `Login` and `BasicLayout` (via `LocaleDropdown`) did not offer Japanese as a switchable language, even though all component `ja-JP` locale files already exist. The dropdown items come from the shared `LOCALE_LIST` constant.

Changes:

- Add `ja-JP` to the `Locale` union type in `packages/ui/src/interface.ts`
- Add the `日本語` entry to `LOCALE_LIST` (placed last) in `packages/ui/src/constant/index.ts`, which is consumed by both `Login` and `BasicLayout` locale dropdowns
- Document `showLocale` / `locales` props in `Login` and `locales` / `langs` in `BasicLayout`

Usage:

```tsx
<Login showLocale locales={['ja-JP', 'zh-CN', 'en-US']} ... />
<BasicLayout topHeader={{ showLocale: true }} ... />
```

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | `Login` and `BasicLayout` locale dropdown now support switching to Japanese (日本語), placed last in the language list. `locales` prop is also documented for both components. |
| 🇨🇳 Chinese | `Login` 和 `BasicLayout` 的语言下拉新增日文（日本語）选项，位于语言列表末尾；同时补充了两者的 `locales` 属性文档。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed