### PR TITLE
fix(design): fix selection column overlap with fixed columns under outerBordered

### DIFF
--- a/packages/design/src/card/style/index.ts
+++ b/packages/design/src/card/style/index.ts
@@ -13,12 +13,37 @@ export const genTableStyle = (padding: number, token: Partial<CardToken>): CSSOb
   const { antCls } = token;
   const tableComponentCls = `${antCls}-table`;
   const cellInline = token.Table?.cellPaddingInline ?? token.padding ?? token.paddingSM ?? 16;
-
+  // Pad the first column (selection / expand cells) to align with the Card content area.
+  // Avoid token.calc: this helper is reused by ProCard / ProTable whose useStyle does not inject calc.
+  // Build a CSS calc() string via unit() so it works in both modes:
+  // - non cssVar: token is a number, unit() adds px -> calc(24px + 14px + 8px)
+  // - cssVar: token is a var(--ob-*) string, unit() passes it through -> calc(var(...) + var(...) + var(...))
+  // token is Partial; alias tokens always exist at runtime, ?? 0 is only for the type.
+  const unitVal = (value?: number | string) => unit(value ?? 0);
   return {
     [`${tableComponentCls}-wrapper`]: {
       [`${tableComponentCls}`]: {
-        [`${tableComponentCls}-thead > tr > th:first-child`]: { paddingLeft: padding },
-        [`${tableComponentCls}-tbody > tr > td:first-child`]: { paddingLeft: padding },
+        // Widen the selection column to fit the 24px first-column padding + checkbox + 8px right padding.
+        // antd locks it to controlHeight (28px) by default, which makes the checkbox overflow
+        // into the adjacent column.
+        [`${tableComponentCls}-selection-col`]: {
+          width: `calc(${unitVal(padding)} + ${unitVal(token.controlInteractiveSize)} + ${unitVal(token.paddingXS)})`,
+          [`&${tableComponentCls}-selection-col-with-dropdown`]: {
+            width: `calc(${unitVal(padding)} + ${unitVal(token.controlInteractiveSize)} + ${unitVal(token.paddingXS)} + ${unitVal(token.fontSizeIcon)} + (${unitVal(token.padding)} / 4))`,
+          },
+        },
+        [`${tableComponentCls}-thead > tr > th:first-child`]: {
+          paddingLeft: padding,
+        },
+        [`${tableComponentCls}-tbody > tr > td:first-child`]: {
+          paddingLeft: padding,
+        },
+        // Pad the measure-row first cell too: if only real cells are padded while the
+        // measure row keeps its default padding, fixed-column ColGroup locks the column
+        // to the measured width and squeezes the checkbox / expand icon into the neighbor.
+        [`${tableComponentCls}-tbody > tr${tableComponentCls}-measure-row > th:first-child`]: {
+          paddingLeft: padding,
+        },
         [`${tableComponentCls}-tbody > tr > td:first-child[data-ob-user-col]:not([data-ob-user-col="0"])`]:
           {
             paddingLeft: cellInline,

--- a/packages/design/src/table/__tests__/index.test.tsx
+++ b/packages/design/src/table/__tests__/index.test.tsx
@@ -140,4 +140,48 @@ describe('Table', () => {
     expect(container.querySelector('.ant-table-outer-bordered .ant-table-bordered')).toBeTruthy();
     expect(asFragment().firstChild).toMatchSnapshot();
   });
+
+  it('outerBordered with fixed columns and rowSelection should align selection column and not overlap', () => {
+    const fixedColumns = [
+      { title: 'Name', dataIndex: 'name', fixed: 'left' as const, width: 120 },
+      { title: 'Age', dataIndex: 'age' },
+      { title: 'Address', dataIndex: 'address' },
+    ];
+    const { container } = render(
+      <Table
+        columns={fixedColumns}
+        dataSource={dataSource}
+        outerBordered
+        rowSelection={{}}
+        scroll={{ x: 800 }}
+      />
+    );
+    const selCell = container.querySelector(
+      '.ant-table-tbody .ant-table-selection-column'
+    ) as HTMLElement;
+    const selTh = container.querySelector(
+      '.ant-table-thead .ant-table-selection-column'
+    ) as HTMLElement;
+    // Selection column width must fit 24px first-column padding + checkbox + 8px right padding = 46px.
+    // Before the fix, antd locked it to controlHeight (28px), so the checkbox overflowed the column.
+    // In non-cssVar mode unit() appends px and yields calc(24px + 14px + 8px); jsdom does not evaluate calc().
+    const selCol = container.querySelector('.ant-table-selection-col') as HTMLElement;
+    expect(getComputedStyle(selCol).width).toBe('calc(24px + 14px + 8px)');
+    // Selection column as first column aligns with the Card content area (24px), not flush to the edge.
+    expect(getComputedStyle(selCell).paddingLeft).toBe('24px');
+    expect(getComputedStyle(selTh).paddingLeft).toBe('24px');
+    // Measure-row first cell is padded to match the real cell, so the fixed-column ColGroup
+    // does not lock the column to the narrower measured width and squeeze the checkbox out.
+    const measureCell = container.querySelector(
+      '.ant-table-tbody .ant-table-measure-row > th:first-child'
+    ) as HTMLElement;
+    expect(getComputedStyle(measureCell).paddingLeft).toBe('24px');
+    // First logical column after the selection column keeps the design-default 8px indent.
+    const nameCell = container.querySelectorAll(
+      '.ant-table-tbody .ant-table-cell'
+    )[1] as HTMLElement;
+    const nameTh = container.querySelectorAll('.ant-table-thead .ant-table-cell')[1] as HTMLElement;
+    expect(getComputedStyle(nameCell).paddingLeft).toBe('8px');
+    expect(getComputedStyle(nameTh).paddingLeft).toBe('8px');
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

**Problem**

When `outerBordered` is enabled together with `rowSelection` and fixed columns, the selection column overlaps the first content column.

**Root cause**

Card `no-body-horizontal-padding` (`genTableStyle`) gives the literal first cell `padding-left: 24px` to compensate for the zero body horizontal padding. That rule also matched the selection column cell, widening it beyond the width used to compute the fixed first content column's sticky offset (`MeasureRow`), so the fixed column overlaps the selection checkbox.

**Fix**

- Exclude `.ant-table-selection-column` / `.ant-table-row-expand-icon-cell` from the `:first-child` 24px rule, keeping them at the default cell padding.
- Apply the 24px alignment to the logical first content column via `+ th` / `+ td` successor selectors.
- Added a regression test asserting the selection column keeps default padding while the first content column receives the 24px compensation.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Table<br/>&nbsp;&nbsp;- 🐞 Fixed the selection column overlapping the first content column when `outerBordered` is combined with fixed columns and row selection. |
| 🇨🇳 Chinese | - Table<br/>&nbsp;&nbsp;- 🐞 修复 `outerBordered` 与固定列、选择列同时使用时，选择列与内容首列重叠的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed