### PR TITLE
[v0] improve: enhance Chrome 83 compatibility across design and ui

### DIFF
--- a/packages/design/src/_util/useFlexGapSupport.ts
+++ b/packages/design/src/_util/useFlexGapSupport.ts
@@ -1,9 +1,10 @@
 import * as React from 'react';
+import useLayoutEffect from 'rc-util/es/hooks/useLayoutEffect';
 import { detectFlexGapSupported } from './styleChecker';
 
 export default () => {
   const [flexible, setFlexible] = React.useState(true);
-  React.useEffect(() => {
+  useLayoutEffect(() => {
     setFlexible(detectFlexGapSupported());
   }, []);
 

--- a/packages/design/src/config-provider/demo/style-provider.tsx
+++ b/packages/design/src/config-provider/demo/style-provider.tsx
@@ -1,0 +1,19 @@
+import { Button, ConfigProvider, Space } from '@oceanbase/design';
+import { legacyLogicalPropertiesTransformer } from '@ant-design/cssinjs';
+import React from 'react';
+
+const App: React.FC = () => (
+  <ConfigProvider
+    styleProviderProps={{
+      hashPriority: 'high',
+      transformers: [legacyLogicalPropertiesTransformer],
+    }}
+  >
+    <Space>
+      <Button type="primary">Button</Button>
+      <Button>Button</Button>
+    </Space>
+  </ConfigProvider>
+);
+
+export default App;

--- a/packages/design/src/config-provider/index.md
+++ b/packages/design/src/config-provider/index.md
@@ -24,6 +24,7 @@ nav:
 <code src="./demo/spin.tsx" title="Spin"></code>
 <code src="./demo/card.tsx" title="Card"></code>
 <code src="../empty/demo/config-provider.tsx" title="空状态"></code>
+<code src="./demo/style-provider.tsx" title="低版本浏览器样式兼容"></code>
 
 ### 样式前缀
 
@@ -57,3 +58,12 @@ export default App;
 | appProps | 内嵌的 App 组件属性 | [AppProps](https://ant-design.antgroup.com/components/app-cn#app) | - | - |
 
 - 更多 API 详见 antd ConfigProvider 文档: https://ant.design/components/config-provider-cn
+
+### 低版本浏览器（Chrome 83）兼容说明
+
+antd 5.x 默认使用 `:where()` 选择器（Chrome 88+）与 CSS 逻辑属性（Chrome 87+），在低版本浏览器（如 Chrome 83）中需要按以下方式接入：
+
+- **样式降级**：通过 `styleProviderProps` 配置 `hashPriority: 'high'`（规避 `:where()` 选择器，适用于 Chrome 88 以下）与 `legacyLogicalPropertiesTransformer`（将 cssinjs 生成的逻辑属性转为物理属性），参考上方「低版本浏览器样式兼容」示例。
+- **弹性间距**：`gap` 弹性布局（`flex`/`grid`）在 Chrome 84 以下无效。请优先使用本库封装的 `Flex` 组件（自动检测浏览器能力，不支持时降级为 `margin` 方案）或 `Space` 组件（自定义 `size` 时同样降级），避免直接使用裸 antd `Flex`。
+- **已知副作用**：配置 `hashPriority: 'high'` 后，`:where()` 选择器不再包裹样式，Popover 等浮层组件注入的 `position: fixed` 样式可能覆盖业务侧样式；如遇定位异常，可在业务样式上使用 `!important` 或改用 `right` 等物理属性定位。
+- **业务侧编译配置**：`@oceanbase/util` 依赖 `query-string@9`（产物含 Chrome 85+ 语法），需在 Umi 的 `extraBabelIncludes` 中按嵌套绝对路径引入该依赖，库侧无需改动代码。

--- a/packages/design/src/flex/__tests__/index.test.tsx
+++ b/packages/design/src/flex/__tests__/index.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Flex } from '@oceanbase/design';
+
+describe('Flex', () => {
+  it('render with gap fallback class in unsupported browsers', () => {
+    const { container } = render(
+      <Flex gap="middle">
+        <span>1</span>
+        <span>2</span>
+      </Flex>
+    );
+    // jsdom 下 detectFlexGapSupported 返回 false，应挂降级类
+    const flex = container.querySelector('div');
+    expect(flex?.className).toContain('not-support-gap');
+    // horizontal 类需显式存在，否则兜底 margin 规则 `.ant-flex-not-support-gap.ant-flex-horizontal` 无法命中
+    expect(flex?.className).toContain('horizontal');
+    expect(flex?.matches('.ant-flex-not-support-gap.ant-flex-horizontal')).toBe(true);
+    // 兜底 CSS 变量应注入内联样式
+    expect((flex as HTMLElement).style.getPropertyValue('--flex-gap-column')).not.toBe('');
+    expect((flex as HTMLElement).style.getPropertyValue('--flex-gap-row')).not.toBe('');
+  });
+
+  it('render vertical class for gap fallback', () => {
+    const { container } = render(
+      <Flex gap="middle" vertical>
+        <span>1</span>
+        <span>2</span>
+      </Flex>
+    );
+    const flex = container.querySelector('div');
+    expect(flex?.className).toContain('vertical');
+    expect(flex?.matches('.ant-flex-not-support-gap.ant-flex-vertical')).toBe(true);
+  });
+
+  it('render wrap class for gap fallback', () => {
+    const { container } = render(
+      <Flex gap="middle" wrap>
+        <span>1</span>
+        <span>2</span>
+      </Flex>
+    );
+    const flex = container.querySelector('div');
+    expect(flex?.className).toContain('wrap');
+    expect(flex?.matches('.ant-flex-not-support-gap.ant-flex-wrap.ant-flex-horizontal')).toBe(true);
+  });
+
+  it('parse gap double value string to row and column css variables', () => {
+    const { container } = render(
+      <Flex gap="8px 16px">
+        <span>1</span>
+        <span>2</span>
+      </Flex>
+    );
+    const flex = container.querySelector('div');
+    expect((flex as HTMLElement).style.getPropertyValue('--flex-gap-row')).toBe('8px');
+    expect((flex as HTMLElement).style.getPropertyValue('--flex-gap-column')).toBe('16px');
+  });
+
+  it('parse preset gap size to token values', () => {
+    const { container } = render(
+      <Flex gap="small">
+        <span>1</span>
+        <span>2</span>
+      </Flex>
+    );
+    const flex = container.querySelector('div');
+    expect((flex as HTMLElement).style.getPropertyValue('--flex-gap-column')).toBe('8px');
+  });
+});

--- a/packages/design/src/flex/demo/basic.tsx
+++ b/packages/design/src/flex/demo/basic.tsx
@@ -1,0 +1,12 @@
+import { Button, Flex } from '@oceanbase/design';
+import React from 'react';
+
+const App: React.FC = () => (
+  <Flex gap="small">
+    <Button type="primary">Button</Button>
+    <Button>Button</Button>
+    <Button>Button</Button>
+  </Flex>
+);
+
+export default App;

--- a/packages/design/src/flex/demo/wrap.tsx
+++ b/packages/design/src/flex/demo/wrap.tsx
@@ -1,0 +1,25 @@
+import { Flex } from '@oceanbase/design';
+import React from 'react';
+
+const App: React.FC = () => (
+  <Flex wrap="wrap" gap="middle">
+    {Array.from({ length: 24 }, (_, i) => (
+      <div
+        key={i}
+        style={{
+          width: 100,
+          height: 100,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#f0f5ff',
+          border: '1px solid #adc6ff',
+        }}
+      >
+        {i + 1}
+      </div>
+    ))}
+  </Flex>
+);
+
+export default App;

--- a/packages/design/src/flex/index.md
+++ b/packages/design/src/flex/index.md
@@ -1,0 +1,17 @@
+---
+title: Flex 弹性布局
+nav:
+  title: 基础组件
+  path: /components
+---
+
+- 🔥 完全继承 antd [Flex](https://ant.design/components/flex-cn/) 的能力和 API，可无缝切换。
+- 💄 低版本浏览器兼容：在不支持 `gap` 弹性布局（如 Chrome 83）的浏览器中，自动降级为 `margin` 方案，无需业务感知。
+
+## 代码演示
+
+<!-- prettier-ignore -->
+<code src="./demo/basic.tsx" title="基本用法"></code>
+<code src="./demo/wrap.tsx" title="自动换行"></code>
+
+- 详见 antd Flex 文档: https://ant.design/components/flex-cn/

--- a/packages/design/src/flex/index.tsx
+++ b/packages/design/src/flex/index.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { Flex as AntFlex } from 'antd';
+import type { FlexProps } from 'antd/es/flex/interface';
+import type { GlobalToken } from 'antd/es/theme/interface';
+import { isPresetSize } from 'antd/es/_util/gapSize';
+import useFlexGapSupport from '../_util/useFlexGapSupport';
+import { ConfigContext } from '../config-provider';
+import theme from '../theme';
+import useStyle from './style';
+
+export type { FlexProps } from 'antd/es/flex/interface';
+
+// normalize a single gap value to a css length, preset sizes map to design tokens
+const toCssGap = (
+  gap: NonNullable<FlexProps['gap']>,
+  token: Pick<GlobalToken, 'paddingXS' | 'padding' | 'paddingLG'>
+): string => {
+  if (typeof gap === 'number') {
+    return `${gap}px`;
+  }
+  if (isPresetSize(gap)) {
+    const presetMap = {
+      small: token.paddingXS,
+      middle: token.padding,
+      large: token.paddingLG,
+    } as const;
+    return `${presetMap[gap as keyof typeof presetMap]}px`;
+  }
+  return gap;
+};
+
+// split a gap into [row, column] css values, matching CSS `gap: <row-gap> <column-gap>`
+const parseGap = (
+  gap: FlexProps['gap'],
+  token: Pick<GlobalToken, 'paddingXS' | 'padding' | 'paddingLG'>
+): { row: string; column: string } | undefined => {
+  if (gap === undefined) {
+    return undefined;
+  }
+  // CSS gap 支持 "row column" 双值字符串语法
+  const [row, column] = toCssGap(gap, token).split(/\s+/);
+  return {
+    row,
+    column: column ?? row,
+  };
+};
+
+const Flex = React.forwardRef<HTMLElement, FlexProps>(
+  ({ prefixCls: customizePrefixCls, className, style, gap, vertical, wrap, ...restProps }, ref) => {
+    const { getPrefixCls } = React.useContext(ConfigContext);
+    const prefixCls = getPrefixCls('flex', customizePrefixCls);
+    const { wrapSSR } = useStyle(prefixCls);
+    const { token } = theme.useToken();
+
+    const supportFlexGap = useFlexGapSupport();
+    const wrapable = wrap === true || wrap === 'wrap' || wrap === 'wrap-reverse';
+    // 类名需与 style 规则选择器一致：
+    // `.ant-flex-not-support-gap.ant-flex-horizontal` 等（antd Flex 不生成 -horizontal/-wrap 类，需显式补上）
+    const flexCls = classNames(
+      {
+        [`${prefixCls}-not-support-gap`]: !supportFlexGap,
+        [`${prefixCls}-horizontal`]: !supportFlexGap && !vertical,
+        [`${prefixCls}-vertical`]: !supportFlexGap && vertical,
+        [`${prefixCls}-wrap`]: !supportFlexGap && wrapable,
+      },
+      className
+    );
+
+    // expose gap as css variables for the `-not-support-gap` margin fallback
+    const gapVar = !supportFlexGap ? parseGap(gap, token) : undefined;
+    const gapVars = gapVar
+      ? {
+          '--flex-gap-row': gapVar.row,
+          '--flex-gap-column': gapVar.column,
+        }
+      : undefined;
+
+    return wrapSSR(
+      <AntFlex
+        ref={ref}
+        className={flexCls}
+        style={{ ...gapVars, ...style }}
+        gap={gap}
+        vertical={vertical}
+        wrap={wrap}
+        {...restProps}
+      />
+    );
+  }
+);
+
+if (process.env.NODE_ENV !== 'production') {
+  Flex.displayName = 'Flex';
+}
+
+export default Flex;

--- a/packages/design/src/flex/style/index.ts
+++ b/packages/design/src/flex/style/index.ts
@@ -1,0 +1,38 @@
+import { type FullToken, type GenerateStyle } from 'antd/es/theme/internal';
+import { genComponentStyleHook } from '../../_util/genComponentStyleHook';
+import type { CSSObject } from '@ant-design/cssinjs';
+
+export type FlexToken = FullToken<'Flex'>;
+
+export const genFlexStyle: GenerateStyle<FlexToken> = (token: FlexToken): CSSObject => {
+  const { componentCls } = token;
+  return {
+    [`${componentCls}-not-support-gap${componentCls}-horizontal`]: {
+      '> *:not(:last-child)': {
+        marginRight: 'var(--flex-gap-column)',
+      },
+    },
+    [`${componentCls}-not-support-gap${componentCls}-vertical`]: {
+      '> *:not(:last-child)': {
+        marginBottom: 'var(--flex-gap-row)',
+      },
+    },
+    [`${componentCls}-not-support-gap${componentCls}-wrap${componentCls}-horizontal`]: {
+      '> *': {
+        marginBottom: 'var(--flex-gap-row)',
+      },
+    },
+    [`${componentCls}-not-support-gap${componentCls}-wrap${componentCls}-vertical`]: {
+      '> *': {
+        marginRight: 'var(--flex-gap-column)',
+      },
+    },
+  };
+};
+
+export default (prefixCls: string) => {
+  const useStyle = genComponentStyleHook('Flex', token => {
+    return [genFlexStyle(token as FlexToken)];
+  });
+  return useStyle(prefixCls);
+};

--- a/packages/design/src/index.ts
+++ b/packages/design/src/index.ts
@@ -12,6 +12,9 @@ export type { ButtonProps } from './button';
 export { default as Space } from './space';
 export type { SpaceProps, SpaceSize } from './space';
 
+export { default as Flex } from './flex';
+export type { FlexProps } from './flex';
+
 export { Col, Row } from './grid';
 export type { ColProps, RowProps, ColSize } from './grid';
 

--- a/packages/design/src/modal/__tests__/__snapshots__/modal.test.tsx.snap
+++ b/packages/design/src/modal/__tests__/__snapshots__/modal.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`Modal > extra prop should work 1`] = `
                   </div>
                   <div
                     class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small ant-space-not-support-gap"
+                    style="--space-gap-row: 8px; --space-gap-column: 8px;"
                   >
                     <div
                       class="ant-space-item"

--- a/packages/design/src/space/__tests__/index.test.tsx
+++ b/packages/design/src/space/__tests__/index.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Space } from '@oceanbase/design';
+
+describe('Space', () => {
+  it('render with gap fallback css variables in unsupported browsers', () => {
+    const { container } = render(
+      <Space>
+        <span>1</span>
+        <span>2</span>
+      </Space>
+    );
+    const space = container.querySelector('.ant-space');
+    expect(space?.className).toContain('not-support-gap');
+    // antd Space 自带 -horizontal 类，兜底规则 `.ant-space-not-support-gap.ant-space-horizontal` 应可命中
+    expect(space?.matches('.ant-space-not-support-gap.ant-space-horizontal')).toBe(true);
+    // jsdom 下 detectFlexGapSupported 返回 false，兜底 CSS 变量应注入内联样式
+    // antd Space 默认 size 为 small，对应 token.paddingXS（8px）
+    expect((space as HTMLElement).style.getPropertyValue('--space-gap-row')).toBe('8px');
+    expect((space as HTMLElement).style.getPropertyValue('--space-gap-column')).toBe('8px');
+  });
+
+  it('render wrap class for gap fallback', () => {
+    const { container } = render(
+      <Space wrap>
+        <span>1</span>
+        <span>2</span>
+      </Space>
+    );
+    const space = container.querySelector('.ant-space');
+    // wrap 类由本组件显式注入，兜底规则 `.ant-space-not-support-gap.ant-space-wrap` 应可命中
+    expect(space?.matches('.ant-space-not-support-gap.ant-space-wrap')).toBe(true);
+  });
+
+  it('parse size array to row and column css variables', () => {
+    // antd Space size 数组顺序为 [horizontal, vertical]，对应 CSS gap 的 [column, row]
+    const { container } = render(
+      <Space size={[16, 8]}>
+        <span>1</span>
+        <span>2</span>
+      </Space>
+    );
+    const space = container.querySelector('.ant-space');
+    expect((space as HTMLElement).style.getPropertyValue('--space-gap-row')).toBe('8px');
+    expect((space as HTMLElement).style.getPropertyValue('--space-gap-column')).toBe('16px');
+  });
+});

--- a/packages/design/src/space/index.tsx
+++ b/packages/design/src/space/index.tsx
@@ -3,18 +3,55 @@ import classNames from 'classnames';
 import useFlexGapSupport from '../_util/useFlexGapSupport';
 import { ConfigContext } from '../config-provider';
 import Compact from 'antd/es/space/Compact';
-import type { SpaceProps } from 'antd/es/space';
+import type { SpaceProps, SpaceSize } from 'antd/es/space';
+import type { GlobalToken } from 'antd/es/theme/interface';
 import { Space as AntSpace } from 'antd';
+import theme from '../theme';
 import useStyle from './style';
 
 export * from 'antd/es/space';
 export { SpaceContext } from 'antd/es/space/context';
 
+// normalize a single SpaceSize to a css value, fallback to token preset size
+const toCssSize = (
+  size: SpaceSize,
+  token: Pick<GlobalToken, 'paddingXS' | 'padding' | 'paddingLG'>
+): string => {
+  if (typeof size === 'number') {
+    return `${size}px`;
+  }
+  if (size === 'small') {
+    return `${token.paddingXS}px`;
+  }
+  if (size === 'large') {
+    return `${token.paddingLG}px`;
+  }
+  return `${token.padding}px`;
+};
+
+// split SpaceSize into [row, column] css values, matching CSS gap: <row-gap> <column-gap>
+// antd Space size array order is [horizontal, vertical], which maps to [column, row] in CSS gap
+const parseSpaceSize = (
+  size: SpaceProps['size'],
+  token: Pick<GlobalToken, 'paddingXS' | 'padding' | 'paddingLG'>
+): { row: string; column: string } => {
+  // antd Space default size is 'small'
+  const mergedSize = size ?? 'small';
+  const [horizontalSize, verticalSize] = Array.isArray(mergedSize)
+    ? mergedSize
+    : [mergedSize, mergedSize];
+  return {
+    row: toCssSize(verticalSize, token),
+    column: toCssSize(horizontalSize, token),
+  };
+};
+
 const Space = React.forwardRef<HTMLDivElement, SpaceProps>(
-  ({ prefixCls: customizePrefixCls, className, ...restProps }, ref) => {
+  ({ prefixCls: customizePrefixCls, className, size, style, ...restProps }, ref) => {
     const { getPrefixCls } = React.useContext(ConfigContext);
     const prefixCls = getPrefixCls('space', customizePrefixCls);
     const { wrapSSR } = useStyle(prefixCls);
+    const { token } = theme.useToken();
 
     const supportFlexGap = useFlexGapSupport();
     const spaceCls = classNames(
@@ -25,7 +62,24 @@ const Space = React.forwardRef<HTMLDivElement, SpaceProps>(
       className
     );
 
-    return wrapSSR(<AntSpace ref={ref} className={spaceCls} {...restProps} />);
+    // expose gap as css variables for the `-not-support-gap` margin fallback
+    const gap = !supportFlexGap ? parseSpaceSize(size, token) : undefined;
+    const gapVars = gap
+      ? {
+          '--space-gap-row': gap.row,
+          '--space-gap-column': gap.column,
+        }
+      : undefined;
+
+    return wrapSSR(
+      <AntSpace
+        ref={ref}
+        className={spaceCls}
+        style={{ ...gapVars, ...style }}
+        size={size}
+        {...restProps}
+      />
+    );
   }
 );
 

--- a/packages/design/src/space/style/index.ts
+++ b/packages/design/src/space/style/index.ts
@@ -9,20 +9,20 @@ export const genSpaceStyle: GenerateStyle<SpaceToken> = (token: SpaceToken): CSS
   return {
     [`${componentCls}-not-support-gap${componentCls}-horizontal`]: {
       [`${componentCls}-item:not(:last-child)`]: {
-        marginRight: '8px',
+        marginRight: 'var(--space-gap-column)',
       },
       [`${componentCls}-item-split`]: {
-        marginRight: '8px',
+        marginRight: 'var(--space-gap-column)',
       },
     },
     [`${componentCls}-not-support-gap${componentCls}-vertical`]: {
       [`${componentCls}-item:not(:last-child)`]: {
-        marginBottom: '16px',
+        marginBottom: 'var(--space-gap-row)',
       },
     },
     [`${componentCls}-not-support-gap${componentCls}-wrap`]: {
       [`${componentCls}-item`]: {
-        marginBottom: '16px',
+        marginBottom: 'var(--space-gap-row)',
       },
     },
   };

--- a/packages/design/src/table/hooks/useDefaultPagination.ts
+++ b/packages/design/src/table/hooks/useDefaultPagination.ts
@@ -19,7 +19,7 @@ export default (pagination?: false | TablePaginationConfig): false | TablePagina
         defaultPageSize: 10,
         showSizeChanger: true,
         pageSizeOptions: ['10', '20', '50', '100'],
-        showTotal: total => paginationLocale.total?.replaceAll('${total}', total?.toString()),
+        showTotal: total => paginationLocale.total?.split('${total}').join(total?.toString()),
         ...contextPagination,
         ...pagination,
       };

--- a/packages/ui/src/DateRanger/Ranger.tsx
+++ b/packages/ui/src/DateRanger/Ranger.tsx
@@ -683,8 +683,9 @@ const Ranger = React.forwardRef((props: DateRangerProps, ref) => {
               <Radio.Button
                 value="stepBack"
                 style={{
-                  paddingInline: 8,
-                  borderInlineStart: 0,
+                  paddingLeft: 8,
+                  paddingRight: 8,
+                  borderLeft: 0,
                   borderTopLeftRadius: 0,
                   borderBottomLeftRadius: 0,
                 }}
@@ -716,7 +717,8 @@ const Ranger = React.forwardRef((props: DateRangerProps, ref) => {
               <Radio.Button
                 value="stepForward"
                 style={{
-                  paddingInline: 8,
+                  paddingLeft: 8,
+                  paddingRight: 8,
                   borderTopLeftRadius: 0,
                   borderBottomLeftRadius: 0,
                 }}
@@ -743,7 +745,7 @@ const Ranger = React.forwardRef((props: DateRangerProps, ref) => {
       </Space>
       {hasSync && rangeName !== CUSTOMIZE && (
         <Button
-          style={{ paddingInline: 8, color: token.colorTextSecondary }}
+          style={{ paddingLeft: 8, paddingRight: 8, color: token.colorTextSecondary }}
           onClick={() => {
             setNow();
           }}

--- a/packages/ui/src/DateRanger/index.less
+++ b/packages/ui/src/DateRanger/index.less
@@ -116,7 +116,8 @@
     flex-wrap: nowrap;
 
     .@{prefixCls}-radio-button-wrapper {
-      padding-inline: 8px;
+      padding-left: 8px;
+      padding-right: 8px;
       color: @colorTextSecondary;
       transition: all 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
 

--- a/packages/ui/src/FullscreenBox/index.less
+++ b/packages/ui/src/FullscreenBox/index.less
@@ -12,18 +12,20 @@
     position: fixed;
     z-index: 900;
     background: #fff;
-    inset-block-start: 0;
-    inset-inline-end: 0;
-    inset-block-end: 0;
-    inset-inline-start: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
   }
   .@{prefix}-box-header {
     display: flex;
     height: 64px;
     .@{prefix}-box-header-left {
       flex: 1;
-      padding-block: 20px;
-      padding-inline: 24px;
+      padding-top: 20px;
+      padding-bottom: 20px;
+      padding-left: 24px;
+      padding-right: 24px;
     }
     .@{prefix}-box-header-icon {
       cursor: pointer;
@@ -32,13 +34,13 @@
       font-weight: 500;
       font-size: 16px;
       line-height: 24px;
-      margin-inline-start: 24px;
+      margin-left: 24px;
     }
     .@{prefix}-box-header-extra {
       flex: 2;
       line-height: 64px;
       text-align: end;
-      padding-inline-end: 24px;
+      padding-right: 24px;
     }
   }
 }

--- a/packages/ui/src/Highlight/index.less
+++ b/packages/ui/src/Highlight/index.less
@@ -20,19 +20,19 @@
   @keyframes copy-button-trans {
     0% {
       opacity: 0.8;
-      margin-block-start: 0;
+      margin-top: 0;
     }
     10% {
       opacity: 0.8;
-      margin-block-start: -16px;
+      margin-top: -16px;
     }
     90% {
       opacity: 0.8;
-      margin-block-start: -16px;
+      margin-top: -16px;
     }
     100% {
       opacity: 0.8;
-      margin-block-start: 0;
+      margin-top: 0;
     }
   }
 
@@ -55,7 +55,7 @@
     }
 
     .@{prefix}-light-index {
-      border-inline-end: 1px solid rgba(0, 0, 0, 0.05);
+      border-right: 1px solid rgba(0, 0, 0, 0.05);
     }
 
     display: block;
@@ -143,12 +143,16 @@
     text-align: end;
     background: rgba(255, 255, 255, 0.03);
     user-select: none;
-    padding-block: 2px;
-    padding-inline: 8px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    padding-left: 8px;
+    padding-right: 8px;
   }
   .@{prefix}-content {
-    padding-block: 2px;
-    padding-inline: 8px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    padding-left: 8px;
+    padding-right: 8px;
   }
   .@{prefix}-copy {
     position: absolute;
@@ -163,8 +167,8 @@
     cursor: pointer;
     opacity: 0.6;
     transition: opacity 0.2s;
-    inset-block-start: 16px;
-    inset-inline-end: 16px;
+    top: 16px;
+    right: 16px;
 
     &:hover {
       opacity: 0.8;
@@ -195,7 +199,7 @@
     border-radius: ~'@{borderRadius}px';
 
     &.@{prefix}-index {
-      border-inline-end: 1px solid rgba(255, 255, 255, 0.05);
+      border-right: 1px solid rgba(255, 255, 255, 0.05);
     }
 
     /* Ocean Comment */
@@ -283,8 +287,10 @@
     .@{prefix}-diff-index,
     .@{prefix}-diff-mark,
     .@{prefix}-diff-code {
-      padding-block: 2px;
-      padding-inline: 8px;
+      padding-top: 2px;
+      padding-bottom: 2px;
+      padding-left: 8px;
+      padding-right: 8px;
     }
 
     .@{prefix}-diff-index,
@@ -320,11 +326,11 @@
 
       .@{prefix}-diff-index {
         background: rgba(0, 0, 0, 0.01);
-        border-inline-end: 1px solid rgba(0, 0, 0, 0.05);
-        border-inline-start: 1px solid rgba(0, 0, 0, 0.1);
+        border-right: 1px solid rgba(0, 0, 0, 0.05);
+        border-left: 1px solid rgba(0, 0, 0, 0.1);
 
         &:first-child {
-          border-inline-start: none;
+          border-left: none;
         }
       }
 
@@ -354,11 +360,11 @@
 
       .@{prefix}-diff-index {
         background: rgba(255, 255, 255, 0.01);
-        border-inline-end: 1px solid rgba(255, 255, 255, 0.05);
-        border-inline-start: 1px solid rgba(255, 255, 255, 0.1);
+        border-right: 1px solid rgba(255, 255, 255, 0.05);
+        border-left: 1px solid rgba(255, 255, 255, 0.1);
 
         &:first-child {
-          border-inline-start: none;
+          border-left: none;
         }
       }
 

--- a/packages/ui/src/PageContainer/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/PageContainer/__tests__/__snapshots__/index.test.tsx.snap
@@ -344,6 +344,7 @@ exports[`PageContainer > extra and footer 1`] = `
         >
           <div
             class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small ant-space-not-support-gap"
+            style="--space-gap-row: 8px; --space-gap-column: 8px;"
           >
             <div
               class="ant-space-item"

--- a/packages/ui/src/PageLoading/index.tsx
+++ b/packages/ui/src/PageLoading/index.tsx
@@ -20,7 +20,7 @@ const PageLoading: React.FC<PageLoadingProps> = ({
         position: 'absolute',
         // horizontal align
         // 36px is 1/2 of large Spin width
-        insetInlineStart: 'calc(50% - 36px)',
+        left: 'calc(50% - 36px)',
         // vertical align
         // 27px is 1/2 of large Spin height
         top: 'calc(50% - 27px)',

--- a/packages/ui/src/ProTable/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/ProTable/__tests__/__snapshots__/index.test.tsx.snap
@@ -362,7 +362,7 @@ exports[`ProTable > ConfigProvider pagination should work 1`] = `
   >
     <div
       class="ant-pro-card-body"
-      style="padding-block: 0;"
+      style="padding-top: 0px; padding-bottom: 0px;"
     >
       <div
         class="ant-pro-table-list-toolbar"
@@ -1257,7 +1257,7 @@ exports[`ProTable > default pagination should work 1`] = `
   >
     <div
       class="ant-pro-card-body"
-      style="padding-block: 0;"
+      style="padding-top: 0px; padding-bottom: 0px;"
     >
       <div
         class="ant-pro-table-list-toolbar"
@@ -2224,7 +2224,7 @@ exports[`ProTable > innerBordered should work 1`] = `
   >
     <div
       class="ant-pro-card-body"
-      style="padding-block: 0;"
+      style="padding-top: 0px; padding-bottom: 0px;"
     >
       <div
         class="ant-pro-table-list-toolbar"
@@ -3191,7 +3191,7 @@ exports[`ProTable > render 1`] = `
   >
     <div
       class="ant-pro-card-body"
-      style="padding-block: 0;"
+      style="padding-top: 0px; padding-bottom: 0px;"
     >
       <div
         class="ant-pro-table-list-toolbar"

--- a/packages/ui/src/ProTable/index.tsx
+++ b/packages/ui/src/ProTable/index.tsx
@@ -100,7 +100,8 @@ function ProTable<T, U, ValueType>({
               cardProps?.className
             ),
             bodyStyle: {
-              paddingBlock: 0,
+              paddingTop: 0,
+              paddingBottom: 0,
               ...cardProps?.bodyStyle,
             },
           }}

--- a/packages/ui/src/SideTip/index.less
+++ b/packages/ui/src/SideTip/index.less
@@ -7,8 +7,8 @@
   z-index: 0;
   font-size: 14px;
   cursor: pointer;
-  inset-inline-end: 24px;
-  inset-block-end: 24px;
+  right: 24px;
+  bottom: 24px;
 
   &.@{prefix}-container-dragged {
     cursor: grab;
@@ -23,7 +23,7 @@
   }
 
   &.@{prefix}-container-hide-not-dragged:hover {
-    inset-inline-end: 0 !important;
+    right: 0 !important;
   }
 
   .@{prefix}-hide {
@@ -40,8 +40,8 @@
     cursor: pointer;
     opacity: 0;
     transition: all 0.18s ease-out 0.18s;
-    inset-block-start: 0;
-    inset-inline-end: -22px;
+    top: 0;
+    right: -22px;
 
     &:hover {
       background: rgba(0, 0, 0, 0.35);
@@ -100,8 +100,8 @@
       height: 56px;
       color: #006aff;
       font-size: 56px;
-      inset-block-start: 0;
-      inset-inline-end: 0;
+      top: 0;
+      right: 0;
 
       &.@{prefix}-button-loading-primary {
         color: #fff;
@@ -124,7 +124,7 @@
       opacity: 0;
       transition: all 0.3s linear;
       user-select: none;
-      inset-block-start: 50%;
+      top: 50%;
 
       &.@{prefix}-button-close-primary {
         color: #fff;
@@ -154,7 +154,7 @@
       opacity: 1;
       transition: all 0.3s linear;
       user-select: none;
-      inset-block-start: 50%;
+      top: 50%;
 
       &.@{prefix}-button-icon-open {
         transform: translateY(-50%) scale(0.4) rotate(45deg);


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- None

### 💡 Background and solution

Target: Chromium 83 support (ocp-451). Three categories of issues verified in this repo:

1. **JS compatibility** — `String.prototype.replaceAll` (Chrome 85+) in Table default pagination.
2. **CSS compatibility** — logical properties written as inline styles / compiled `.less` do not go through `legacyLogicalPropertiesTransformer` and break on Chrome 83; converted to physical properties in `@oceanbase/ui`.
3. **Flex / Space gap** — flex `gap` is unsupported on Chrome 83; added a `Flex` component with automatic fallback and made Space fallback margins honor custom `size`.

| Before | After |
| :--- | :--- |
| `replaceAll` throws on Chrome 83 | `split`/`join` — no runtime API dependency |
| Space fallback margin hardcoded 8/16px, ignores custom size | fallback uses CSS variables matching parsed size |
| No gap fallback for `Flex` | new `Flex` wraps antd Flex, auto-degrades on Chrome 83 |
| Inline/less logical properties break layout on Chrome 83 | physical properties (PageLoading, DateRanger, ProTable, SideTip, FullscreenBox, Highlight) |
| `useFlexGapSupport` first-frame flash | isomorphic `useLayoutEffect` |

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Flex<br/>&nbsp;&nbsp;- 🆕 Built-in gap fallback for browsers without flex gap support (e.g. Chrome 83), otherwise identical to antd `Flex`.<br/>- Space<br/>&nbsp;&nbsp;- 🐞 Fallback margins now follow custom `size` values instead of hardcoded 8/16px on older browsers.<br/>- Table<br/>&nbsp;&nbsp;- 🐞 Default pagination no longer uses `String.prototype.replaceAll`, fixing a runtime error on Chrome < 85.<br/>- @oceanbase/ui<br/>&nbsp;&nbsp;- 🐞 Replaced CSS logical properties with physical ones in `PageLoading`, `DateRanger`, `ProTable`, `SideTip`, `FullscreenBox`, `Highlight` so layouts render correctly on Chrome 83.<br/>- ConfigProvider<br/>&nbsp;&nbsp;- 📖 Added `styleProviderProps` guidance (`hashPriority: 'high'` + `legacyLogicalPropertiesTransformer`) and a demo for low-version browser integration. |
| 🇨🇳 Chinese | - Flex<br/>&nbsp;&nbsp;- 🆕 内置 gap 降级能力，在低版本浏览器（如 Chrome 83）下自动使用 margin 兜底，其余行为与 antd `Flex` 一致。<br/>- Space<br/>&nbsp;&nbsp;- 🐞 低版本浏览器下的兜底间距改为跟随自定义 `size`，不再写死 8/16px。<br/>- Table<br/>&nbsp;&nbsp;- 🐞 默认分页不再使用 `String.prototype.replaceAll`，修复 Chrome 85 以下运行时报错。<br/>- @oceanbase/ui<br/>&nbsp;&nbsp;- 🐞 `PageLoading`、`DateRanger`、`ProTable`、`SideTip`、`FullscreenBox`、`Highlight` 的 CSS 逻辑属性改为物理属性，保证 Chrome 83 布局正常。<br/>- ConfigProvider<br/>&nbsp;&nbsp;- 📖 补充 `styleProviderProps` 低版本浏览器接入指引（`hashPriority: 'high'` + `legacyLogicalPropertiesTransformer`）及示例。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
