### PR TITLE
feat(design): cap Notification height with internal scrolling

### DIFF
--- a/packages/design/src/notification/demo/max-height.tsx
+++ b/packages/design/src/notification/demo/max-height.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Button, Space, notification } from '@oceanbase/design';
+
+const longParagraph =
+  'This is a very long description used to verify the max height behavior. ' +
+  'When the content grows beyond the limit, the content area should scroll internally ' +
+  'while the close button and the auto-close progress bar stay fixed at the card edge. ';
+
+const longDescription = (
+  <>
+    {[0, 1, 2, 3, 4, 5, 6, 7, 8].map(i => (
+      <p key={i} style={{ margin: 0 }}>
+        {longParagraph}
+      </p>
+    ))}
+  </>
+);
+
+const manyErrorDetails = Array.from({ length: 12 }, (_, i) => ({
+  label: `Detail item ${i + 1}`,
+  value: `value-${i + 1}-with-a-very-long-value-to-fill-up-the-available-height`,
+}));
+
+export default () => {
+  return (
+    <Space wrap>
+      <Button
+        onClick={() => {
+          notification.info({
+            message: 'Long description',
+            description: longDescription,
+          });
+        }}
+      >
+        Long description
+      </Button>
+      <Button
+        onClick={() => {
+          notification.error({
+            message: 'Long error details',
+            description: 'Expand the details below to verify internal scrolling.',
+            errorDetails: manyErrorDetails,
+          });
+        }}
+      >
+        Long error details
+      </Button>
+    </Space>
+  );
+};

--- a/packages/design/src/notification/index.en-US.md
+++ b/packages/design/src/notification/index.en-US.md
@@ -26,6 +26,7 @@ Use notifications for non-blocking task results or system feedback that can reac
 <code src="./demo/stack.tsx" title="Stack" description="Up to 3 stacked notifications."></code>
 <code src="./demo/dedupe.tsx" title="Dedupe" description="`dedupeKey` skips duplicates per type; different from `key`, which replaces in place."></code>
 <code src="./demo/hooks.tsx" title="Hooks" description="Use `notification.useNotification()` to access ConfigProvider context."></code>
+<code src="./demo/max-height.tsx" title="Content max height" description="Content scrolls inside when exceeding 320px; close button and progress stay fixed." debug></code>
 
 ## Notification types
 
@@ -78,6 +79,7 @@ Use notifications for non-blocking task results or system feedback that can reac
 | showProgress                | enabled when auto closing          |
 | pauseOnHover                | `true`                             |
 | closable                    | `true` (close button always shown) |
+| content max height          | `320px`, scrolls inside beyond     |
 
 Pass `duration` explicitly to override the auto-close strategy above.
 

--- a/packages/design/src/notification/index.md
+++ b/packages/design/src/notification/index.md
@@ -26,6 +26,7 @@ nav:
 <code src="./demo/stack.tsx" title="堆叠" description="最多堆叠 3 条，悬停展开。"></code>
 <code src="./demo/dedupe.tsx" title="去重" description="`dedupeKey` 在同类型下去除重复弹出；与 `key`（替换）语义不同。"></code>
 <code src="./demo/hooks.tsx" title="Hooks" description="通过 `notification.useNotification()` 获取可消费 ConfigProvider 上下文的实例。"></code>
+<code src="./demo/max-height.tsx" title="内容最大高度" description="内容超过 320px 时内容区内部滚动，关闭按钮与进度条保持固定。" debug></code>
 
 ## 通知类型
 
@@ -66,18 +67,19 @@ nav:
 
 ### 默认行为
 
-| 行为               | 默认值                     |
-| ------------------ | -------------------------- |
-| placement          | `bottomLeft`               |
-| bottom             | `24`                       |
-| width              | `350px`                    |
-| stack              | 最多 3 条，展开间距 8px    |
-| duration（仅标题） | `5`                        |
-| duration（含描述） | `10`                       |
-| duration（error）  | `0`（不自动关闭）          |
-| showProgress       | 自动关闭时启用             |
-| pauseOnHover       | `true`                     |
-| closable           | `true`（始终显示关闭按钮） |
+| 行为               | 默认值                        |
+| ------------------ | ----------------------------- |
+| placement          | `bottomLeft`                  |
+| bottom             | `24`                          |
+| width              | `350px`                       |
+| stack              | 最多 3 条，展开间距 8px       |
+| duration（仅标题） | `5`                           |
+| duration（含描述） | `10`                          |
+| duration（error）  | `0`（不自动关闭）             |
+| showProgress       | 自动关闭时启用                |
+| pauseOnHover       | `true`                        |
+| closable           | `true`（始终显示关闭按钮）    |
+| 内容最大高度       | `320px`，超出后内容区内部滚动 |
 
 传入 `duration` 可覆盖以上自动关闭策略。
 

--- a/packages/design/src/notification/style/index.ts
+++ b/packages/design/src/notification/style/index.ts
@@ -11,10 +11,18 @@ export type NotificationToken = FullToken<'Notification'> & {
    * @descEN Stack layer of Notification
    */
   notificationStackLayer: number;
+  /**
+   * @desc 提醒框内容区域最大高度，超出后内部滚动
+   * @descEN Max height of the Notification content area, scrolls inside when exceeded
+   */
+  maxHeight: number | string;
 };
 
 /** Figma shadow-2 on Notification; differs from token.boxShadowSecondary until aligned globally. */
 const NOTIFICATION_SHADOW = '0 6px 8px rgba(19, 33, 57, 0.1)';
+
+/** Default max height of the Notification content area before internal scrolling kicks in. */
+const NOTIFICATION_MAX_HEIGHT = 320;
 
 type NotificationVisualType = 'success' | 'info' | 'warning' | 'error' | 'loading';
 
@@ -85,6 +93,7 @@ export const genNotificationStyle: GenerateStyle<NotificationToken> = (
     componentCls,
     calc,
     width = 350,
+    maxHeight = NOTIFICATION_MAX_HEIGHT,
     paddingSM,
     padding,
     paddingXS,
@@ -125,6 +134,13 @@ export const genNotificationStyle: GenerateStyle<NotificationToken> = (
           maxWidth: width,
           padding: `${unit(paddingSM)} ${unit(padding)}`,
           boxShadow: NOTIFICATION_SHADOW,
+          [`${noticeCls}-content`]: {
+            // Cap the content height and scroll inside when it overflows,
+            // so the card never grows without bound (close / progress stay fixed).
+            maxHeight,
+            overflowY: 'auto',
+            overflowX: 'hidden',
+          },
           [`${noticeCls}-with-icon`]: {
             display: 'grid',
             gridTemplateColumns: `${unit(fontSizeLG)} minmax(0, 1fr)`,

--- a/packages/design/src/theme/default.ts
+++ b/packages/design/src/theme/default.ts
@@ -358,6 +358,9 @@ const seedTheme: ThemeConfig = {
     Notification: {
       borderRadiusLG: borderRadiusLG,
       width: 350,
+      // 内容区域最大高度，超出后内部滚动
+      // Max height of the content area; scrolls inside when exceeded
+      maxHeight: 320,
       colorSuccessBg: white,
       colorErrorBg: white,
       colorInfoBg: white,

--- a/packages/design/src/theme/interface.ts
+++ b/packages/design/src/theme/interface.ts
@@ -173,3 +173,13 @@ declare module 'antd/es/table/style' {
     localeEnEmbeddedControls?: boolean;
   }
 }
+
+declare module 'antd/es/notification/style' {
+  export interface ComponentToken {
+    /**
+     * 提醒框内容区域的最大高度，超出后内部滚动。
+     * @descEN Max height of the Notification content area; scrolls inside when exceeded.
+     */
+    maxHeight?: number | string;
+  }
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [x] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Notification cards grow without bound when a long title or description is passed. This PR caps the card at a configurable max height (default `320px`); when content exceeds the limit, the content area scrolls internally while the close button and the auto-close progress bar stay fixed at the card edge.

Solution:

- New `Notification` theme token `maxHeight` (default `320`), extended via `ComponentToken` augmentation in `theme/interface.ts` and registered in `theme/default.ts`.
- Style: cap `.ant-notification-notice-content` with `maxHeight + overflow-y: auto; overflow-x: hidden`; the notice card keeps `position: relative; overflow: hidden` so the progress bar stays fixed and corners keep their radius.
- Demo `max-height.tsx` verifies long description and long error details.
- Docs (zh + en) describe the new default.

| Before | After |
| :--- | :--- |
| Card grows with long content | Content scrolls inside; close / progress fixed |

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Notification<br/>&nbsp;&nbsp;- 🆕 Added a max height for the content area (default 320px); overflowing content scrolls inside while the close button and progress bar stay fixed. |
| 🇨🇳 Chinese | - Notification<br/>&nbsp;&nbsp;- 🆕 内容区域新增最大高度（默认 320px），超出后内容区内部滚动，关闭按钮与进度条保持固定。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed