### PR TITLE
fix(ui): apply custom rules to Password validation

### DIFF
--- a/packages/ui/src/Password/Content.tsx
+++ b/packages/ui/src/Password/Content.tsx
@@ -107,9 +107,24 @@ function resolveFieldError(
   if (!value) return locale.emptyMessage;
   if (hasForbiddenPasswordChars(value)) return locale.forbiddenCharsMessage;
 
-  const failedRules = validators.filter(rule => !rule.validate(value));
+  const failedRules = validators.filter(rule => !rule.optional && !rule.validate(value));
   if (failedRules.length >= 2) return locale.genericFailMessage;
   if (!validateCloudPasswordLength(value)) return locale.lengthRuleMessage;
+  if (failedRules.length === 1) return formatRuleFieldError(failedRules[0]);
+  return undefined;
+}
+
+/** Field error resolution driven purely by caller-provided (custom) rules. */
+function resolveCustomFieldError(
+  value: string | undefined,
+  locale: CloudPasswordLocale,
+  validators: Validator[],
+  touched: boolean
+): string | undefined {
+  if (!touched) return undefined;
+  if (!value) return locale.emptyMessage;
+  const failedRules = validators.filter(rule => !rule.optional && !rule.validate(value));
+  if (failedRules.length >= 2) return locale.genericFailMessage;
   if (failedRules.length === 1) return formatRuleFieldError(failedRules[0]);
   return undefined;
 }
@@ -125,6 +140,32 @@ function resolveRiskLevel(
   return 'high';
 }
 
+/** Shared core: map a value through a validator list into statuses and failure counts.
+ * Optional rules never block validation: they are excluded from the failure count and
+ * render as `wait` when unmet (Content also renders them neutrally). */
+function analyzeWithValidators(
+  value: string | undefined,
+  validators: Validator[],
+  touched: boolean
+): Pick<CloudPasswordAnalysis, 'failedRuleCount' | 'ruleStatuses' | 'fieldErrors'> {
+  const fieldFailures = validators
+    .filter(rule => !rule.optional)
+    .map(rule => (rule.validate(value) ? undefined : rule.message))
+    .filter((message): message is string => Boolean(message));
+
+  const ruleStatuses: PasswordRuleStatus[] = validators.map(rule => {
+    if (!touched || !value) return 'wait';
+    if (rule.validate(value)) return 'pass';
+    return rule.optional ? 'wait' : 'fail';
+  });
+
+  return {
+    failedRuleCount: fieldFailures.length,
+    ruleStatuses,
+    fieldErrors: fieldFailures,
+  };
+}
+
 export function analyzeCloudPassword(
   value: string | undefined,
   locale: CloudPasswordLocale,
@@ -132,16 +173,11 @@ export function analyzeCloudPassword(
 ): CloudPasswordAnalysis {
   const touched = options?.touched ?? true;
   const validators = getCloudPasswordValidators(locale);
-  const fieldFailures = validators
-    .map(rule => (rule.validate(value) ? undefined : rule.message))
-    .filter((message): message is string => Boolean(message));
-
-  const ruleStatuses: PasswordRuleStatus[] = validators.map(rule => {
-    if (!touched || !value) return 'wait';
-    return rule.validate(value) ? 'pass' : 'fail';
-  });
-
-  const failedRuleCount = fieldFailures.length;
+  const { failedRuleCount, ruleStatuses, fieldErrors } = analyzeWithValidators(
+    value,
+    validators,
+    touched
+  );
   const passed = Boolean(value) && failedRuleCount === 0 && !hasForbiddenPasswordChars(value);
 
   return {
@@ -150,7 +186,40 @@ export function analyzeCloudPassword(
     riskLevel: resolveRiskLevel(value, failedRuleCount, touched),
     fieldError: passed ? undefined : resolveFieldError(value, locale, validators, touched),
     ruleStatuses,
-    fieldErrors: fieldFailures,
+    fieldErrors,
+  };
+}
+
+/** Analyze a value against caller-provided (custom) rules only, bypassing the built-in cloud rules. */
+export function analyzeCustomPassword(
+  value: string | undefined,
+  validators: Validator[],
+  locale: CloudPasswordLocale,
+  options?: { touched?: boolean }
+): CloudPasswordAnalysis {
+  const touched = options?.touched ?? true;
+  const { failedRuleCount, ruleStatuses, fieldErrors } = analyzeWithValidators(
+    value,
+    validators,
+    touched
+  );
+  const passed = Boolean(value) && failedRuleCount === 0;
+  const riskLevel: PasswordRiskLevel =
+    !value || !touched
+      ? 'none'
+      : failedRuleCount === 0
+        ? 'success'
+        : failedRuleCount === 1
+          ? 'medium'
+          : 'high';
+
+  return {
+    passed,
+    failedRuleCount,
+    riskLevel,
+    fieldError: passed ? undefined : resolveCustomFieldError(value, locale, validators, touched),
+    ruleStatuses,
+    fieldErrors,
   };
 }
 

--- a/packages/ui/src/Password/__tests__/customRules.test.tsx
+++ b/packages/ui/src/Password/__tests__/customRules.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Form } from '@oceanbase/design';
+import Password from '../index';
+
+const CUSTOM_RULE_MESSAGE = 'At least 12 characters';
+// 8 位且包含大小写+数字，可通过内置云密码规则（8-20 位、三类字符），但不符合自定义规则（≥12 位）
+const customRules = [
+  {
+    validate: (val?: string) => Boolean(val && val.length >= 12),
+    message: CUSTOM_RULE_MESSAGE,
+  },
+];
+
+describe('Password custom rules', () => {
+  it('validates against custom rules instead of the built-in cloud rules', async () => {
+    const user = userEvent.setup();
+
+    const { container } = render(
+      <Form>
+        <Form.Item name="password" label="Password">
+          <Password rules={customRules} />
+        </Form.Item>
+      </Form>
+    );
+
+    const passwordInput = container.querySelector('.ant-input-password input') as HTMLInputElement;
+    expect(passwordInput).toBeTruthy();
+
+    await user.type(passwordInput, 'Abcdef12');
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText(CUSTOM_RULE_MESSAGE, { exact: false })).toBeTruthy();
+    });
+  });
+});

--- a/packages/ui/src/Password/__tests__/passwordRules.test.ts
+++ b/packages/ui/src/Password/__tests__/passwordRules.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 import enUS from '../locale/en-US';
 import {
   analyzeCloudPassword,
+  analyzeCustomPassword,
   CLOUD_PASSWORD_REGEX,
   hasForbiddenPasswordChars,
   validateCloudPasswordLength,
   validateCloudPasswordStrength,
+  type Validator,
 } from '../Content';
 
 const locale = {
@@ -84,5 +86,103 @@ describe('passwordRules', () => {
     expect(validateCloudPasswordLength('12345678')).toBe(true);
     expect(validateCloudPasswordLength('12345678901234567890')).toBe(true);
     expect(validateCloudPasswordLength('123456789012345678901')).toBe(false);
+  });
+});
+
+describe('custom rules', () => {
+  const customRules: Validator[] = [
+    {
+      validate: (val?: string) => Boolean(val && val.length >= 6),
+      message: 'At least 6 characters',
+    },
+    {
+      validate: (val?: string) => Boolean(val && /[A-Z]/.test(val)),
+      message: 'Contains uppercase letter',
+    },
+  ];
+
+  it('passes when all custom rules pass', () => {
+    const analysis = analyzeCustomPassword('Abcdef', customRules, locale, { touched: true });
+    expect(analysis.passed).toBe(true);
+    expect(analysis.riskLevel).toBe('success');
+    expect(analysis.ruleStatuses).toEqual(['pass', 'pass']);
+    expect(analysis.fieldError).toBeUndefined();
+  });
+
+  it('reports the failing custom rule message, not the built-in cloud rules', () => {
+    // 'abcdef' would pass several built-in cloud rules but fails the uppercase custom rule
+    const analysis = analyzeCustomPassword('abcdef', customRules, locale, { touched: true });
+    expect(analysis.passed).toBe(false);
+    expect(analysis.failedRuleCount).toBe(1);
+    expect(analysis.fieldError).toBe('Contains uppercase letter');
+    expect(analysis.riskLevel).toBe('medium');
+  });
+
+  it('returns the generic message when multiple custom rules fail', () => {
+    const analysis = analyzeCustomPassword('ab', customRules, locale, { touched: true });
+    expect(analysis.passed).toBe(false);
+    expect(analysis.failedRuleCount).toBeGreaterThanOrEqual(2);
+    expect(analysis.fieldError).toBe(locale.genericFailMessage);
+    expect(analysis.riskLevel).toBe('high');
+  });
+
+  it('keeps wait state before touch and returns empty message after touch', () => {
+    const untouched = analyzeCustomPassword('ab', customRules, locale, { touched: false });
+    expect(untouched.ruleStatuses.every(status => status === 'wait')).toBe(true);
+    expect(untouched.fieldError).toBeUndefined();
+
+    const empty = analyzeCustomPassword('', customRules, locale, { touched: true });
+    expect(empty.passed).toBe(false);
+    expect(empty.fieldError).toBe(locale.emptyMessage);
+  });
+
+  it('does not fail validation when only optional rules are unmet', () => {
+    const rulesWithOptional: Validator[] = [
+      {
+        validate: (val?: string) => Boolean(val && val.length >= 6),
+        message: 'At least 6 characters',
+      },
+      {
+        validate: (val?: string) => Boolean(val && /[A-Z]/.test(val)),
+        message: 'Contains uppercase letter',
+      },
+      {
+        validate: (val?: string) => Boolean(val && /[._+@#$%]/.test(val)),
+        message: 'Contains a special character',
+        optional: true,
+      },
+    ];
+
+    const analysis = analyzeCustomPassword('Abcdef', rulesWithOptional, locale, { touched: true });
+    expect(analysis.passed).toBe(true);
+    expect(analysis.failedRuleCount).toBe(0);
+    expect(analysis.riskLevel).toBe('success');
+    expect(analysis.fieldError).toBeUndefined();
+    // 未满足的可选规则展示为 wait，不阻塞校验
+    expect(analysis.ruleStatuses).toEqual(['pass', 'pass', 'wait']);
+  });
+
+  it('reports the required rule message even when an optional rule also fails', () => {
+    const rulesWithOptional: Validator[] = [
+      {
+        validate: (val?: string) => Boolean(val && val.length >= 6),
+        message: 'At least 6 characters',
+      },
+      {
+        validate: (val?: string) => Boolean(val && /[A-Z]/.test(val)),
+        message: 'Contains uppercase letter',
+      },
+      {
+        validate: (val?: string) => Boolean(val && /[._+@#$%]/.test(val)),
+        message: 'Contains a special character',
+        optional: true,
+      },
+    ];
+
+    // 仅长度规则（必填）未满足，可选规则也未满足，但不影响必填规则错误提示
+    const analysis = analyzeCustomPassword('Abc', rulesWithOptional, locale, { touched: true });
+    expect(analysis.passed).toBe(false);
+    expect(analysis.failedRuleCount).toBe(1);
+    expect(analysis.fieldError).toBe('At least 6 characters');
   });
 });

--- a/packages/ui/src/Password/index.en-US.md
+++ b/packages/ui/src/Password/index.en-US.md
@@ -27,7 +27,7 @@ nav:
 | Property | Description | Type | Default | Version |
 | :-- | :-- | :-- | :-- | :-- |
 | autoComplete | Browser autofill hint; `new-password` shows strength popover, `current-password` is a plain current-password field | string | `'new-password'` | - |
-| rules | Rules shown in the popover (UI only; Form handles validation timing) | [Validator](password#validator)[] | Cloud defaults | - |
+| rules | Custom password validation rules; when provided, the strength popover and blur validation follow these rules; defaults to the built-in cloud rules | [Validator](password#validator)[] | Cloud defaults | - |
 | generatePasswordRegex | Regex for random password; non-empty shows generate button | RegExp | - | - |
 | value | Password value | string | - | - |
 | onChange | Value change callback | (value?: string) => void | - | - |

--- a/packages/ui/src/Password/index.md
+++ b/packages/ui/src/Password/index.md
@@ -27,7 +27,7 @@ nav:
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | :-- | :-- | :-- | :-- | :-- |
 | autoComplete | 浏览器自动填充提示；`new-password` 展示强度气泡，`current-password` 为简单当前密码输入 | string | `'new-password'` | - |
-| rules | 气泡内展示的密码规则（仅 UI，校验时机由 Form 负责） | [Validator](password#validator)[] | 多云默认规则 | - |
+| rules | 自定义密码校验规则；传入后强度气泡与失焦校验均按自定义规则执行，未传入时使用内置多云规则 | [Validator](password#validator)[] | 多云默认规则 | - |
 | generatePasswordRegex | 随机生成密码的正则表达式，不为空则展示随机生成的按钮 | RegExp | - | - |
 | value | 密码框内容 | string | - | - |
 | onChange | 密码框内容变化的回调 | (value?: string) => void | - | - |

--- a/packages/ui/src/Password/index.tsx
+++ b/packages/ui/src/Password/index.tsx
@@ -7,6 +7,7 @@ import type { LocaleWrapperProps } from '../locale/LocaleWrapper';
 import LocaleWrapper from '../locale/LocaleWrapper';
 import Content, {
   analyzeCloudPassword,
+  analyzeCustomPassword,
   getCloudPasswordValidators,
   type CloudPasswordLocale,
   type PasswordRiskLevel,
@@ -93,9 +94,12 @@ const Password: React.FC<PasswordProps> = ({
           fieldErrors: [],
         };
       }
+      if (rules) {
+        return analyzeCustomPassword(newValue, rules, cloudLocale, { touched: interactive });
+      }
       return analyzeCloudPassword(newValue, cloudLocale, { touched: interactive });
     },
-    [cloudLocale, isCurrentPassword]
+    [cloudLocale, isCurrentPassword, rules]
   );
 
   const popoverInteractive = Boolean(displayValue) || isFocused;
@@ -248,3 +252,5 @@ export default LocaleWrapper({
   componentName: 'Password',
   defaultLocale: zhCN,
 })(Password);
+
+export type { Validator } from './Content';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -66,7 +66,7 @@ export { default as LightFilter } from './LightFilter';
 export type { LightFilterProps } from './LightFilter';
 
 export { default as Password } from './Password';
-export type { PasswordProps } from './Password';
+export type { PasswordProps, Validator } from './Password';
 
 export { default as Ranger } from './Ranger';
 export type { RangerProps } from './Ranger';


### PR DESCRIPTION
### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

**Bug:** `Password`'s `rules` prop only fed the strength popover checklist display. The actual validation analysis (rule pass/fail statuses, strength progress, risk level, and blur error message) always ran through the built-in cloud password rules (8–20 chars, allowed charset, 3-of-4 character types) via `analyzeCloudPassword`, which ignored caller-provided `rules`. So custom rules never took effect and users always saw built-in rule validation.

**Fix:**
- Added `analyzeCustomPassword` in `Content.tsx`, which validates a value against caller-provided rules only, and used it in `Password` when `rules` is passed. Blur feedback and popover statuses now follow the custom rules.
- `optional` rules no longer block validation: they are excluded from the failure count and render as a neutral `wait` state when unmet (aligns with the documented `optional` API).
- Exported the `Validator` type from the package entry so TS consumers can type their custom rules.
- Updated `index.md` / `index.en-US.md` to reflect that `rules` drive validation feedback.

**Tests:** Added unit tests for `analyzeCustomPassword` (pass / single-fail message / multi-fail generic message / optional semantics) and a component regression test asserting a value that passes built-in cloud rules but fails a custom rule shows the custom error on blur.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Password<br/>&nbsp;&nbsp;- 🐞 Custom `rules` now drive validation: the strength popover and blur feedback follow custom rules, and `optional` rules no longer block validation. |
| 🇨🇳 Chinese | - Password<br/>&nbsp;&nbsp;- 🐞 自定义 `rules` 现在会驱动校验：强度气泡与失焦提示按自定义规则执行，`optional` 规则不再阻塞校验。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed