### PR TITLE
feat(design): scroll to first error field on validateFields failure

### DIFF
--- a/packages/design/src/form/__tests__/scrollToFirstError.test.tsx
+++ b/packages/design/src/form/__tests__/scrollToFirstError.test.tsx
@@ -1,0 +1,220 @@
+import React, { useEffect } from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { ConfigProvider, Drawer, Form, Input, Modal } from '@oceanbase/design';
+import type { FormInstance } from '@oceanbase/design';
+import { describe, expect, it, vi } from 'vitest';
+
+const requiredRule = { required: true, message: 'Name is required' };
+
+const FormWithInstance: React.FC<
+  React.ComponentProps<typeof Form> & {
+    onMount?: (form: FormInstance) => void;
+  }
+> = ({ onMount, ...props }) => {
+  const [form] = Form.useForm();
+  onMount?.(form);
+  return (
+    <Form form={form} {...props}>
+      <Form.Item label="Name" name="name" rules={[requiredRule]}>
+        <Input id="name" />
+      </Form.Item>
+    </Form>
+  );
+};
+
+describe('Form scrollToFirstError on validateFields', () => {
+  it('should scroll to first error field when validateFields fails with scrollToFirstError', async () => {
+    let form!: FormInstance;
+    render(<FormWithInstance scrollToFirstError onMount={f => (form = f)} />);
+
+    const scrollSpy = vi.spyOn(form, 'scrollToField').mockImplementation(() => {});
+
+    await form.validateFields().catch(() => {});
+
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+    expect(scrollSpy).toHaveBeenCalledWith(['name'], undefined);
+  });
+
+  it('should pass options to scrollToField when scrollToFirstError is an object', async () => {
+    let form!: FormInstance;
+    render(<FormWithInstance scrollToFirstError={{ block: 'center' }} onMount={f => (form = f)} />);
+
+    const scrollSpy = vi.spyOn(form, 'scrollToField').mockImplementation(() => {});
+
+    await form.validateFields().catch(() => {});
+
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+    expect(scrollSpy).toHaveBeenCalledWith(['name'], { block: 'center' });
+  });
+
+  it('should scroll by default when scrollToFirstError is not configured', async () => {
+    let form!: FormInstance;
+    render(<FormWithInstance onMount={f => (form = f)} />);
+
+    const scrollSpy = vi.spyOn(form, 'scrollToField').mockImplementation(() => {});
+
+    await form.validateFields().catch(() => {});
+
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+    expect(scrollSpy).toHaveBeenCalledWith(['name'], undefined);
+  });
+
+  it('should not scroll when scrollToFirstError is false', async () => {
+    let form!: FormInstance;
+    render(<FormWithInstance scrollToFirstError={false} onMount={f => (form = f)} />);
+
+    const scrollSpy = vi.spyOn(form, 'scrollToField').mockImplementation(() => {});
+
+    await form.validateFields().catch(() => {});
+
+    expect(scrollSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not scroll when ConfigProvider disables scrollToFirstError', async () => {
+    let form!: FormInstance;
+    render(
+      <ConfigProvider form={{ scrollToFirstError: false }}>
+        <FormWithInstance onMount={f => (form = f)} />
+      </ConfigProvider>
+    );
+
+    const scrollSpy = vi.spyOn(form, 'scrollToField').mockImplementation(() => {});
+
+    await form.validateFields().catch(() => {});
+
+    expect(scrollSpy).not.toHaveBeenCalled();
+  });
+
+  it('should scroll exactly once on submit failure (antd path unchanged)', async () => {
+    let form!: FormInstance;
+    render(<FormWithInstance scrollToFirstError onMount={f => (form = f)} />);
+
+    const scrollSpy = vi.spyOn(form, 'scrollToField').mockImplementation(() => {});
+
+    form.submit();
+
+    await waitFor(() => {
+      expect(scrollSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(scrollSpy).toHaveBeenCalledWith(['name'], { block: 'nearest' });
+  });
+
+  it('should not scroll on internal revalidate after blur (onTouched)', async () => {
+    let form!: FormInstance;
+    const { container } = render(
+      <FormWithInstance validateMode="onTouched" scrollToFirstError onMount={f => (form = f)} />
+    );
+
+    const scrollSpy = vi.spyOn(form, 'scrollToField').mockImplementation(() => {});
+    const input = container.querySelector('#name') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(input.closest('.ant-form-item')?.classList.contains('ant-form-item-has-error')).toBe(
+        true
+      );
+    });
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    await waitFor(() => {
+      expect(input.closest('.ant-form-item')?.classList.contains('ant-form-item-has-error')).toBe(
+        true
+      );
+    });
+
+    expect(scrollSpy).not.toHaveBeenCalled();
+  });
+
+  it('should apply scrollToFirstError from ConfigProvider', async () => {
+    let form!: FormInstance;
+    render(
+      <ConfigProvider form={{ scrollToFirstError: true }}>
+        <FormWithInstance onMount={f => (form = f)} />
+      </ConfigProvider>
+    );
+
+    const scrollSpy = vi.spyOn(form, 'scrollToField').mockImplementation(() => {});
+
+    await form.validateFields().catch(() => {});
+
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+    expect(scrollSpy).toHaveBeenCalledWith(['name'], undefined);
+  });
+
+  it('should prefer form prop over ConfigProvider', async () => {
+    let form!: FormInstance;
+    render(
+      <ConfigProvider form={{ scrollToFirstError: true }}>
+        <FormWithInstance scrollToFirstError={false} onMount={f => (form = f)} />
+      </ConfigProvider>
+    );
+
+    const scrollSpy = vi.spyOn(form, 'scrollToField').mockImplementation(() => {});
+
+    await form.validateFields().catch(() => {});
+
+    expect(scrollSpy).not.toHaveBeenCalled();
+  });
+
+  it('should scroll to first error field when Modal onOk calls validateFields', async () => {
+    let form!: FormInstance;
+    const ModalForm: React.FC = () => {
+      const [open, setOpen] = React.useState(false);
+      useEffect(() => {
+        setOpen(true);
+      }, []);
+      return (
+        <Modal
+          open={open}
+          onOk={() => {
+            form.validateFields().catch(() => {});
+          }}
+        >
+          <FormWithInstance scrollToFirstError onMount={f => (form = f)} />
+        </Modal>
+      );
+    };
+    render(<ModalForm />);
+
+    // Modal portal renders into document.body, so query there
+    await waitFor(() => {
+      expect(document.body.querySelector('.ant-modal-wrap')).toBeTruthy();
+    });
+    const scrollSpy = vi.spyOn(form, 'scrollToField').mockImplementation(() => {});
+
+    fireEvent.click(document.body.querySelector('.ant-btn-primary') as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(scrollSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(scrollSpy).toHaveBeenCalledWith(['name'], undefined);
+  });
+
+  it('should scroll to first error field when Drawer contains patched Form', async () => {
+    let form!: FormInstance;
+    const DrawerForm: React.FC = () => {
+      const [open, setOpen] = React.useState(false);
+      useEffect(() => {
+        setOpen(true);
+      }, []);
+      return (
+        <Drawer open={open}>
+          <FormWithInstance scrollToFirstError onMount={f => (form = f)} />
+        </Drawer>
+      );
+    };
+    render(<DrawerForm />);
+
+    // Drawer portal renders into document.body, so query there
+    await waitFor(() => {
+      expect(document.body.querySelector('.ant-drawer-content')).toBeTruthy();
+    });
+    const scrollSpy = vi.spyOn(form, 'scrollToField').mockImplementation(() => {});
+
+    await form.validateFields().catch(() => {});
+
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+    expect(scrollSpy).toHaveBeenCalledWith(['name'], undefined);
+  });
+});

--- a/packages/design/src/form/index.en-US.md
+++ b/packages/design/src/form/index.en-US.md
@@ -12,12 +12,12 @@ nav:
 - 🆕 Form.Item `tooltip` adds `type` prop for different Tooltip types, see [Tooltip docs](/components/Tooltip).
 - 🆕 Form.Item adds `description` prop for description before form control.
 - 🆕 Form adds `validateMode` / `reValidateMode`, aligned with [react-hook-form](https://react-hook-form.com/docs/useform). Defaults: `validateMode="onSubmit"` + `reValidateMode="onChange"`. Configure globally via [ConfigProvider](/components/config-provider) `form.validateMode`.
+- 🆕 Form `scrollToFirstError` scrolls to the first error field on validation failure: antd only triggers it on `form.submit()` failure, while `@oceanbase/design` also triggers it when calling `form.validateFields()` directly (e.g. Modal `onOk`). Enabled by default; opt out via `scrollToFirstError={false}` or the global [ConfigProvider](/components/config-provider) `form.scrollToFirstError`.
 
 ## Code Examples
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx" title="Basic" description="Default optional style."></code>
-<code src="./demo/validate-mode.tsx" title="Validation modes" description="Aligned with react-hook-form `mode` / `reValidateMode`; no errors until submit by default."></code>
 <code src="./demo/requiredMark-same-with-antd.tsx" title="Required Style" description="Set via `requiredMark`."></code>
 <code src="./demo/form-item-description.tsx" title="Description" description="Set description before form control via Form.Item `description`."></code>
 <code src="./demo/form-item-extra.tsx" title="Extra Info" description="Set extra info after form control via Form.Item `extra`."></code>
@@ -28,6 +28,7 @@ nav:
 <code src="./demo/control-hooks.tsx" title="Form Methods"></code>
 <code src="./demo/hideRequiredMark.tsx" title="hideRequiredMark" debug></code>
 <code src="./demo/pro-form.tsx" title="ProForm" debug></code>
+<code src="./demo/validate-mode.tsx" title="Validation modes" description="Aligned with react-hook-form `mode` / `reValidateMode`; no errors until submit by default." debug></code>
 
 ## API
 
@@ -42,7 +43,7 @@ Explicit `validateTrigger` takes precedence. Use `validateMode="onChange"` to re
 
 ### ConfigProvider
 
-Use `form.validateMode` / `form.reValidateMode` on ConfigProvider for global defaults. Applies only to `Form` from `@oceanbase/design` (not ProForm or other components that use antd Form internally).
+Use `form.validateMode` / `form.reValidateMode` / `form.scrollToFirstError` on ConfigProvider for global defaults. Applies only to `Form` from `@oceanbase/design` (not ProForm or other components that use antd Form internally).
 
 ### Form.Item
 

--- a/packages/design/src/form/index.md
+++ b/packages/design/src/form/index.md
@@ -12,12 +12,12 @@ nav:
 - 🆕 Form.Item `tooltip` 新增 `type` 属性，支持不同类型的 Tooltip 提示，详见 [Tooltip 文档](/components/Tooltip)。
 - 🆕 Form.Item 新增 `description` 属性，用于设置表单控件前的描述信息。
 - 🆕 Form 新增 `validateMode` / `reValidateMode`，对齐 [react-hook-form](https://react-hook-form.com/docs/useform) 校验时机；默认 `validateMode="onSubmit"` + `reValidateMode="onChange"`（与 shadcn 官方示例一致）。可通过 [ConfigProvider](/components/config-provider) `form.validateMode` 全局配置。
+- 🆕 Form `scrollToFirstError` 校验失败时支持滚动到首个错误字段：antd 仅在 `form.submit()` 失败时触发，`@oceanbase/design` 对直接调用 `form.validateFields()` 失败同样生效（如 Modal `onOk` 场景），默认开启，可通过 `scrollToFirstError={false}` 或 [ConfigProvider](/components/config-provider) `form.scrollToFirstError` 全局关闭。
 
 ## 代码演示
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx" title="基本" description="默认为可选样式。"></code>
-<code src="./demo/validate-mode.tsx" title="校验模式" description="对齐 react-hook-form 的 `mode` / `reValidateMode`，默认 submit 前不展示错误。"></code>
 <code src="./demo/requiredMark-same-with-antd.tsx" title="设置为必选样式" description="通过 `requiredMark` 进行设置。"></code>
 <code src="./demo/form-item-description.tsx" title="描述信息" description="可通过 `Form.Item` 的 `description` 属性在表单控件前设置描述信息。"></code>
 <code src="./demo/form-item-extra.tsx" title="额外信息" description="可通过 `Form.Item` 的 `extra` 属性在表单控件后设置额外信息。"></code>
@@ -28,6 +28,7 @@ nav:
 <code src="./demo/control-hooks.tsx" title="表单方法调用"></code>
 <code src="./demo/hideRequiredMark.tsx" title="hideRequiredMark" debug></code>
 <code src="./demo/pro-form.tsx" title="ProForm" debug></code>
+<code src="./demo/validate-mode.tsx" title="校验模式" description="对齐 react-hook-form 的 `mode` / `reValidateMode`，默认 submit 前不展示错误。" debug></code>
 
 ## API
 
@@ -42,7 +43,7 @@ nav:
 
 ### ConfigProvider
 
-可通过 `ConfigProvider` 的 `form.validateMode` / `form.reValidateMode` 全局配置，仅对 `@oceanbase/design` 的 `Form` 生效（ProForm 等内部使用 antd Form 的组件不适用）。
+可通过 `ConfigProvider` 的 `form.validateMode` / `form.reValidateMode` / `form.scrollToFirstError` 全局配置，仅对 `@oceanbase/design` 的 `Form` 生效（ProForm 等内部使用 antd Form 的组件不适用）。
 
 ### Form.Item
 

--- a/packages/design/src/form/index.tsx
+++ b/packages/design/src/form/index.tsx
@@ -1,15 +1,15 @@
-import React, { useCallback, useContext, useRef } from 'react';
+import React, { useCallback, useContext, useLayoutEffect, useRef } from 'react';
 import { Form as AntForm } from 'antd';
 import type { FormProps as AntFormProps } from 'antd/es/form';
 import classNames from 'classnames';
 import ConfigProvider from '../config-provider';
 import Item from './FormItem';
 import { useFormItemChildFeedback } from './FormItemChildFeedback';
+import { patchScrollOnValidateError, setScrollToFirstErrorFlag } from './scrollToFirstError';
 import useStyle from './style';
 import type { FormReValidateMode, FormValidateMode, OBFormConfig } from './validateMode';
 import {
   markFormSubmitted,
-  needsValidateModeFormInstance,
   revalidateOnChange,
   resolveReValidateMode,
   resolveValidateMode,
@@ -53,6 +53,7 @@ const Form: CompoundedComponent = ({
   onFinish,
   onFinishFailed,
   form: propForm,
+  scrollToFirstError,
   ...restProps
 }) => {
   const { getPrefixCls, form: contextForm } = useContext(ConfigProvider.ConfigContext);
@@ -74,12 +75,11 @@ const Form: CompoundedComponent = ({
   const trackBlurredFields = validateMode === 'onTouched' && propValidateTrigger === undefined;
 
   const [fallbackForm] = AntForm.useForm();
-  const needsFormInstance = needsValidateModeFormInstance(
-    validateMode,
-    injectRevalidate,
-    propValidateTrigger
-  );
-  const mergedForm = needsFormInstance ? (propForm ?? fallbackForm) : propForm;
+  const mergedForm = propForm ?? fallbackForm;
+
+  // Scroll to the first error field by default; explicitly opt out via
+  // `scrollToFirstError={false}` or a global `form.scrollToFirstError: false`.
+  const mergedScrollToFirstError = scrollToFirstError ?? contextForm?.scrollToFirstError ?? true;
 
   const blurredFieldsRef = useRef(new Set<string>());
   const submittedRef = useRef(false);
@@ -145,6 +145,11 @@ const Form: CompoundedComponent = ({
   const [wrapCSSVar] = useStyle(prefixCls);
   const formCls = classNames(className);
 
+  useLayoutEffect(() => {
+    patchScrollOnValidateError(mergedForm);
+    setScrollToFirstErrorFlag(mergedForm, mergedScrollToFirstError);
+  }, [mergedForm, mergedScrollToFirstError]);
+
   return wrapCSSVar(
     // @ts-ignore to ignore children type error
     <AntForm
@@ -161,6 +166,7 @@ const Form: CompoundedComponent = ({
       prefixCls={customizePrefixCls}
       className={formCls}
       form={mergedForm}
+      scrollToFirstError={mergedScrollToFirstError}
       validateTrigger={resolvedValidateTrigger}
       onValuesChange={injectRevalidate ? handleValuesChange : onValuesChange}
       onFieldsChange={

--- a/packages/design/src/form/scrollToFirstError.ts
+++ b/packages/design/src/form/scrollToFirstError.ts
@@ -1,0 +1,71 @@
+import type { FormInstance } from 'antd/es/form';
+// `ScrollFocusOptions` is defined in `antd/es/form/interface`; the `antd/es/form`
+// entry does not re-export it (would be TS2614 under father's dts check).
+import type { ScrollFocusOptions } from 'antd/es/form/interface';
+
+const SCROLL_FLAG = Symbol('oceanbase.form.scrollToFirstError');
+const SCROLL_PATCHED = Symbol('oceanbase.form.scrollToFirstErrorPatched');
+const SKIP_NEXT_CALL = Symbol('oceanbase.form.skipScrollOnErrorNextCall');
+
+type ScrollToFirstErrorValue = ScrollFocusOptions | boolean | undefined;
+type FlaggedForm = FormInstance & Record<symbol, unknown>;
+
+export function setScrollToFirstErrorFlag(
+  instance: FormInstance,
+  value: ScrollToFirstErrorValue
+): void {
+  (instance as unknown as FlaggedForm)[SCROLL_FLAG] = value;
+}
+
+function getScrollToFirstErrorFlag(instance: FormInstance): ScrollToFirstErrorValue {
+  return (instance as unknown as FlaggedForm)[SCROLL_FLAG] as ScrollToFirstErrorValue;
+}
+
+/**
+ * Run `fn` with the scroll-on-error behavior suppressed for its `validateFields`
+ * call. The patched `validateFields` reads the marker synchronously, so it is
+ * captured per call; the marker is cleared when the returned promise settles.
+ */
+export function withSkipScrollOnError<T>(form: FormInstance, fn: () => Promise<T>): Promise<T> {
+  const flags = form as unknown as FlaggedForm;
+  flags[SKIP_NEXT_CALL] = true;
+  const result = fn();
+  return result.finally(() => {
+    flags[SKIP_NEXT_CALL] = false;
+  });
+}
+
+/**
+ * Patch `validateFields` so that a validation failure also scrolls to the first
+ * error field when `scrollToFirstError` is configured. antd only wires the
+ * property to the `submit()` failure branch; this covers direct `validateFields()`
+ * calls (e.g. Modal `onOk`). The store's internal `submit()` calls its own
+ * `validateFields` (not the patched instance method), so no double scroll.
+ */
+export function patchScrollOnValidateError(instance: FormInstance): void {
+  const flags = instance as unknown as FlaggedForm;
+  if (flags[SCROLL_PATCHED]) {
+    return;
+  }
+  flags[SCROLL_PATCHED] = true;
+
+  const originalValidateFields = instance.validateFields;
+  flags.validateFields = ((...args: Parameters<typeof originalValidateFields>) => {
+    const skipScroll = flags[SKIP_NEXT_CALL] === true;
+
+    const result = originalValidateFields.apply(instance, args);
+    return result.catch(
+      (errorInfo: { errorFields?: { name: Parameters<typeof instance.scrollToField>[0] }[] }) => {
+        if (!skipScroll && errorInfo?.errorFields?.length) {
+          const flag = getScrollToFirstErrorFlag(instance);
+          if (flag) {
+            const scrollOptions = flag === true ? undefined : flag;
+            instance.scrollToField?.(errorInfo.errorFields[0].name, scrollOptions);
+          }
+        }
+        // Keep the original rejection so callers observe unchanged semantics.
+        return Promise.reject(errorInfo);
+      }
+    );
+  }) as typeof originalValidateFields;
+}

--- a/packages/design/src/form/validateMode.ts
+++ b/packages/design/src/form/validateMode.ts
@@ -1,6 +1,7 @@
 import type { FormInstance } from 'antd/es/form';
 import type { NamePath } from 'antd/es/form/interface';
 import type { FormProps as AntFormProps } from 'antd/es/form';
+import { withSkipScrollOnError } from './scrollToFirstError';
 
 type FieldChangeMeta = {
   name?: NamePath;
@@ -304,15 +305,8 @@ export function revalidateOnChange(
   if (names.length > 0) {
     // Defer until rc-field-form commits changed values (aligns with RHF async field updates)
     queueMicrotask(() => {
-      form.validateFields(names).catch(() => {});
+      // Internal revalidation must not scroll to the first error on failure.
+      withSkipScrollOnError(form, () => form.validateFields(names)).catch(() => {});
     });
   }
-}
-
-export function needsValidateModeFormInstance(
-  validateMode: FormValidateMode,
-  injectRevalidate: boolean,
-  explicitTrigger?: AntFormProps['validateTrigger']
-): boolean {
-  return injectRevalidate || (validateMode === 'onTouched' && explicitTrigger === undefined);
 }


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

antd's `scrollToFirstError` only fires when `form.submit()` fails. A direct `form.validateFields()` call (e.g. inside Modal `onOk` / Drawer confirm) rejects with the error info but never scrolls, and antd has declined to support it (issues #30174 / #40190 / #36743). This change makes `@oceanbase/design` Form scroll to the first error field on direct `validateFields()` failures as well.

- `validateFields` on the form instance is patched once (idempotent); on rejection it calls `scrollToField(errorFields[0].name)` — with `ScrollFocusOptions` passed through when `scrollToFirstError` is an object — then re-throws to keep the original rejection semantics.
- The store's internal `submit()` path calls its own `validateFields`, not the patched instance method, so the antd native scroll on submit failure is unchanged (no double scroll).
- Enabled by default; opt out via `scrollToFirstError={false}` or the global `ConfigProvider form.scrollToFirstError: false`. Element-level props take precedence over the global config.
- Internal revalidates (validateMode / reValidateMode) are marked with a skip symbol so typing never triggers repeated scrolling.

```tsx
// Modal 场景：onOk 直接返回 validateFields，失败时自动滚动到首个错误字段
<Modal
  onOk={() => form.validateFields()}
>
  <Form form={form}>...</Form>
</Modal>

// 关闭默认行为
<Form scrollToFirstError={false}>...</Form>
```

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Form<br/>&nbsp;&nbsp;- 🆕 `scrollToFirstError` now also scrolls to the first error field when `validateFields()` fails directly (e.g. Modal `onOk`), enabled by default. |
| 🇨🇳 Chinese | - Form<br/>&nbsp;&nbsp;- 🆕 `scrollToFirstError` 对直接调用 `validateFields()` 校验失败同样生效（如 Modal `onOk` 场景），默认开启。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed