### PR TITLE
fix(design): keep antd generic Values typing for Form and Form.Item

### DIFF
--- a/packages/design/src/form/FormItem.tsx
+++ b/packages/design/src/form/FormItem.tsx
@@ -25,17 +25,19 @@ export type WrapperTooltipProps = Omit<TooltipProps, 'mouseFollow'> & {
 
 export type LabelTooltipType = WrapperTooltipProps | React.ReactNode;
 
-export interface FormItemProps extends AntFormItemProps {
+export interface FormItemProps<Values = any> extends AntFormItemProps<Values> {
   tooltip?: WrapperTooltipProps | ReactNode;
   action?: ReactNode;
   description?: ReactNode;
 }
 
-type CompoundedComponent = React.FC<FormItemProps> & {
+type FormItemComponent = <Values = any>(props: FormItemProps<Values>) => React.ReactElement;
+
+type CompoundedComponent = FormItemComponent & {
   useStatus: typeof AntFormItem.useStatus;
 };
 
-const FormItem: CompoundedComponent = ({
+const InternalFormItem = ({
   children,
   label,
   tooltip,
@@ -47,7 +49,7 @@ const FormItem: CompoundedComponent = ({
   help: propHelp,
   validateStatus: propValidateStatus,
   ...restProps
-}) => {
+}: FormItemProps) => {
   const { childFeedback, contextValue } = useFormItemChildFeedbackState();
   // Child feedback is opt-in (e.g. Password blur hints). When absent, props pass through unchanged.
   const mergedHelp = childFeedback != null ? (childFeedback.help ?? propHelp) : propHelp;
@@ -128,6 +130,8 @@ const FormItem: CompoundedComponent = ({
     </FormItemChildFeedbackProvider>
   );
 };
+
+const FormItem: CompoundedComponent = InternalFormItem as CompoundedComponent;
 
 FormItem.useStatus = AntFormItem.useStatus;
 

--- a/packages/design/src/form/__tests__/index.test.tsx
+++ b/packages/design/src/form/__tests__/index.test.tsx
@@ -85,4 +85,35 @@ describe('Form', () => {
     expect(typeof ref.current?.validateFields).toBe('function');
     expect(ref.current?.nativeElement).toBe(container.querySelector('form'));
   });
+
+  // Type-only regression guard: Form / Form.Item must keep antd's generic <Values>
+  // inference (validated by `tsc --noEmit`, not by vitest at runtime).
+  it('keeps antd-style generic typing for Form and Form.Item', () => {
+    const TypedForm = () => {
+      const [form] = Form.useForm<{ name: string }>();
+      return (
+        <Form
+          form={form}
+          onFinish={values => {
+            // Values must be inferred from the form instance, not `any`.
+            // @ts-expect-error inferred Values has no `nonexistentProp`
+            expect(values.nonexistentProp).toBeUndefined();
+            return undefined;
+          }}
+        />
+      );
+    };
+    render(<TypedForm />);
+
+    render(
+      <Form.Item name="name">
+        {fieldForm => {
+          // render-prop form instance must be typed, not `any`.
+          // @ts-expect-error FormInstance has no `nonexistentMethod`
+          expect(fieldForm.nonexistentMethod).toBeUndefined();
+          return null;
+        }}
+      </Form.Item>
+    );
+  });
 });

--- a/packages/design/src/form/index.en-US.md
+++ b/packages/design/src/form/index.en-US.md
@@ -7,7 +7,7 @@ nav:
 
 - 🔥 Fully inherits antd [Form](https://ant.design/components/form-cn) capabilities and API, seamless migration.
 - 💄 Custom theme and styles, aligned with OceanBase Design specification.
-- 📢 Form `preserve` defaults to `true`.
+- 📢 Form `preserve` defaults to `false`.
 - 📢 Form `requiredMark` defaults to `optional` style.
 - 🆕 Form.Item `tooltip` adds `type` prop for different Tooltip types, see [Tooltip docs](/components/Tooltip).
 - 🆕 Form.Item adds `description` prop for description before form control.

--- a/packages/design/src/form/index.md
+++ b/packages/design/src/form/index.md
@@ -7,7 +7,7 @@ nav:
 
 - 🔥 完全继承 antd [Form](https://ant.design/components/form-cn) 的能力和 API，可无缝切换。
 - 💄 定制主题和样式，符合 OceanBase Design 设计规范。
-- 📢 Form `preserve` 属性的默认值为 `true`。
+- 📢 Form `preserve` 属性的默认值为 `false`。
 - 📢 Form `requiredMark` 默认为 `optional` 可选样式。
 - 🆕 Form.Item `tooltip` 新增 `type` 属性，支持不同类型的 Tooltip 提示，详见 [Tooltip 文档](/components/Tooltip)。
 - 🆕 Form.Item 新增 `description` 属性，用于设置表单控件前的描述信息。

--- a/packages/design/src/form/index.tsx
+++ b/packages/design/src/form/index.tsx
@@ -24,7 +24,7 @@ export * from 'antd/es/form';
 export type { FormItemProps } from './FormItem';
 export type { FormReValidateMode, FormValidateMode, OBFormConfig } from './validateMode';
 
-export type FormProps = AntFormProps & {
+export type FormProps<Values = any> = AntFormProps<Values> & {
   validateMode?: FormValidateMode;
   reValidateMode?: FormReValidateMode;
 };
@@ -32,19 +32,22 @@ export type FormProps = AntFormProps & {
 /** Ref exposed by the underlying antd Form: the form instance plus the native `<form>` element. */
 type FormRef = React.ComponentRef<typeof AntForm>;
 
-type CompoundedComponent = React.ForwardRefExoticComponent<
-  React.PropsWithoutRef<FormProps> & React.RefAttributes<FormRef>
-> & {
-  Item: typeof Item;
-  List: typeof AntForm.List;
-  ErrorList: typeof AntForm.ErrorList;
-  useForm: typeof AntForm.useForm;
-  useFormInstance: typeof AntForm.useFormInstance;
-  useWatch: typeof AntForm.useWatch;
-  useFormItemChildFeedback: typeof useFormItemChildFeedback;
-  Provider: typeof AntForm.Provider;
-  create: typeof AntForm.create;
-};
+type FormComponent = <Values = any>(
+  props: React.PropsWithChildren<FormProps<Values>> & React.RefAttributes<FormRef>
+) => React.ReactElement;
+
+type CompoundedComponent = FormComponent &
+  Pick<React.FC, 'displayName'> & {
+    Item: typeof Item;
+    List: typeof AntForm.List;
+    ErrorList: typeof AntForm.ErrorList;
+    useForm: typeof AntForm.useForm;
+    useFormInstance: typeof AntForm.useFormInstance;
+    useWatch: typeof AntForm.useWatch;
+    useFormItemChildFeedback: typeof useFormItemChildFeedback;
+    Provider: typeof AntForm.Provider;
+    create: typeof AntForm.create;
+  };
 
 const InternalForm = forwardRef<FormRef, FormProps>((props, ref) => {
   const {
@@ -190,7 +193,9 @@ const InternalForm = forwardRef<FormRef, FormProps>((props, ref) => {
   );
 });
 
-const Form: CompoundedComponent = InternalForm as typeof Form;
+// `InternalForm` is a non-generic forwardRef wrapper; the public Form keeps antd's
+// generic <Values> call signature so consumers get the same type inference.
+const Form: CompoundedComponent = InternalForm as unknown as CompoundedComponent;
 
 if (process.env.NODE_ENV !== 'production') {
   Form.displayName = 'Form';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

OB Design's `Form` and `Form.Item` wrap antd's counterparts, but the wrapper prop types (`FormProps`, `FormItemProps`) were non-generic, so the `<Values>` type argument antd infers through `Form.useForm<Values>()` was lost:

- `Form` `onFinish`'s `values` parameter fell back to `any`.
- `Form.Item` render-prop's `FormInstance` fell back to `any`.

Users migrating from antd lost type safety and got no compile-time help.

Solution: make `FormProps<Values>` / `FormItemProps<Values>` generic and expose `Form` / `Form.Item` as generic function components (same call-signature shape as antd), so `Values` flows from the form instance through `onFinish` and the render-prop. A type-only regression guard is added to the Form test suite (validated by `tsc --noEmit`).

Also fixes the Form docs: `preserve` was documented as defaulting to `true`, but the actual default is `false`.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Form<br/>&nbsp;&nbsp;- 🐞 Fixed `onFinish` values and Form.Item render-prop losing antd's generic `<Values>` type inference.<br/>&nbsp;&nbsp;- 📖 Corrected docs: Form `preserve` defaults to `false`, not `true`. |
| 🇨🇳 Chinese | - Form<br/>&nbsp;&nbsp;- 🐞 修复 `onFinish` 的 values 与 Form.Item render-prop 丢失 antd 泛型 `<Values>` 类型推断的问题。<br/>&nbsp;&nbsp;- 📖 修正文档：Form `preserve` 的默认值为 `false`，而非 `true`。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
