### PR TITLE
fix(design): out-rank antd notification styles with doubled root selector

### DIFF
--- a/packages/design/src/notification/style/index.ts
+++ b/packages/design/src/notification/style/index.ts
@@ -119,7 +119,9 @@ export const genNotificationStyle: GenerateStyle<NotificationToken> = (
   }, {});
 
   return {
-    [componentCls]: {
+    // Root selector is doubled (`${componentCls}${componentCls}`) to out-rank antd's
+    // own notification styles, which otherwise override ours.
+    [`${componentCls}${componentCls}`]: {
       [`${noticeCls}-wrapper`]: {
         marginBottom: paddingXS,
         width,


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

**Background**: antd and OceanBase Design emit structurally identical Notification selectors with identical specificity (0-3-0), e.g. `.ant-notification .ant-notification-notice-wrapper .ant-notification-notice`. antd registers its Notification styles lazily — only when a notification opens on the client — so its `<style>` tag lands after OB's eagerly-registered styles. With equal specificity the later tag wins, and antd's styles override OB's. On Next.js sites this is amplified by `@ant-design/nextjs-registry`, which extracts OB's eagerly-registered styles into a single static SSR `<style>` tag that is never re-injected on the client.

**Solution**: Double the root selector (`${componentCls}${componentCls}`) so every OB Notification rule resolves to ≥ 0-4-0 and wins regardless of registration order. The doubling is expressed via `componentCls` rather than a hardcoded `.ant-notification`, so it stays correct when OB styles ship under a custom class prefix (where the conflict disappears and the doubling is inert).

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Notification<br/>&nbsp;&nbsp;- 🐞 Fixed Notification visuals being overridden by antd's own styles when antd registers them after OB (e.g. in Next.js/SSR apps). |
| 🇨🇳 Chinese | - Notification<br/>&nbsp;&nbsp;- 🐞 修复 Notification 样式在部分场景（如 Next.js/SSR）下被 antd 自身样式覆盖的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed