### PR TITLE
fix(design): avoid ConfigProvider SizeContext deprecation warning

### DIFF
--- a/packages/design/src/config-provider/index.tsx
+++ b/packages/design/src/config-provider/index.tsx
@@ -20,6 +20,7 @@ import type { StyleContextProps } from '@ant-design/cssinjs/es/StyleContext';
 import { CaretRightOutlined } from '@oceanbase/icons';
 import aliyunTheme from '@oceanbase/aliyun-theme';
 import { merge } from 'lodash';
+import SizeContext from 'antd/es/config-provider/SizeContext';
 import App from '../app';
 import StaticFunction from '../static-function';
 import themeConfig from '../theme';
@@ -110,7 +111,7 @@ export type ConfigProviderType = React.FC<ConfigProviderProps> & {
   ExtendedConfigContext: typeof ExtendedConfigContext;
 } & {
   ConfigContext: React.Context<ConfigConsumerProps>;
-  SizeContext: typeof AntConfigProvider.SizeContext;
+  SizeContext: typeof SizeContext;
   config: typeof AntConfigProvider.config;
   useConfig: typeof AntConfigProvider.useConfig;
 };
@@ -312,7 +313,9 @@ const ConfigProvider: ConfigProviderType = ({
 
 ConfigProvider.ConfigContext = AntConfigProvider.ConfigContext;
 ConfigProvider.ExtendedConfigContext = ExtendedConfigContext;
-ConfigProvider.SizeContext = AntConfigProvider.SizeContext;
+// Read SizeContext from the module directly instead of `AntConfigProvider.SizeContext`,
+// which triggers antd's deprecated getter (`ConfigProvider.SizeContext`) and logs a warning.
+ConfigProvider.SizeContext = SizeContext;
 ConfigProvider.config = AntConfigProvider.config;
 ConfigProvider.useConfig = AntConfigProvider.useConfig;
 


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

The `@oceanbase/design` `ConfigProvider` previously assigned `ConfigProvider.SizeContext = AntConfigProvider.SizeContext`. antd defines `ConfigProvider.SizeContext` as a deprecated getter (with a `Object.defineProperty` accessor), so reading `AntConfigProvider.SizeContext` at module-eval time triggers the warning `ConfigProvider.SizeContext is deprecated. Please use \`ConfigProvider.useConfig().componentSize\` instead.` in every dev console.

Fix: import `SizeContext` directly from `antd/es/config-provider/SizeContext` (the same context object the getter returns) and assign that. `ConfigProvider.SizeContext` remains public with an identical type (`React.Context<SizeType>`), so the public API is unchanged — it just no longer trips the deprecated getter and no longer logs the warning.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | No user-facing changes. |
| 🇨🇳 Chinese | 无用户可感知变更。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed