### PR TITLE
chore(docs): Add changelog for @oceanbase/design@1.4.2

### DIFF
--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,12 +8,15 @@ group: General
 
 ---
 
-## Unreleased
+## 1.4.2
+
+`2026-08-31`
 
 - ConfigProvider
   - 🆕 Added global `form.preserve` config to control whether unmounted field values are kept; the `Form` `preserve` prop takes precedence, and values are still dropped by default. [#1557](https://github.com/oceanbase/oceanbase-design/pull/1557)
 - Form
   - 🐞 Forwarded `ref` to the underlying antd form instance, exposing the form instance and the native `<form>` element. [#1558](https://github.com/oceanbase/oceanbase-design/pull/1558)
+  - 🐞 Kept antd's generic `Values` typing on `Form` and `Form.Item`, restoring type inference for typed forms. [#1560](https://github.com/oceanbase/oceanbase-design/pull/1560)
 
 ## 1.4.1
 

--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,13 @@ group: General
 
 ---
 
+## Unreleased
+
+- ConfigProvider
+  - 🆕 Added global `form.preserve` config to control whether unmounted field values are kept; the `Form` `preserve` prop takes precedence, and values are still dropped by default. [#1557](https://github.com/oceanbase/oceanbase-design/pull/1557)
+- Form
+  - 🐞 Forwarded `ref` to the underlying antd form instance, exposing the form instance and the native `<form>` element. [#1558](https://github.com/oceanbase/oceanbase-design/pull/1558)
+
 ## 1.4.1
 
 `2026-08-28`

--- a/docs/design/design-CHANGELOG.zh-CN.md
+++ b/docs/design/design-CHANGELOG.zh-CN.md
@@ -8,12 +8,15 @@ group: 基础组件
 
 ---
 
-## Unreleased
+## 1.4.2
+
+`2026-08-31`
 
 - ConfigProvider
   - 🆕 新增全局 `form.preserve` 配置，控制字段卸载后是否保留字段值；`Form` 的 `preserve` 属性优先级更高，默认仍不保留字段值。[#1557](https://github.com/oceanbase/oceanbase-design/pull/1557)
 - Form
   - 🐞 修复 `ref` 未透传到底层 antd 表单实例的问题，现在可通过 `ref` 获取表单实例与原生 `<form>` 元素。[#1558](https://github.com/oceanbase/oceanbase-design/pull/1558)
+  - 🐞 保留 antd 的泛型 `Values` 类型签名，`Form` 和 `Form.Item` 恢复对表单字段的类型推断。[#1560](https://github.com/oceanbase/oceanbase-design/pull/1560)
 
 ## 1.4.1
 

--- a/docs/design/design-CHANGELOG.zh-CN.md
+++ b/docs/design/design-CHANGELOG.zh-CN.md
@@ -8,6 +8,13 @@ group: 基础组件
 
 ---
 
+## Unreleased
+
+- ConfigProvider
+  - 🆕 新增全局 `form.preserve` 配置，控制字段卸载后是否保留字段值；`Form` 的 `preserve` 属性优先级更高，默认仍不保留字段值。[#1557](https://github.com/oceanbase/oceanbase-design/pull/1557)
+- Form
+  - 🐞 修复 `ref` 未透传到底层 antd 表单实例的问题，现在可通过 `ref` 获取表单实例与原生 `<form>` 元素。[#1558](https://github.com/oceanbase/oceanbase-design/pull/1558)
+
 ## 1.4.1
 
 `2026-08-28`


### PR DESCRIPTION
## @oceanbase/design@1.4.2

`2026-08-31`

- ConfigProvider
  - 🆕 Added global `form.preserve` config to control whether unmounted field values are kept; the `Form` `preserve` prop takes precedence, and values are still dropped by default. [#1557](https://github.com/oceanbase/oceanbase-design/pull/1557)
- Form
  - 🐞 Forwarded `ref` to the underlying antd form instance, exposing the form instance and the native `<form>` element. [#1558](https://github.com/oceanbase/oceanbase-design/pull/1558)
  - 🐞 Kept antd's generic `Values` typing on `Form` and `Form.Item`, restoring type inference for typed forms. [#1560](https://github.com/oceanbase/oceanbase-design/pull/1560)
