### PR TITLE
[v0] fix(workflow): trigger release-helper on 0.x branch pushes

### DIFF
--- a/.github/workflows/release-helper.yml
+++ b/.github/workflows/release-helper.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - 'master'
+      - '0.x'
 
 permissions:
   contents: read


### PR DESCRIPTION
### 📦 Modified package

- [ ] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [x] Other (GitHub Actions workflow)

### 🤔 This is a ...

- [x] Workflow

### 💡 Background and solution

0.x 分支上执行 `pnpm run publish`（lerna）时，生成的 `Publish` 提交只推送在 0.x 分支，而 `release-helper.yml` 的触发条件仅监听 `master` 分支，导致 0.x 发布不会自动创建 GitHub Release、也不会推送钉钉通知（0.4.22 / 0.4.26 曾因此缺失 release，需要手工补建）。

修改内容： 将 `0.x` 加入 workflow 的触发分支列表；

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | No user-facing changes |
| 🇨🇳 Chinese | 无用户可感知变更 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed