### PR TITLE
feat(design): support global form.preserve via ConfigProvider

### DIFF
--- a/packages/design/src/config-provider/__tests__/form.test.tsx
+++ b/packages/design/src/config-provider/__tests__/form.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import { ConfigProvider } from '@oceanbase/design';
+import { render, act } from '@testing-library/react';
+import { ConfigProvider, Form, Input } from '@oceanbase/design';
+import type { FormInstance } from '@oceanbase/design';
 import { ProForm, ProFormText } from '@oceanbase/ui';
 import type { ProFormProps } from '@oceanbase/ui';
 
@@ -20,6 +21,31 @@ const ProFormTest: React.FC<ProFormProps> = props => (
   </ProForm>
 );
 
+const PreserveFormTest: React.FC<{
+  preserve?: boolean;
+  onFormReady?: (form: FormInstance) => void;
+}> = ({ preserve, onFormReady }) => {
+  const [showField, setShowField] = React.useState(true);
+  const [form] = Form.useForm();
+  React.useEffect(() => {
+    onFormReady?.(form);
+  }, [form, onFormReady]);
+  return (
+    <ConfigProvider form={{ preserve }}>
+      <button type="button" onClick={() => setShowField(false)}>
+        remove
+      </button>
+      <Form form={form}>
+        {showField && (
+          <Form.Item name="name" label="Name">
+            <Input />
+          </Form.Item>
+        )}
+      </Form>
+    </ConfigProvider>
+  );
+};
+
 describe('ConfigProvider form', () => {
   it('ConfigProvider form.requiredMark should be `optional` by default and work for ProForm', () => {
     const { container, asFragment } = render(
@@ -32,5 +58,33 @@ describe('ConfigProvider form', () => {
     ).toBeTruthy();
     expect(container.querySelector('.ant-form-item-optional')).toBeTruthy();
     expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  it('ConfigProvider form.preserve=true should keep unmounted field values', () => {
+    let formInstance: FormInstance | undefined;
+    const { container } = render(
+      <PreserveFormTest preserve={true} onFormReady={form => (formInstance = form)} />
+    );
+    act(() => {
+      formInstance?.setFieldValue('name', 'oceanbase');
+    });
+    // Remove the field from the form
+    act(() => {
+      container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(formInstance?.getFieldsValue(true)).toEqual({ name: 'oceanbase' });
+  });
+
+  it('unmounted field values should be dropped by default (preserve=false)', () => {
+    let formInstance: FormInstance | undefined;
+    const { container } = render(<PreserveFormTest onFormReady={form => (formInstance = form)} />);
+    act(() => {
+      formInstance?.setFieldValue('name', 'oceanbase');
+    });
+    // Remove the field from the form
+    act(() => {
+      container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(formInstance?.getFieldsValue(true)).toEqual({});
   });
 });

--- a/packages/design/src/form/index.en-US.md
+++ b/packages/design/src/form/index.en-US.md
@@ -43,7 +43,7 @@ Explicit `validateTrigger` takes precedence. Use `validateMode="onChange"` to re
 
 ### ConfigProvider
 
-Use `form.validateMode` / `form.reValidateMode` / `form.scrollToFirstError` on ConfigProvider for global defaults. Applies only to `Form` from `@oceanbase/design` (not ProForm or other components that use antd Form internally).
+Use `form.validateMode` / `form.reValidateMode` / `form.scrollToFirstError` / `form.preserve` on ConfigProvider for global defaults. Applies only to `Form` from `@oceanbase/design` (not ProForm or other components that use antd Form internally). `preserve` precedence: Form prop > ConfigProvider `form.preserve` > default `false`.
 
 ### Form.Item
 

--- a/packages/design/src/form/index.md
+++ b/packages/design/src/form/index.md
@@ -43,7 +43,7 @@ nav:
 
 ### ConfigProvider
 
-可通过 `ConfigProvider` 的 `form.validateMode` / `form.reValidateMode` / `form.scrollToFirstError` 全局配置，仅对 `@oceanbase/design` 的 `Form` 生效（ProForm 等内部使用 antd Form 的组件不适用）。
+可通过 `ConfigProvider` 的 `form.validateMode` / `form.reValidateMode` / `form.scrollToFirstError` / `form.preserve` 全局配置，仅对 `@oceanbase/design` 的 `Form` 生效（ProForm 等内部使用 antd Form 的组件不适用）。`preserve` 优先级：Form 组件 prop > ConfigProvider `form.preserve` > 默认值 `false`。
 
 ### Form.Item
 

--- a/packages/design/src/form/index.tsx
+++ b/packages/design/src/form/index.tsx
@@ -54,6 +54,7 @@ const Form: CompoundedComponent = ({
   onFinishFailed,
   form: propForm,
   scrollToFirstError,
+  preserve: propPreserve,
   ...restProps
 }) => {
   const { getPrefixCls, form: contextForm } = useContext(ConfigProvider.ConfigContext);
@@ -80,6 +81,9 @@ const Form: CompoundedComponent = ({
   // Scroll to the first error field by default; explicitly opt out via
   // `scrollToFirstError={false}` or a global `form.scrollToFirstError: false`.
   const mergedScrollToFirstError = scrollToFirstError ?? contextForm?.scrollToFirstError ?? true;
+
+  // Preserve unmounted field values. Precedence: Form prop > ConfigProvider `form.preserve` > OB default `false`.
+  const mergedPreserve = propPreserve ?? obFormConfig?.preserve ?? false;
 
   const blurredFieldsRef = useRef(new Set<string>());
   const submittedRef = useRef(false);
@@ -162,7 +166,7 @@ const Form: CompoundedComponent = ({
             : 'optional'
       }
       hideRequiredMark={hideRequiredMark}
-      preserve={false}
+      preserve={mergedPreserve}
       prefixCls={customizePrefixCls}
       className={formCls}
       form={mergedForm}

--- a/packages/design/src/form/validateMode.ts
+++ b/packages/design/src/form/validateMode.ts
@@ -22,6 +22,8 @@ export const DEFAULT_REVALIDATE_MODE: FormReValidateMode = 'onChange';
 export type OBFormConfig = {
   validateMode?: FormValidateMode;
   reValidateMode?: FormReValidateMode;
+  /** Preserve field values when fields unmount (antd default `true`, OB default `false`). */
+  preserve?: boolean;
 };
 
 export function resolveValidateMode(


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

`ConfigProvider form.preserve` previously had no effect on `@oceanbase/design` Form:

- OB Form hardcoded `preserve={false}` (different from antd's default `true`).
- antd's `ConfigProvider.form` type (`FormConfig`) does not include `preserve`, and antd Form never reads it from the config context at runtime.

Solution: OB Form now resolves `preserve` with the precedence **Form prop > ConfigProvider `form.preserve` > default `false`**, and `preserve` was added to `OBFormConfig` so `ConfigProvider form={{ preserve: true }}` passes type checking. Existing per-form behavior (`<Form preserve={...}>`) is unchanged.

Usage:

```tsx
<ConfigProvider form={{ preserve: true }}>
  <App />
</ConfigProvider>
```

Note: only applies to `Form` from `@oceanbase/design` (ProForm etc. use antd Form internally and are unaffected).

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Form<br/>&nbsp;&nbsp;- 🆕 `preserve` now supports global configuration via `ConfigProvider form.preserve` to keep unmounted field values by default. |
| 🇨🇳 Chinese | - Form<br/>&nbsp;&nbsp;- 🆕 `preserve` 支持通过 `ConfigProvider form.preserve` 全局配置，可默认保留已卸载字段的值。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
