### PR TITLE
[v0] chore(docs): Add changelog for @oceanbase/design@0.4.22 and @oceanbase/ui@0.4.26

### DIFF
--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,17 @@ group: 基础组件
 
 ---
 
+## 0.4.22
+
+`2026-08-13`
+
+- Flex
+  - 🆕 新增 Flex 组件，完整继承 antd Flex 的能力和 API，可无缝切换。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+  - 💄 低版本浏览器兼容：在不支持 `gap` 弹性布局的浏览器（如 Chrome 83）中，自动降级为 `margin` 方案。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+- 💄 优化 Space 在不支持 `gap` 的浏览器中的间距降级方案，自定义 `size` 时同样生效。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+- 🐞 修复 Table 默认分页的合计文案在低版本浏览器（Chrome 85 以下）中因不支持 `replaceAll` 语法而渲染异常的问题。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+- 📖 ConfigProvider 新增低版本浏览器（Chrome 83）样式兼容示例和接入说明。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+
 ## 0.4.21
 
 `2026-06-14`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,13 @@ group: 业务组件
 
 ---
 
+## 0.4.26
+
+`2026-08-13`
+
+- 🌐 Login 和 BasicLayout 的语种切换下拉框新增日语 (ja-JP) 支持。[#1534](https://github.com/oceanbase/oceanbase-design/pull/1534)
+- 💄 兼容低版本浏览器（Chrome 83）：将 PageLoading、DateRanger、ProTable、SideTip、FullscreenBox 和 Highlight 组件中的逻辑属性和内联样式转换为物理属性，修复样式显示异常。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+
 ## 0.4.25
 
 `2026-06-14`


### PR DESCRIPTION
## @oceanbase/design@0.4.22

`2026-08-13`

- Flex
  - 🆕 新增 Flex 组件，完整继承 antd Flex 的能力和 API，可无缝切换。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
  - 💄 低版本浏览器兼容：在不支持 `gap` 弹性布局的浏览器（如 Chrome 83）中，自动降级为 `margin` 方案。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
- 💄 优化 Space 在不支持 `gap` 的浏览器中的间距降级方案，自定义 `size` 时同样生效。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
- 🐞 修复 Table 默认分页的合计文案在低版本浏览器（Chrome 85 以下）中因不支持 `replaceAll` 语法而渲染异常的问题。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
- 📖 ConfigProvider 新增低版本浏览器（Chrome 83）样式兼容示例和接入说明。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)

---

## @oceanbase/ui@0.4.26

`2026-08-13`

- 🌐 Login 和 BasicLayout 的语种切换下拉框新增日语 (ja-JP) 支持。[#1534](https://github.com/oceanbase/oceanbase-design/pull/1534)
- 💄 兼容低版本浏览器（Chrome 83）：将 PageLoading、DateRanger、ProTable、SideTip、FullscreenBox 和 Highlight 组件中的逻辑属性和内联样式转换为物理属性，修复样式显示异常。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)

Made with [Cursor](https://cursor.com)