### PR TITLE
chore(docs): Add changelog for @oceanbase/design@1.2.0 and @oceanbase/ui@1.2.0

### DIFF
--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,31 @@ group: General
 
 ---
 
+## 1.2.0
+
+`2026-08-13`
+
+- Chrome 83 Compatibility
+  - 🆕 Added Flex component with `gap` fallback to `margin` on browsers without flex `gap` support (e.g. Chrome 83). [#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+  - 💄 Space fallback margins now honor custom `size` on browsers without flex `gap` support. [#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+  - 🐞 Fixed Table default pagination total text breaking on browsers below Chrome 85 (replaced `replaceAll` with `split`/`join`). [#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+  - 📖 Added low-version browser (Chrome 83) style compatibility demo and migration guidance in ConfigProvider. [#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+- Table
+  - 🆕 Added `outerBordered` to show outer borders in addition to `innerBordered` column borders. [#1533](https://github.com/oceanbase/oceanbase-design/pull/1533)
+  - 🆕 Aligned `column.tooltip` semantics with `Form.Item.tooltip` (text or config object). [#1532](https://github.com/oceanbase/oceanbase-design/pull/1532)
+- Typography
+  - 🆕 Added `block` prop to `Text` and `Link`. [#1525](https://github.com/oceanbase/oceanbase-design/pull/1525)
+  - 🐞 Added missing units to editable padding and margins. [#1530](https://github.com/oceanbase/oceanbase-design/pull/1530)
+- Tag
+  - 🆕 Added lightweight CSS ellipsis mode to prevent content overflow. [#1529](https://github.com/oceanbase/oceanbase-design/pull/1529)
+- Radio / Checkbox
+  - 🐞 Restored baseline alignment of Radio and Checkbox wrappers. [#1531](https://github.com/oceanbase/oceanbase-design/pull/1531)
+  - 🐞 Top-aligned Radio and Checkbox labels for multi-line content. [#1522](https://github.com/oceanbase/oceanbase-design/pull/1522)
+- Input.Password
+  - 🐞 Renders as a text input until user interaction to suppress the saved-password dropdown. [#1528](https://github.com/oceanbase/oceanbase-design/pull/1528)
+- Upload
+  - 🐞 Preserved Button icon color inside Upload. [#1523](https://github.com/oceanbase/oceanbase-design/pull/1523)
+
 ## 1.1.0
 
 `2026-08-04`
@@ -40,6 +65,7 @@ group: General
   - 📌 Message documented as deprecated; migrate to Notification. [#1507](https://github.com/oceanbase/oceanbase-design/pull/1507)
 - Notification
   - 💄 Default bottom-left placement, fixed width 350px, linear icons with auto-close progress bar; links in title/description use type color. [#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
+  - 💄 Aligned Notification styles with design tokens and fixed close icon alignment. [#1520](https://github.com/oceanbase/oceanbase-design/pull/1520)
   - 🆕 Added `notification.loading` for in-progress feedback. [#1507](https://github.com/oceanbase/oceanbase-design/pull/1507)
   - 🆕 Added `errorDetails` with Markdown copy support. [#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
   - 🆕 Added `dedupeKey` to deduplicate notifications. [#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
@@ -454,6 +480,25 @@ group: General
 - 💄 Removed Empty and Result large size styles. [#1175](https://github.com/oceanbase/oceanbase-design/pull/1175)
 - 💄 Updated Table styles: removed zebra striping, added row dividers, adjusted cell spacing, etc. [#1176](https://github.com/oceanbase/oceanbase-design/pull/1176)
 - 💄 Adjusted Tabs font color and ink bar length. [#1177](https://github.com/oceanbase/oceanbase-design/pull/1177)
+
+## 0.4.22
+
+`2026-08-13`
+
+- Flex
+  - 🆕 Added Flex component, fully inheriting antd Flex capabilities and API with seamless switching. [#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+  - 💄 Low-version browser compatibility: falls back to a `margin` solution on browsers without flex `gap` support (e.g. Chrome 83). [#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+- 💄 Space spacing fallback also applies to custom `size` on browsers without flex `gap` support. [#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+- 🐞 Fixed Table default pagination total text rendering abnormally on low-version browsers (below Chrome 85) due to unsupported `replaceAll`. [#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+- 📖 Added low-version browser (Chrome 83) style compatibility demo and integration guidance in ConfigProvider. [#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+
+## 0.4.21
+
+`2026-06-14`
+
+- Spin
+  - 💄 Updated Spin loading animation (gray/color). [#1484](https://github.com/oceanbase/oceanbase-design/pull/1484)
+  - 🐞 Fixed Spin background being opaque in dark theme. [#1484](https://github.com/oceanbase/oceanbase-design/pull/1484)
 
 ## 0.4.20
 

--- a/docs/design/design-CHANGELOG.zh-CN.md
+++ b/docs/design/design-CHANGELOG.zh-CN.md
@@ -8,6 +8,31 @@ group: 基础组件
 
 ---
 
+## 1.2.0
+
+`2026-08-13`
+
+- Chrome 83 兼容
+  - 🆕 新增 Flex 组件，在不支持 `gap` 弹性布局的浏览器（如 Chrome 83）中自动降级为 `margin` 方案。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+  - 💄 Space 在不支持 `gap` 的浏览器中的间距降级方案，自定义 `size` 时同样生效。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+  - 🐞 修复 Table 默认分页的合计文案在低版本浏览器（Chrome 85 以下）中因不支持 `replaceAll` 语法而渲染异常的问题。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+  - 📖 ConfigProvider 新增低版本浏览器（Chrome 83）样式兼容示例和接入说明。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+- Table
+  - 🆕 新增 `outerBordered`，在 `innerBordered` 列边框之外展示外部边框。[#1533](https://github.com/oceanbase/oceanbase-design/pull/1533)
+  - 🆕 `column.tooltip` 语义与 `Form.Item.tooltip` 对齐（支持文本或配置对象）。[#1532](https://github.com/oceanbase/oceanbase-design/pull/1532)
+- Typography
+  - 🆕 `Text` 和 `Link` 新增 `block` 属性。[#1525](https://github.com/oceanbase/oceanbase-design/pull/1525)
+  - 🐞 修复编辑态内边距和外边距缺少单位的问题。[#1530](https://github.com/oceanbase/oceanbase-design/pull/1530)
+- Tag
+  - 🆕 新增轻量级 CSS 省略模式，避免内容溢出。[#1529](https://github.com/oceanbase/oceanbase-design/pull/1529)
+- Radio / Checkbox
+  - 🐞 恢复 Radio 和 Checkbox 包裹容器的基线对齐。[#1531](https://github.com/oceanbase/oceanbase-design/pull/1531)
+  - 🐞 多行标签时 Radio 和 Checkbox 顶对齐。[#1522](https://github.com/oceanbase/oceanbase-design/pull/1522)
+- Input.Password
+  - 🐞 用户交互前以纯文本输入渲染，抑制浏览器保存密码下拉框。[#1528](https://github.com/oceanbase/oceanbase-design/pull/1528)
+- Upload
+  - 🐞 修复 Upload 内 Button 图标颜色被覆盖的问题。[#1523](https://github.com/oceanbase/oceanbase-design/pull/1523)
+
 ## 1.1.0
 
 `2026-08-04`
@@ -40,6 +65,7 @@ group: 基础组件
   - 📌 Message 文档标注弃用，请迁移至 Notification。[#1507](https://github.com/oceanbase/oceanbase-design/pull/1507)
 - Notification
   - 💄 默认左下角展示，固定宽度 350px，线性图标与自动关闭进度条；标题/描述内链接使用类型色。[#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
+  - 💄 Notification 样式对齐设计 token，修复关闭图标对齐。[#1520](https://github.com/oceanbase/oceanbase-design/pull/1520)
   - 🆕 新增 `notification.loading` 用于进行中反馈。[#1507](https://github.com/oceanbase/oceanbase-design/pull/1507)
   - 🆕 新增 `errorDetails`，支持复制为 Markdown。[#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
   - 🆕 新增 `dedupeKey` 去除重复弹出。[#1506](https://github.com/oceanbase/oceanbase-design/pull/1506)
@@ -454,6 +480,25 @@ group: 基础组件
 - 💄 去掉 Empty 和 Result 的大尺寸样式。[#1175](https://github.com/oceanbase/oceanbase-design/pull/1175)
 - 💄 更新 Table 样式，包括去掉斑马纹、增加行分隔线、调整单元格间距等。[#1176](https://github.com/oceanbase/oceanbase-design/pull/1176)
 - 💄 调整 Tabs 的字体颜色和火柴棍长度。[#1177](https://github.com/oceanbase/oceanbase-design/pull/1177)
+
+## 0.4.22
+
+`2026-08-13`
+
+- Flex
+  - 🆕 新增 Flex 组件，完整继承 antd Flex 的能力和 API，可无缝切换。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+  - 💄 低版本浏览器兼容：在不支持 `gap` 弹性布局的浏览器（如 Chrome 83）中，自动降级为 `margin` 方案。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+- 💄 优化 Space 在不支持 `gap` 的浏览器中的间距降级方案，自定义 `size` 时同样生效。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+- 🐞 修复 Table 默认分页的合计文案在低版本浏览器（Chrome 85 以下）中因不支持 `replaceAll` 语法而渲染异常的问题。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+- 📖 ConfigProvider 新增低版本浏览器（Chrome 83）样式兼容示例和接入说明。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+
+## 0.4.21
+
+`2026-06-14`
+
+- Spin
+  - 💄 更新 Spin 的加载动画（灰色/彩色）。[#1484](https://github.com/oceanbase/oceanbase-design/pull/1484)
+  - 🐞 修复 Spin 在暗色主题下背景不透明的问题。[#1484](https://github.com/oceanbase/oceanbase-design/pull/1484)
 
 ## 0.4.20
 

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,18 @@ group: Biz Components
 
 ---
 
+## 1.2.0
+
+`2026-08-13`
+
+- Chrome 83 Compatibility
+  - 💄 Converted inline styles and logical properties to physical ones in PageLoading, DateRanger, ProTable, SideTip, FullscreenBox, and Highlight to fix style issues on low-version browsers. [#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+  - 💄 Converted remaining logical properties to physical ones in Action.Group and DateRanger. [#1538](https://github.com/oceanbase/oceanbase-design/pull/1538)
+- Login
+  - 🌐 Added Japanese (ja-JP) to the locale dropdown of Login and BasicLayout. [#1534](https://github.com/oceanbase/oceanbase-design/pull/1534)
+- DateRanger
+  - 🐞 Tightened play button vertical padding to 2px. [#1539](https://github.com/oceanbase/oceanbase-design/pull/1539)
+
 ## 1.1.0
 
 `2026-08-04`
@@ -167,6 +179,20 @@ group: Biz Components
 `2025-09-08`
 
 - 💄 Remove large-size styles from FooterToolbar and PageContainer. [#1175](https://github.com/oceanbase/oceanbase-design/pull/1175)
+
+## 0.4.26
+
+`2026-08-13`
+
+- 💄 Low-version browser (Chrome 83) compatibility: converted logical properties and inline styles to physical ones in PageLoading, DateRanger, ProTable, SideTip, FullscreenBox, and Highlight to fix style issues. [#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+- 🌐 Added Japanese (ja-JP) support to the locale dropdown of Login and BasicLayout. [#1534](https://github.com/oceanbase/oceanbase-design/pull/1534)
+
+## 0.4.25
+
+`2026-06-14`
+
+- 💄 Replaced default brand logo assets (`oceanbase_logo`, `oceanbase_logo_dark`, `oceanbase_watermark`) with the new blue-purple gradient brand identity. [#1486](https://github.com/oceanbase/oceanbase-design/pull/1486)
+- 💄 Updated the logo CDN link in the Highlight demo. [#1486](https://github.com/oceanbase/oceanbase-design/pull/1486)
 
 ## 0.4.24
 

--- a/docs/ui/ui-CHANGELOG.zh-CN.md
+++ b/docs/ui/ui-CHANGELOG.zh-CN.md
@@ -8,6 +8,18 @@ group: 业务组件
 
 ---
 
+## 1.2.0
+
+`2026-08-13`
+
+- Chrome 83 兼容
+  - 💄 将 PageLoading、DateRanger、ProTable、SideTip、FullscreenBox 和 Highlight 组件中的逻辑属性和内联样式转换为物理属性，修复低版本浏览器样式显示异常。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+  - 💄 将 Action.Group、DateRanger 中剩余的逻辑属性转换为物理属性。[#1538](https://github.com/oceanbase/oceanbase-design/pull/1538)
+- Login
+  - 🌐 Login 和 BasicLayout 的语种切换下拉框新增日语 (ja-JP) 支持。[#1534](https://github.com/oceanbase/oceanbase-design/pull/1534)
+- DateRanger
+  - 🐞 播放按钮垂直内边距收紧为 2px。[#1539](https://github.com/oceanbase/oceanbase-design/pull/1539)
+
 ## 1.1.0
 
 `2026-08-04`
@@ -167,6 +179,20 @@ group: 业务组件
 `2025-09-08`
 
 - 💄 去掉 FooterToolbar 和 PageContainer 的大尺寸样式。[#1175](https://github.com/oceanbase/oceanbase-design/pull/1175)
+
+## 0.4.26
+
+`2026-08-13`
+
+- 💄 兼容低版本浏览器（Chrome 83）：将 PageLoading、DateRanger、ProTable、SideTip、FullscreenBox 和 Highlight 组件中的逻辑属性和内联样式转换为物理属性，修复样式显示异常。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
+- 🌐 Login 和 BasicLayout 的语种切换下拉框新增日语 (ja-JP) 支持。[#1534](https://github.com/oceanbase/oceanbase-design/pull/1534)
+
+## 0.4.25
+
+`2026-06-14`
+
+- 💄 替换默认品牌 logo 资产（`oceanbase_logo`、`oceanbase_logo_dark`、`oceanbase_watermark`），采用新蓝紫渐变品牌标识。[#1486](https://github.com/oceanbase/oceanbase-design/pull/1486)
+- 💄 更新 Highlight demo 中的 logo CDN 链接。[#1486](https://github.com/oceanbase/oceanbase-design/pull/1486)
 
 ## 0.4.24
 


### PR DESCRIPTION
## @oceanbase/design@1.2.0

`2026-08-13`

- Chrome 83 兼容
  - 🆕 新增 Flex 组件，在不支持 `gap` 弹性布局的浏览器（如 Chrome 83）中自动降级为 `margin` 方案。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
  - 💄 Space 在不支持 `gap` 的浏览器中的间距降级方案，自定义 `size` 时同样生效。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
  - 🐞 修复 Table 默认分页的合计文案在低版本浏览器（Chrome 85 以下）中因不支持 `replaceAll` 语法而渲染异常的问题。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
  - 📖 ConfigProvider 新增低版本浏览器（Chrome 83）样式兼容示例和接入说明。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
- Table
  - 🆕 新增 `outerBordered`，在 `innerBordered` 列边框之外展示外部边框。[#1533](https://github.com/oceanbase/oceanbase-design/pull/1533)
  - 🆕 `column.tooltip` 语义与 `Form.Item.tooltip` 对齐（支持文本或配置对象）。[#1532](https://github.com/oceanbase/oceanbase-design/pull/1532)
- Typography
  - 🆕 `Text` 和 `Link` 新增 `block` 属性。[#1525](https://github.com/oceanbase/oceanbase-design/pull/1525)
  - 🐞 修复编辑态内边距和外边距缺少单位的问题。[#1530](https://github.com/oceanbase/oceanbase-design/pull/1530)
- Tag
  - 🆕 新增轻量级 CSS 省略模式，避免内容溢出。[#1529](https://github.com/oceanbase/oceanbase-design/pull/1529)
- Radio / Checkbox
  - 🐞 恢复 Radio 和 Checkbox 包裹容器的基线对齐。[#1531](https://github.com/oceanbase/oceanbase-design/pull/1531)
  - 🐞 多行标签时 Radio 和 Checkbox 顶对齐。[#1522](https://github.com/oceanbase/oceanbase-design/pull/1522)
- Input.Password
  - 🐞 用户交互前以纯文本输入渲染，抑制浏览器保存密码下拉框。[#1528](https://github.com/oceanbase/oceanbase-design/pull/1528)
- Upload
  - 🐞 修复 Upload 内 Button 图标颜色被覆盖的问题。[#1523](https://github.com/oceanbase/oceanbase-design/pull/1523)

---

## @oceanbase/ui@1.2.0

`2026-08-13`

- Chrome 83 兼容
  - 💄 将 PageLoading、DateRanger、ProTable、SideTip、FullscreenBox 和 Highlight 组件中的逻辑属性和内联样式转换为物理属性，修复低版本浏览器样式显示异常。[#1535](https://github.com/oceanbase/oceanbase-design/pull/1535)
  - 💄 将 Action.Group、DateRanger 中剩余的逻辑属性转换为物理属性。[#1538](https://github.com/oceanbase/oceanbase-design/pull/1538)
- Login
  - 🌐 Login 和 BasicLayout 的语种切换下拉框新增日语 (ja-JP) 支持。[#1534](https://github.com/oceanbase/oceanbase-design/pull/1534)
- DateRanger
  - 🐞 播放按钮垂直内边距收紧为 2px。[#1539](https://github.com/oceanbase/oceanbase-design/pull/1539)