### PR TITLE
chore(docs): Add changelog for @oceanbase/design@1.4.0 and @oceanbase/ui@1.4.0

### DIFF
--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,16 @@ group: General
 
 ---
 
+## 1.4.0
+
+`2026-08-25`
+
+- ConfigProvider
+  - 🐞 Avoided the antd deprecation warning emitted when accessing `ConfigProvider.SizeContext`. [#1550](https://github.com/oceanbase/oceanbase-design/pull/1550)
+- Notification
+  - 🆕 Added `maxHeight` token (default `320px`); when content exceeds the limit it scrolls inside the content area while the close button and auto-close progress bar stay fixed at the card edge. [#1551](https://github.com/oceanbase/oceanbase-design/pull/1551)
+  - 🐞 Fixed Notification styles (e.g. width, spacing) being overridden by antd's default styles. [#1552](https://github.com/oceanbase/oceanbase-design/pull/1552)
+
 ## 1.3.0
 
 `2026-08-18`

--- a/docs/design/design-CHANGELOG.zh-CN.md
+++ b/docs/design/design-CHANGELOG.zh-CN.md
@@ -8,6 +8,16 @@ group: 基础组件
 
 ---
 
+## 1.4.0
+
+`2026-08-25`
+
+- ConfigProvider
+  - 🐞 避免访问 `ConfigProvider.SizeContext` 时触发 antd 弃用警告。[#1550](https://github.com/oceanbase/oceanbase-design/pull/1550)
+- Notification
+  - 🆕 新增 `maxHeight` token（默认 `320px`）；内容超出上限后内容区内部滚动，关闭按钮与自动关闭进度条保持固定在卡片边缘。[#1551](https://github.com/oceanbase/oceanbase-design/pull/1551)
+  - 🐞 修复 Notification 样式（如宽度、间距）被 antd 默认样式覆盖不生效的问题。[#1552](https://github.com/oceanbase/oceanbase-design/pull/1552)
+
 ## 1.3.0
 
 `2026-08-18`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,14 @@ group: Biz Components
 
 ---
 
+## 1.4.0
+
+`2026-08-25`
+
+- Password
+  - 🆕 Custom `rules` now drive the strength popover and on-blur validation (previously display-only); built-in multi-cloud rules apply when omitted. [#1549](https://github.com/oceanbase/oceanbase-design/pull/1549)
+  - 🆕 Exported the `Validator` type for typed custom rules. [#1549](https://github.com/oceanbase/oceanbase-design/pull/1549)
+
 ## 1.2.0
 
 `2026-08-13`

--- a/docs/ui/ui-CHANGELOG.zh-CN.md
+++ b/docs/ui/ui-CHANGELOG.zh-CN.md
@@ -8,6 +8,14 @@ group: 业务组件
 
 ---
 
+## 1.4.0
+
+`2026-08-25`
+
+- Password
+  - 🆕 自定义 `rules` 现在真正参与校验：强度气泡与失焦校验均按自定义规则执行（此前仅展示）；未传入时使用内置多云规则。[#1549](https://github.com/oceanbase/oceanbase-design/pull/1549)
+  - 🆕 导出 `Validator` 类型，便于编写类型安全的自定义规则。[#1549](https://github.com/oceanbase/oceanbase-design/pull/1549)
+
 ## 1.2.0
 
 `2026-08-13`


### PR DESCRIPTION
## @oceanbase/design@1.4.0

`2026-08-25`

- ConfigProvider
  - 🐞 Avoided the antd deprecation warning emitted when accessing `ConfigProvider.SizeContext`. [#1550](https://github.com/oceanbase/oceanbase-design/pull/1550)
- Notification
  - 🆕 Added `maxHeight` token (default `320px`); when content exceeds the limit it scrolls inside the content area while the close button and auto-close progress bar stay fixed at the card edge. [#1551](https://github.com/oceanbase/oceanbase-design/pull/1551)
  - 🐞 Fixed Notification styles (e.g. width, spacing) being overridden by antd's default styles. [#1552](https://github.com/oceanbase/oceanbase-design/pull/1552)

## @oceanbase/ui@1.4.0

`2026-08-25`

- Password
  - 🆕 Custom `rules` now drive the strength popover and on-blur validation (previously display-only); built-in multi-cloud rules apply when omitted. [#1549](https://github.com/oceanbase/oceanbase-design/pull/1549)
  - 🆕 Exported the `Validator` type for typed custom rules. [#1549](https://github.com/oceanbase/oceanbase-design/pull/1549)