### PR TITLE
fix(ui): replace remaining inline logical properties with physical ones for Chrome 83

### DIFF
--- a/.dumi/rehypePlugin.ts
+++ b/.dumi/rehypePlugin.ts
@@ -7,6 +7,8 @@ function shouldSkipLocalePrefix(href: string): boolean {
   if (href.startsWith('/.well-known/')) return true;
   // Raw .md / .txt exports (design.md, llms.txt, /components/foo.md, /docs/**/*.md)
   if (/\.(md|txt)$/.test(href)) return true;
+  // Static files in public/ (wcag-audit-report.html etc.) live at site root
+  if (/\.html$/.test(href)) return true;
   return false;
 }
 

--- a/.github/workflows/release-helper.yml
+++ b/.github/workflows/release-helper.yml
@@ -26,8 +26,8 @@ jobs:
         uses: dengfuping/monorepo-release-helper@v1
         with:
           branch: 'master'
-          changelogs: 'docs/design/design-CHANGELOG.md, docs/ui/ui-CHANGELOG.md, docs/charts/charts-CHANGELOG.md, docs/codemod/codemod-CHANGELOG.md'
-          dingding-changelogs: 'docs/design/design-CHANGELOG.md, docs/ui/ui-CHANGELOG.md, docs/charts/charts-CHANGELOG.md, docs/codemod/codemod-CHANGELOG.md'
+          changelogs: 'docs/design/design-CHANGELOG.md, docs/design/design-CHANGELOG.zh-CN.md, docs/ui/ui-CHANGELOG.md, docs/ui/ui-CHANGELOG.zh-CN.md, docs/charts/charts-CHANGELOG.md, docs/charts/charts-CHANGELOG.zh-CN.md, docs/codemod/codemod-CHANGELOG.md, docs/codemod/codemod-CHANGELOG.zh-CN.md'
+          dingding-changelogs: 'docs/design/design-CHANGELOG.zh-CN.md, docs/ui/ui-CHANGELOG.zh-CN.md, docs/charts/charts-CHANGELOG.zh-CN.md, docs/codemod/codemod-CHANGELOG.zh-CN.md'
           dingding-token: ${{ secrets.DINGDING_BOT_TOKEN }}
           dingding-message-title: '# 🎉 OceanBase Design 新版本发布 🎉'
           dingding-message-poster: 'https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*zx7LTI_ECSAAAAAAAAAAAABkARQnAQ'

--- a/packages/ui/src/Action/Group.tsx
+++ b/packages/ui/src/Action/Group.tsx
@@ -405,7 +405,12 @@ export default ({
                       <Menu.Item
                         key={fcKey}
                         className={`${prefixCls}-more-menu-fn`}
-                        style={{ height: 'auto', lineHeight: 'normal', paddingBlock: 4 }}
+                        style={{
+                          height: 'auto',
+                          lineHeight: 'normal',
+                          paddingTop: 4,
+                          paddingBottom: 4,
+                        }}
                       >
                         {React.cloneElement(slot.el, { key: fcKey })}
                       </Menu.Item>

--- a/packages/ui/src/DateRanger/Ranger.tsx
+++ b/packages/ui/src/DateRanger/Ranger.tsx
@@ -706,8 +706,9 @@ const Ranger = React.forwardRef((props: DateRangerProps, ref) => {
                   value="stepBack"
                   aria-label={locale.jumpBack}
                   style={{
-                    paddingInline: 8,
-                    borderInlineStart: 0,
+                    paddingLeft: 8,
+                    paddingRight: 8,
+                    borderLeft: 0,
                     borderTopLeftRadius: 0,
                     borderBottomLeftRadius: 0,
                   }}
@@ -740,7 +741,8 @@ const Ranger = React.forwardRef((props: DateRangerProps, ref) => {
                   value="stepForward"
                   aria-label={locale.jumpForward}
                   style={{
-                    paddingInline: 8,
+                    paddingLeft: 8,
+                    paddingRight: 8,
                     borderTopLeftRadius: 0,
                     borderBottomLeftRadius: 0,
                   }}
@@ -769,7 +771,11 @@ const Ranger = React.forwardRef((props: DateRangerProps, ref) => {
       {hasSync && rangeName !== CUSTOMIZE && (
         <Button
           aria-label={locale.syncToCurrent}
-          style={{ paddingInline: 8, color: token.colorTextSecondary }}
+          style={{
+            paddingLeft: 8,
+            paddingRight: 8,
+            color: token.colorTextSecondary,
+          }}
           onClick={() => {
             setNow();
           }}


### PR DESCRIPTION
### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [x] Other (site build plugin / release workflow)

### 🤔 This is a ...

- [x] Bug fix
- [ ] Site / documentation update
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

ocp-451

### 💡 Background and solution

Following the Chrome 83 compatibility work merged via #1535, a scan found remaining inline logical properties that do not go through `legacyLogicalPropertiesTransformer` and break on Chrome 83 (logical properties only supported from Chrome 87):

- `DateRanger` shortcut toggle buttons: `paddingInline` / `borderInlineStart` in inline styles
- `Action` more-menu items: `paddingBlock` in inline styles

Also includes two unrelated pending workspace changes: site build plugin skips locale prefix for static `.html` files, and release workflow now includes zh-CN changelogs.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - DateRanger<br/>&nbsp;&nbsp;- 🐞 Fixed shortcut toggle button padding/divider not rendering on Chrome < 87 by replacing CSS logical properties with physical ones.<br/>- Action<br/>&nbsp;&nbsp;- 🐞 Fixed more-menu item vertical padding not rendering on Chrome < 87. |
| 🇨🇳 Chinese | - DateRanger<br/>&nbsp;&nbsp;- 🐞 修复快捷切换按钮的内边距与分隔线在 Chrome 87 以下浏览器不生效的问题，CSS 逻辑属性改为物理属性。<br/>- Action<br/>&nbsp;&nbsp;- 🐞 修复更多菜单项垂直内边距在 Chrome 87 以下不生效的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
