### PR TITLE
fix(design): polish Notification styles

### DIFF
--- a/packages/design/src/filter/demo/range.tsx
+++ b/packages/design/src/filter/demo/range.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Filter, Space } from '@oceanbase/design';
 import dayjs from 'dayjs';
 

--- a/packages/design/src/message/demo/basic.tsx
+++ b/packages/design/src/message/demo/basic.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Button, Space, message } from '@oceanbase/design';
 
 export default () => {

--- a/packages/design/src/notification/index.en-US.md
+++ b/packages/design/src/notification/index.en-US.md
@@ -21,10 +21,10 @@ Use notifications for non-blocking task results or system feedback that can reac
 <code src="./demo/placement.tsx" title="Placement" description="Defaults to `bottomLeft`."></code>
 <code src="./demo/auto-close.tsx" title="Auto close" description="5s for title only, 10s with description; errors do not auto close; pause on hover."></code>
 <code src="./demo/update.tsx" title="Update content" description="Use `key` to update the same notification, e.g. loading progress."></code>
-<code src="./demo/error-details.tsx" title="Error details" description="Structured diagnostics for warning / error with collapse and Markdown copy."></code>
 <code src="./demo/actions.tsx" title="Text link actions" description="Custom `<a>` or `Typography.Link` in `message` / `description`; styles match the notification type."></code>
-<code src="./demo/dedupe.tsx" title="Dedupe" description="`dedupeKey` skips duplicates per type; different from `key`, which replaces in place."></code>
+<code src="./demo/error-details.tsx" title="Error details" description="Structured diagnostics for warning / error with collapse and Markdown copy."></code>
 <code src="./demo/stack.tsx" title="Stack" description="Up to 3 stacked notifications."></code>
+<code src="./demo/dedupe.tsx" title="Dedupe" description="`dedupeKey` skips duplicates per type; different from `key`, which replaces in place."></code>
 <code src="./demo/hooks.tsx" title="Hooks" description="Use `notification.useNotification()` to access ConfigProvider context."></code>
 
 ## Notification types

--- a/packages/design/src/notification/index.md
+++ b/packages/design/src/notification/index.md
@@ -21,10 +21,10 @@ nav:
 <code src="./demo/placement.tsx" title="位置" description="默认 `bottomLeft`。"></code>
 <code src="./demo/auto-close.tsx" title="自动关闭" description="仅标题 5s、含描述 10s；error 默认不自动关闭；悬停暂停倒计时。"></code>
 <code src="./demo/update.tsx" title="更新消息内容" description="通过 `key` 更新同一条通知，适用于 loading 等进度场景。"></code>
-<code src="./demo/error-details.tsx" title="异常明细" description="warning / error 可附加结构化诊断信息，支持折叠展开与 Markdown 复制。"></code>
 <code src="./demo/actions.tsx" title="文字链操作" description="在 `message` / `description` 中插入 `<a>` 或 `Typography.Link`，样式自动按通知类型着色。"></code>
-<code src="./demo/dedupe.tsx" title="去重" description="`dedupeKey` 在同类型下去除重复弹出；与 `key`（替换）语义不同。"></code>
+<code src="./demo/error-details.tsx" title="异常明细" description="warning / error 可附加结构化诊断信息，支持折叠展开与 Markdown 复制。"></code>
 <code src="./demo/stack.tsx" title="堆叠" description="最多堆叠 3 条，悬停展开。"></code>
+<code src="./demo/dedupe.tsx" title="去重" description="`dedupeKey` 在同类型下去除重复弹出；与 `key`（替换）语义不同。"></code>
 <code src="./demo/hooks.tsx" title="Hooks" description="通过 `notification.useNotification()` 获取可消费 ConfigProvider 上下文的实例。"></code>
 
 ## 通知类型

--- a/packages/design/src/notification/style/index.ts
+++ b/packages/design/src/notification/style/index.ts
@@ -1,10 +1,17 @@
 import type { CSSObject } from '@ant-design/cssinjs';
 import { unit } from '@ant-design/cssinjs';
+import { mergeToken } from 'antd/es/theme/internal';
 import type { FullToken, GenerateStyle } from '../../theme/interface';
 import { genStyleHooks } from '../../_util/genComponentStyleHook';
 import { upperFirst } from 'lodash';
 
-export type NotificationToken = FullToken<'Notification'>;
+export type NotificationToken = FullToken<'Notification'> & {
+  /**
+   * @desc 提醒框堆叠层数
+   * @descEN Stack layer of Notification
+   */
+  notificationStackLayer: number;
+};
 
 /** Figma shadow-2 on Notification; differs from token.boxShadowSecondary until aligned globally. */
 const NOTIFICATION_SHADOW = '0 6px 8px rgba(19, 33, 57, 0.1)';
@@ -24,7 +31,6 @@ const genNotificationTypeStyle = (
     type === 'loading' ? token.colorPrimaryHover : token[`color${upperFirst(type)}TextHover`];
   const activeColor =
     type === 'loading' ? token.colorPrimaryActive : token[`color${upperFirst(type)}TextActive`];
-  const typeNoticeSelector = `${noticeCls}-wrapper ${noticeCls}-${type}`;
   const linkStyle = {
     color: textColor,
     textDecoration: 'underline',
@@ -37,8 +43,8 @@ const genNotificationTypeStyle = (
   };
 
   return {
-    [typeNoticeSelector]: {
-      [`${noticeCls}-message`]: {
+    [`${noticeCls}${noticeCls}-${type}`]: {
+      [`${noticeCls}-message, ${noticeCls}-error-details-action`]: {
         color: textColor,
         a: linkStyle,
         [`${token.antCls}-typography-link`]: linkStyle,
@@ -58,6 +64,18 @@ const genNotificationTypeStyle = (
       },
     },
   };
+};
+
+const genStackChildrenStyle = (token: NotificationToken): CSSObject => {
+  const childrenStyle: CSSObject = {};
+  for (let i = 1; i < token.notificationStackLayer; i++) {
+    childrenStyle[`&:nth-last-child(${i + 1})`] = {
+      [`& > ${token.componentCls}-notice`]: {
+        opacity: 1,
+      },
+    };
+  }
+  return childrenStyle;
 };
 
 export const genNotificationStyle: GenerateStyle<NotificationToken> = (
@@ -81,7 +99,6 @@ export const genNotificationStyle: GenerateStyle<NotificationToken> = (
   const titleLineHeight = calc(fontSizeHeading5).mul(lineHeightHeading5).equal();
   const titleCloseReserve = calc(padding).add(fontSizeLG).equal();
   const bottomRadius = unit(token.borderRadiusLG);
-  const progressBottomRadius = `0 0 ${bottomRadius} ${bottomRadius}`;
 
   const typeStyles = (
     ['success', 'info', 'warning', 'error', 'loading'] as const
@@ -94,150 +111,155 @@ export const genNotificationStyle: GenerateStyle<NotificationToken> = (
 
   return {
     [componentCls]: {
-      ...typeStyles,
       [`${noticeCls}-wrapper`]: {
         marginBottom: paddingXS,
         width,
         maxWidth: width,
         [`${noticeCls}`]: {
+          // Keep the card as the positioning containing block for the progress bar
+          // and clip its square corners against the card radius.
+          position: 'relative',
+          overflow: 'hidden',
+          borderRadius: bottomRadius,
           width,
           maxWidth: width,
           padding: `${unit(paddingSM)} ${unit(padding)}`,
           boxShadow: NOTIFICATION_SHADOW,
-        },
-        [`${noticeCls}-with-icon`]: {
-          display: 'grid',
-          gridTemplateColumns: `${unit(fontSizeLG)} minmax(0, 1fr)`,
-          columnGap: paddingXS,
-          rowGap: paddingXXS,
-          alignItems: 'start',
-        },
-        [`${noticeCls}-icon`]: {
-          position: 'static',
-          gridColumn: '1',
-          gridRow: '1',
-          alignSelf: 'start',
-          marginInlineEnd: 0,
-          marginTop: 0,
-          width: fontSizeLG,
-          fontSize: fontSizeLG,
-          lineHeight: 1,
-          height: titleLineHeight,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          [`${token.iconCls}`]: {
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
+          [`${noticeCls}-with-icon`]: {
+            display: 'grid',
+            gridTemplateColumns: `${unit(fontSizeLG)} minmax(0, 1fr)`,
+            columnGap: paddingXS,
+            rowGap: paddingXXS,
+            alignItems: 'start',
+          },
+          [`${noticeCls}-icon`]: {
+            position: 'static',
+            gridColumn: '1',
+            gridRow: '1',
+            alignSelf: 'start',
+            marginInlineEnd: 0,
+            marginTop: 0,
+            width: fontSizeLG,
             fontSize: fontSizeLG,
             lineHeight: 1,
-          },
-        },
-        [`${noticeCls}-message`]: {
-          gridColumn: '2',
-          gridRow: '1',
-          marginInlineStart: 0,
-          marginBottom: 0,
-          paddingInlineEnd: titleCloseReserve,
-          minHeight: titleLineHeight,
-          fontSize,
-          fontWeight: token.fontWeightStrong,
-          lineHeight: unit(titleLineHeight),
-          color: token.colorText,
-        },
-        [`${noticeCls}-description`]: {
-          gridColumn: '2',
-          gridRow: '2',
-          marginInlineStart: 0,
-          marginTop: 0,
-          fontSize,
-          lineHeight: unit(titleLineHeight),
-          color: token.colorText,
-        },
-        [`${noticeCls}-with-icon ${noticeCls}-message`]: {
-          marginInlineStart: 0,
-          fontSize,
-        },
-        [`${noticeCls}-with-icon ${noticeCls}-description`]: {
-          marginInlineStart: 0,
-        },
-        // Close aligns to title first line: top = paddingSM, height = titleLineHeight.
-        [`${noticeCls}-close`]: {
-          top: paddingSM,
-          insetInlineEnd: padding,
-          width: fontSizeLG,
-          height: titleLineHeight,
-          fontSize: fontSizeLG,
-          lineHeight: 1,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          '&:hover': {
-            backgroundColor: 'transparent',
-            color: token.colorIconHover,
-          },
-        },
-        [`${noticeCls}-progress`]: {
-          position: 'absolute',
-          blockSize: 2,
-          insetInlineStart: 0,
-          insetInlineEnd: 0,
-          inlineSize: '100%',
-          left: 0,
-          right: 0,
-          bottom: 0,
-          borderRadius: progressBottomRadius,
-          overflow: 'hidden',
-          clipPath: `inset(0 round 0 0 ${bottomRadius} ${bottomRadius})`,
-          '&, &::-webkit-progress-bar': {
-            backgroundColor: 'transparent',
-            borderRadius: progressBottomRadius,
-          },
-          '&::-moz-progress-bar': {
-            background: token.gray6,
-            borderBottomLeftRadius: token.borderRadiusLG,
-          },
-          '&::-webkit-progress-value': {
-            borderBottomLeftRadius: token.borderRadiusLG,
-            background: token.gray6,
-          },
-        },
-      },
-      [`${componentCls}-stack${componentCls}-stack-expanded`]: {
-        [`& > ${componentCls}-notice-wrapper`]: {
-          '&:not(:nth-last-child(-n + 1))': {
-            '&:after': {
-              height: paddingXS,
-              bottom: calc(paddingXS).mul(-1).equal(),
+            height: titleLineHeight,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            [`${token.iconCls}`]: {
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: fontSizeLG,
+              lineHeight: 1,
             },
           },
+          [`${noticeCls}-message`]: {
+            gridColumn: '2',
+            gridRow: '1',
+            marginInlineStart: 0,
+            marginBottom: 0,
+            paddingInlineEnd: titleCloseReserve,
+            minHeight: titleLineHeight,
+            fontSize,
+            fontWeight: token.fontWeightStrong,
+            lineHeight: unit(titleLineHeight),
+            color: token.colorText,
+          },
+          [`${noticeCls}-description`]: {
+            gridColumn: '2',
+            gridRow: '2',
+            marginInlineStart: 0,
+            marginTop: 0,
+            fontSize,
+            lineHeight: unit(titleLineHeight),
+            color: token.colorText,
+          },
+          [`${noticeCls}-with-icon ${noticeCls}-message`]: {
+            marginInlineStart: 0,
+            fontSize,
+          },
+          [`${noticeCls}-with-icon ${noticeCls}-description`]: {
+            marginInlineStart: 0,
+          },
+          // Close aligns to title first line: top = paddingSM, height = titleLineHeight.
+          [`${noticeCls}-close`]: {
+            top: paddingSM,
+            insetInlineEnd: padding,
+            width: fontSizeLG,
+            height: titleLineHeight,
+            fontSize: fontSizeLG,
+            lineHeight: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            '&:hover': {
+              backgroundColor: 'transparent',
+              color: token.colorIconHover,
+            },
+          },
+          [`${noticeCls}-progress`]: {
+            position: 'absolute',
+            blockSize: 2,
+            insetInlineStart: 0,
+            insetInlineEnd: 0,
+            inlineSize: '100%',
+            left: 0,
+            right: 0,
+            bottom: 0,
+            // The card's overflow: hidden + border-radius clips both square ends
+            // to hug the card radius; clip-path is unreliable on <progress>.
+            borderRadius: 0,
+            '&, &::-webkit-progress-bar': {
+              backgroundColor: 'transparent',
+            },
+            '&::-moz-progress-bar': {
+              background: token.gray6,
+              borderBottomLeftRadius: token.borderRadiusLG,
+            },
+            '&::-webkit-progress-value': {
+              borderBottomLeftRadius: token.borderRadiusLG,
+              background: token.gray6,
+            },
+          },
+          [`${noticeCls}-error-details`]: {
+            marginTop: token.marginXXS,
+            color: token.colorTextTertiary,
+            fontSize,
+            lineHeight: unit(titleLineHeight),
+          },
+          [`${noticeCls}-error-details-line`]: {
+            display: 'block',
+          },
+          [`${noticeCls}-error-details-collapsed`]: {
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+          },
+          [`${noticeCls}-error-details-actions`]: {
+            marginTop: token.marginXXS,
+            display: 'flex',
+            gap: token.marginSM,
+          },
+          [`${noticeCls}-error-details-action`]: {
+            cursor: 'pointer',
+          },
         },
+        ...typeStyles,
       },
-      [`${noticeCls}-error-details`]: {
-        marginTop: token.marginXXS,
-        color: token.colorTextTertiary,
-        fontSize,
-        lineHeight: unit(titleLineHeight),
+    },
+    [`${componentCls}-stack`]: {
+      [`& > ${componentCls}-notice-wrapper`]: {
+        ...genStackChildrenStyle(token),
       },
-      [`${noticeCls}-error-details-line`]: {
-        display: 'block',
-      },
-      [`${noticeCls}-error-details-collapsed`]: {
-        overflow: 'hidden',
-        whiteSpace: 'nowrap',
-        textOverflow: 'ellipsis',
-      },
-      [`${noticeCls}-error-details-actions`]: {
-        marginTop: token.marginXXS,
-        display: 'flex',
-        gap: token.marginSM,
-      },
-      [`${noticeCls}-error-details-action`]: {
-        color: token.colorPrimary,
-        cursor: 'pointer',
-        '&:hover': {
-          color: token.colorPrimaryHover,
+    },
+    [`${componentCls}-stack${componentCls}-stack-expanded`]: {
+      [`& > ${componentCls}-notice-wrapper`]: {
+        '&:not(:nth-last-child(-n + 1))': {
+          '&:after': {
+            height: paddingXS,
+            bottom: calc(paddingXS).mul(-1).equal(),
+          },
         },
       },
     },
@@ -245,5 +267,8 @@ export const genNotificationStyle: GenerateStyle<NotificationToken> = (
 };
 
 export default genStyleHooks('Notification', token => {
-  return [genNotificationStyle(token as NotificationToken)];
+  const notificationToken = mergeToken<NotificationToken>(token, {
+    notificationStackLayer: 3,
+  });
+  return [genNotificationStyle(notificationToken)];
 });

--- a/packages/ui/src/DateRanger/demo/updateCurrentTime.tsx
+++ b/packages/ui/src/DateRanger/demo/updateCurrentTime.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import { DateRanger } from '@oceanbase/ui';
 import { Divider, Flex, Button } from '@oceanbase/design';
 import dayjs from 'dayjs';

--- a/packages/ui/src/SideTip/demo/draggable.tsx
+++ b/packages/ui/src/SideTip/demo/draggable.tsx
@@ -1,6 +1,7 @@
 /**
  * iframe: true
  */
+import React from 'react';
 import { SideTip } from '@oceanbase/ui';
 import { CloudUploadOutlined } from '@oceanbase/icons';
 


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

**1. Progress bar no longer hugs the card radius**

The auto-close countdown progress bar used full-width positioning + `clip-path: inset() round` on the `<progress>` element, which is unreliable on WebKit — the two square ends stuck out past the card's rounded corners. The card now acts as the clipping containing block (`position: relative` + `overflow: hidden` + `borderRadius`), and the full-width progress bar is clipped structurally.

**2. Error-details actions follow the notification type color**

「展开 / 复制」(expand / copy) in error details used a fixed primary color. It now uses the same per-type color as the `message` / `description` text (`color${type}Text` for success/info/warning/error, `colorPrimary` for loading), including hover/active states.

**3. Notification title styles take effect again**

The notice card layout (grid, `fontSize`, `marginInlineStart`) is now applied again, so the Notification title (`message`) font size and left spacing work as expected.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Notification<br/>&nbsp;&nbsp;- 🐞 Fixed countdown progress bar clipping to hug the card rounded corners.<br/>&nbsp;&nbsp;- 🐞 Fixed Notification error-details actions (expand / copy) not following the notification type color.<br/>&nbsp;&nbsp;- 🐞 Fixed title font size and left spacing styles not taking effect. |
| 🇨🇳 Chinese | - Notification<br/>&nbsp;&nbsp;- 🐞 修复自动关闭进度条与卡片圆角贴合的问题。<br/>&nbsp;&nbsp;- 🐞 修复 Notification 异常明细的展开 / 复制操作色未跟随通知类型色的问题。<br/>&nbsp;&nbsp;- 🐞 修复标题字体大小、左侧间距等样式不生效的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed