### PR TITLE
fix(design): remove Drawer header divider negative margin

### DIFF
--- a/packages/design/src/drawer/style/index.ts
+++ b/packages/design/src/drawer/style/index.ts
@@ -66,9 +66,6 @@ export const genDrawerStyle: GenerateStyle<DrawerToken> = (token: DrawerToken): 
             right: 0,
             height: '1px',
             backgroundColor: colorSplit,
-            // 使用负margin让分割线贯通到content边缘
-            marginLeft: calc(token.paddingLG).mul(-1).equal(),
-            marginRight: calc(token.paddingLG).mul(-1).equal(),
           },
         },
         [`${componentCls}-header-shadow`]: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

The Drawer header bottom divider is drawn with an `::after` pseudo-element positioned `left: 0; right: 0` at the bottom of the header. The header itself has horizontal padding (`paddingLG`), so the divider already spans the full header edge — the negative left/right margins (inherited from an older design-token refactor) pushed it outside the content box unnecessarily.

Remove the negative `marginLeft` / `marginRight` so the divider spans exactly the header content width and aligns with the body content edges.

| Before | After |
| :--- | :--- |
| Divider overflows header content edges (negative margin) | Divider aligns with header content edges |

### 📝 Changelog

<!--
User-perceivable only (one short sentence per language). Omit file paths, CI, and internal tooling.
See .cursor/skills/github-pr-submit/SKILL.md (Changelog). Pure internal work: "No user-facing changes" / "无用户可感知变更".
List breaking changes or risks if any.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Drawer<br/>&nbsp;&nbsp;- 🐞 Fixed the header bottom divider overrunning the header content edges. |
| 🇨🇳 Chinese | - Drawer<br/>&nbsp;&nbsp;- 🐞 修复标题栏底部分割线超出标题栏内容边缘的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed