### PR TITLE
fix(design): forward Form ref to antd form instance

### DIFF
--- a/packages/design/src/form/__tests__/index.test.tsx
+++ b/packages/design/src/form/__tests__/index.test.tsx
@@ -71,4 +71,18 @@ describe('Form', () => {
     );
     expect(asFragment().firstChild).toMatchSnapshot();
   });
+
+  it('ref should forward to the underlying antd form', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Form>>();
+    const { container } = render(
+      <Form ref={ref}>
+        <Form.Item label="Name" name="name">
+          <Input />
+        </Form.Item>
+      </Form>
+    );
+    expect(ref.current).toBeTruthy();
+    expect(typeof ref.current?.validateFields).toBe('function');
+    expect(ref.current?.nativeElement).toBe(container.querySelector('form'));
+  });
 });

--- a/packages/design/src/form/index.tsx
+++ b/packages/design/src/form/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useLayoutEffect, useRef } from 'react';
+import React, { forwardRef, useCallback, useContext, useLayoutEffect, useRef } from 'react';
 import { Form as AntForm } from 'antd';
 import type { FormProps as AntFormProps } from 'antd/es/form';
 import classNames from 'classnames';
@@ -29,7 +29,12 @@ export type FormProps = AntFormProps & {
   reValidateMode?: FormReValidateMode;
 };
 
-type CompoundedComponent = React.FC<FormProps> & {
+/** Ref exposed by the underlying antd Form: the form instance plus the native `<form>` element. */
+type FormRef = React.ComponentRef<typeof AntForm>;
+
+type CompoundedComponent = React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<FormProps> & React.RefAttributes<FormRef>
+> & {
   Item: typeof Item;
   List: typeof AntForm.List;
   ErrorList: typeof AntForm.ErrorList;
@@ -41,21 +46,22 @@ type CompoundedComponent = React.FC<FormProps> & {
   create: typeof AntForm.create;
 };
 
-const Form: CompoundedComponent = ({
-  hideRequiredMark,
-  prefixCls: customizePrefixCls,
-  className,
-  validateMode: propValidateMode,
-  reValidateMode: propReValidateMode,
-  validateTrigger: propValidateTrigger,
-  onValuesChange,
-  onFieldsChange,
-  onFinish,
-  onFinishFailed,
-  form: propForm,
-  scrollToFirstError,
-  ...restProps
-}) => {
+const InternalForm = forwardRef<FormRef, FormProps>((props, ref) => {
+  const {
+    hideRequiredMark,
+    prefixCls: customizePrefixCls,
+    className,
+    validateMode: propValidateMode,
+    reValidateMode: propReValidateMode,
+    validateTrigger: propValidateTrigger,
+    onValuesChange,
+    onFieldsChange,
+    onFinish,
+    onFinishFailed,
+    form: propForm,
+    scrollToFirstError,
+    ...restProps
+  } = props;
   const { getPrefixCls, form: contextForm } = useContext(ConfigProvider.ConfigContext);
   const obFormConfig = contextForm as OBFormConfig | undefined;
 
@@ -153,6 +159,7 @@ const Form: CompoundedComponent = ({
   return wrapCSSVar(
     // @ts-ignore to ignore children type error
     <AntForm
+      ref={ref}
       requiredMark={
         // could remove hideRequiredMark logic after https://github.com/ant-design/ant-design/pull/46299 is published
         hideRequiredMark
@@ -177,7 +184,13 @@ const Form: CompoundedComponent = ({
       {...restProps}
     />
   );
-};
+});
+
+const Form: CompoundedComponent = InternalForm as typeof Form;
+
+if (process.env.NODE_ENV !== 'production') {
+  Form.displayName = 'Form';
+}
 
 Form.Item = Item;
 Form.List = AntForm.List;


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

`Form` wraps antd's `Form` but was a plain function component without `forwardRef`. In React 18 any `ref` passed to it was dropped (with a "Function components cannot be given refs" warning), which breaks the antd-compatible API contract that antd's own Form and every other OB wrapper component honor — antd's Form exposes the form instance plus `nativeElement` via `forwardRef` + `useImperativeHandle`.

Fixed by wrapping `Form` in `forwardRef` and forwarding the `ref` straight to the underlying antd Form, so `<OBForm ref={ref}>` now returns the same value as `<AntForm ref={ref}>` (form instance + `nativeElement`). The ref type is derived from the antd component (`React.ComponentRef<typeof AntForm>`) so it stays in sync with antd upgrades.

Added a regression test asserting the ref is populated, exposes `validateFields`, and its `nativeElement` is the rendered `<form>` element.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - 🐞 Fixed Form not forwarding `ref` to the underlying form instance. `Form` ref now returns the same value as antd's Form (form instance with `nativeElement`). |
| 🇨🇳 Chinese | - 🐞 修复 Form 未将 `ref` 转发到底层表单实例的问题。现在 `Form` 的 ref 返回与 antd Form 一致的值（含 `nativeElement` 的表单实例）。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
