### PR TITLE
fix(ui): tighten DateRanger play button vertical padding to 2px

### DIFF
--- a/packages/ui/src/DateRanger/style/index.ts
+++ b/packages/ui/src/DateRanger/style/index.ts
@@ -55,7 +55,7 @@ export const genDateRangerStyle: GenerateStyle<DateRangerToken> = (
         borderBottomRightRadius: 0,
       },
       [`${componentCls}-play`]: {
-        padding: '3px 11px 3px',
+        padding: '2px 11px 2px',
       },
       [`${componentCls}-picker-input`]: {
         maxWidth: 125,


### PR DESCRIPTION
### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

Tightens the vertical padding of the DateRanger play state label from `3px` to `2px` so the label spacing aligns with the playback control height.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - DateRanger<br/>&nbsp;&nbsp;- 💄 The play state label vertical padding is tightened to align with the playback control. |
| 🇨🇳 Chinese | - DateRanger<br/>&nbsp;&nbsp;- 💄 播放态标签垂直内边距微调，与播放控制高度对齐。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed