### PR TITLE
fix(cli): report real package version in ob-design -V

### DIFF
--- a/packages/cli/src/cli.mjs
+++ b/packages/cli/src/cli.mjs
@@ -1,4 +1,8 @@
+import { createRequire } from 'node:module';
 import { Command } from 'commander';
+
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json');
 import { infoCommand } from './commands/info.mjs';
 import { docCommand } from './commands/doc.mjs';
 import { demoCommand } from './commands/demo.mjs';
@@ -21,7 +25,7 @@ function globalFlags(cmd) {
 
 export async function runCli(argv) {
   const program = new Command();
-  program.name('ob-design').description('OceanBase Design CLI').version('0.1.0-alpha.1');
+  program.name('ob-design').description('OceanBase Design CLI').version(version);
 
   globalFlags(program.command('info <name>').description('Merged OB component API')).action(
     async (name, opts) => infoCommand(name, opts),


### PR DESCRIPTION
### 📦 Modified package

- [ ] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [x] Other (`@oceanbase/design-cli`)

### 🤔 This is a ...

- [x] Bug fix
- [ ] New feature
- [ ] Site / documentation update
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

`ob-design -V` showed a hardcoded `0.1.0-alpha.1` even though the published package version is `1.2.0` (npm latest). The version string in `packages/cli/src/cli.mjs` was a stale hardcoded literal that never tracked the `package.json` version, so every release (1.0.0 → 1.1.0 → 1.2.0) shipped with the wrong `-V` output.

Fix: read the version from `packages/cli/package.json` via `createRequire` and pass it to commander's `.version()`, so `ob-design -V` always matches the installed package version.

Verified: `node packages/cli/bin/ob-design.mjs -V` → `1.2.0`.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - 🐞 `ob-design -V` now reports the real installed package version instead of a stale `0.1.0-alpha.1`. |
| 🇨🇳 Chinese | - 🐞 `ob-design -V` 现在显示实际安装的包版本，不再固定输出过期的 `0.1.0-alpha.1`。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed