### PR TITLE
fix(design): restore Input.Password autofill by delegating to antd Password

### DIFF
--- a/packages/design/src/input/Input.tsx
+++ b/packages/design/src/input/Input.tsx
@@ -4,8 +4,8 @@ import type { InputProps as AntInputProps, InputRef } from 'antd';
 import type { ShowCountFormatter } from 'rc-input/es/interface';
 import ConfigProvider from '../config-provider';
 import type { ConfigConsumerProps } from '../config-provider';
-import defaultLocale from '../locale/en-US';
 import useStyle from './style';
+import { resolveInputLocale } from './resolveInputLocale';
 
 export * from 'antd/es/input/Input';
 
@@ -26,13 +26,7 @@ const Input = forwardRef<InputRef, InputProps>(
     const { getPrefixCls, locale: contextLocale } = useContext<ConfigConsumerProps>(
       ConfigProvider.ConfigContext
     );
-    const inputLocale: InputLocale = {
-      placeholder:
-        contextLocale?.global?.inputPlaceholder || defaultLocale.global?.inputPlaceholder,
-      ...defaultLocale.Input,
-      ...contextLocale?.Input,
-      ...customLocale,
-    };
+    const inputLocale = resolveInputLocale(contextLocale, customLocale);
     const prefixCls = getPrefixCls('input', customizePrefixCls);
     const [wrapCSSVar] = useStyle(prefixCls);
 

--- a/packages/design/src/input/Password.tsx
+++ b/packages/design/src/input/Password.tsx
@@ -1,16 +1,13 @@
-import React, { forwardRef, useContext, useEffect, useState } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { Input as AntInput } from 'antd';
 import type { InputRef } from 'antd';
 import type { PasswordProps as AntPasswordProps } from 'antd/es/input/Password';
-import DisabledContext from 'antd/es/config-provider/DisabledContext';
-import { EyeInvisibleOutlined, EyeOutlined } from '@oceanbase/icons';
-import classNames from 'classnames';
 import type { InputLocale } from './Input';
 import ConfigProvider from '../config-provider';
 import type { ConfigConsumerProps } from '../config-provider';
-import defaultLocale from '../locale/en-US';
 import { showCountFormatter } from './Input';
 import useStyle from './style';
+import { resolveInputLocale } from './resolveInputLocale';
 
 export * from 'antd/es/input/Password';
 
@@ -22,126 +19,34 @@ function isNewPasswordField(autoComplete?: string): boolean {
   return autoComplete === 'new-password';
 }
 
-const defaultIconRender = (visible: boolean) =>
-  visible ? <EyeOutlined /> : <EyeInvisibleOutlined />;
-
-const actionMap = {
-  click: 'onClick',
-  hover: 'onMouseOver',
+const NEW_PASSWORD_MANAGER_ATTRS = {
+  'data-lpignore': 'true',
+  'data-1p-ignore': 'true',
+  'data-bwignore': 'true',
+  'data-form-type': 'other',
 } as const;
 
 const Password = forwardRef<InputRef, PasswordProps>(
   (
-    {
-      prefixCls: customizePrefixCls,
-      locale: customLocale,
-      showCount,
-      autoComplete,
-      action = 'click',
-      visibilityToggle = true,
-      iconRender = defaultIconRender,
-      suffix,
-      className,
-      size,
-      disabled: customDisabled,
-      ...restProps
-    },
+    { prefixCls: customizePrefixCls, locale: customLocale, showCount, autoComplete, ...restProps },
     ref
   ) => {
     const { getPrefixCls, locale: contextLocale } = useContext<ConfigConsumerProps>(
       ConfigProvider.ConfigContext
     );
     const inputPrefixCls = getPrefixCls('input', customizePrefixCls);
-    const prefixCls = getPrefixCls('input-password', customizePrefixCls);
     const [wrapCSSVar] = useStyle(inputPrefixCls);
-    const inputLocale: InputLocale = {
-      placeholder:
-        contextLocale?.global?.inputPlaceholder || defaultLocale.global?.inputPlaceholder,
-      ...defaultLocale.Input,
-      ...contextLocale?.Input,
-      ...customLocale,
-    };
-
-    // 以 type="text" + -webkit-text-security 呈现密码遮蔽，
-    // 避免浏览器识别为原生密码框而弹出密码保存/填充下拉
-    const disabled = useContext(DisabledContext);
-    const mergedDisabled = customDisabled ?? disabled;
-
-    const visibilityControlled =
-      typeof visibilityToggle === 'object' && visibilityToggle.visible !== undefined;
-    const [visible, setVisible] = useState<boolean>(() =>
-      visibilityControlled ? (visibilityToggle.visible ?? false) : false
-    );
-
-    useEffect(() => {
-      if (visibilityControlled) {
-        setVisible(visibilityToggle.visible ?? false);
-      }
-    }, [visibilityControlled, visibilityToggle]);
-
-    const onVisibleChange = () => {
-      if (mergedDisabled) {
-        return;
-      }
-      const nextVisible = !visible;
-      setVisible(nextVisible);
-      if (typeof visibilityToggle === 'object') {
-        visibilityToggle.onVisibleChange?.(nextVisible);
-      }
-    };
-
-    const getIcon = (iconPrefixCls: string) => {
-      const icon = iconRender(visible);
-      const iconTrigger = actionMap[action];
-      const iconProps = {
-        className: `${iconPrefixCls}-icon`,
-        key: 'passwordIcon',
-        onMouseDown: (e: React.MouseEvent<HTMLElement>) => {
-          // 防止点击图标时输入框失焦
-          e.preventDefault();
-        },
-        onMouseUp: (e: React.MouseEvent<HTMLElement>) => {
-          // 防止光标位置变化
-          e.preventDefault();
-        },
-        [iconTrigger]: onVisibleChange,
-      };
-      return React.cloneElement(React.isValidElement(icon) ? icon : <span>{icon}</span>, iconProps);
-    };
-
-    const inputClassName = classNames(prefixCls, className, {
-      [`${prefixCls}-${size}`]: !!size,
-    });
-
-    const suffixIcon = visibilityToggle && getIcon(prefixCls);
+    const inputLocale = resolveInputLocale(contextLocale, customLocale);
 
     return wrapCSSVar(
-      <AntInput
+      <AntInput.Password
         ref={ref}
-        type="text"
         prefixCls={customizePrefixCls}
-        className={inputClassName}
-        size={size}
         placeholder={inputLocale.placeholder}
         showCount={showCount === true ? { formatter: showCountFormatter } : showCount}
         autoComplete={autoComplete}
-        disabled={customDisabled}
-        suffix={
-          <>
-            {suffixIcon}
-            {suffix}
-          </>
-        }
-        classNames={{ input: visible ? undefined : `${inputPrefixCls}-text-security` }}
-        {...(isNewPasswordField(autoComplete)
-          ? {
-              'data-lpignore': 'true',
-              'data-1p-ignore': 'true',
-              'data-bwignore': 'true',
-              'data-form-type': 'other',
-            }
-          : {})}
         {...restProps}
+        {...(isNewPasswordField(autoComplete) ? NEW_PASSWORD_MANAGER_ATTRS : {})}
       />
     );
   }

--- a/packages/design/src/input/Search.tsx
+++ b/packages/design/src/input/Search.tsx
@@ -6,10 +6,10 @@ import { composeRef } from 'rc-util/lib/ref';
 import type { SearchProps as AntSearchProps } from 'antd/es/input/Search';
 import ConfigProvider from '../config-provider';
 import type { ConfigConsumerProps } from '../config-provider';
-import defaultLocale from '../locale/en-US';
 import InternalInput, { showCountFormatter } from './Input';
 import type { InputLocale, InputRef } from './Input';
 import useStyle from './style';
+import { resolveInputLocale } from './resolveInputLocale';
 
 export * from 'antd/es/input/Search';
 
@@ -48,12 +48,7 @@ const Search = forwardRef<InputRef, SearchProps>((props, ref) => {
   const inputRef = useRef<InputRef>(null);
   const composedRef = useRef(false);
 
-  const inputLocale: InputLocale = {
-    placeholder: contextLocale?.global?.inputPlaceholder || defaultLocale.global?.inputPlaceholder,
-    ...defaultLocale.Input,
-    ...contextLocale?.Input,
-    ...customLocale,
-  };
+  const inputLocale = resolveInputLocale(contextLocale, customLocale);
 
   if (!enterButton && !addonAfter) {
     const handleChange: AntSearchProps['onChange'] = e => {

--- a/packages/design/src/input/TextArea.tsx
+++ b/packages/design/src/input/TextArea.tsx
@@ -4,9 +4,9 @@ import type { TextAreaProps as AntTextAreaProps } from 'antd/es/input/TextArea';
 import type { InputLocale, InputRef } from './Input';
 import ConfigProvider from '../config-provider';
 import type { ConfigConsumerProps } from '../config-provider';
-import defaultLocale from '../locale/en-US';
 import { showCountFormatter } from './Input';
 import useStyle from './style';
+import { resolveInputLocale } from './resolveInputLocale';
 
 export * from 'antd/es/input/TextArea';
 
@@ -21,13 +21,7 @@ const TextArea = forwardRef<InputRef, TextAreaProps>(
     );
     const prefixCls = getPrefixCls('input', customizePrefixCls);
     const [wrapCSSVar] = useStyle(prefixCls);
-    const inputLocale: InputLocale = {
-      placeholder:
-        contextLocale?.global?.inputPlaceholder || defaultLocale.global?.inputPlaceholder,
-      ...defaultLocale.Input,
-      ...contextLocale?.Input,
-      ...customLocale,
-    };
+    const inputLocale = resolveInputLocale(contextLocale, customLocale);
 
     return wrapCSSVar(
       <AntInput.TextArea

--- a/packages/design/src/input/__tests__/password.test.tsx
+++ b/packages/design/src/input/__tests__/password.test.tsx
@@ -3,24 +3,49 @@ import { fireEvent, render } from '@testing-library/react';
 import { Input } from '@oceanbase/design';
 
 describe('Input.Password', () => {
-  it('renders as text input masked by -webkit-text-security', () => {
+  it('renders as native password input by default', () => {
     const { container } = render(<Input.Password />);
     const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
-    expect(input.getAttribute('type')).toBe('text');
-    expect(input.classList.contains('ant-input-text-security')).toBe(true);
+    expect(input.getAttribute('type')).toBe('password');
     expect(input.readOnly).toBe(false);
+  });
+
+  it('renders as native password input for current-password', () => {
+    const { container } = render(<Input.Password autoComplete="current-password" />);
+    const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
+    expect(input.getAttribute('type')).toBe('password');
   });
 
   it('reveals plain text when visibility toggled', () => {
     const { container } = render(<Input.Password defaultValue="password" />);
     const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
-    expect(input.classList.contains('ant-input-text-security')).toBe(true);
+    expect(input.getAttribute('type')).toBe('password');
 
     fireEvent.click(container.querySelector('.ant-input-password-icon') as HTMLElement);
-    expect(input.classList.contains('ant-input-text-security')).toBe(false);
+    expect(input.getAttribute('type')).toBe('text');
 
     fireEvent.click(container.querySelector('.ant-input-password-icon') as HTMLElement);
-    expect(input.classList.contains('ant-input-text-security')).toBe(true);
+    expect(input.getAttribute('type')).toBe('password');
+  });
+
+  it('renders new-password as native password input', () => {
+    const { container } = render(<Input.Password autoComplete="new-password" />);
+    const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
+    expect(input.getAttribute('type')).toBe('password');
+  });
+
+  it('reveals plain text when visibility toggled for new-password', () => {
+    const { container } = render(
+      <Input.Password autoComplete="new-password" defaultValue="password" />
+    );
+    const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
+    expect(input.getAttribute('type')).toBe('password');
+
+    fireEvent.click(container.querySelector('.ant-input-password-icon') as HTMLElement);
+    expect(input.getAttribute('type')).toBe('text');
+
+    fireEvent.click(container.querySelector('.ant-input-password-icon') as HTMLElement);
+    expect(input.getAttribute('type')).toBe('password');
   });
 
   it('keeps third-party password manager ignore attrs for new-password', () => {

--- a/packages/design/src/input/index.en-US.md
+++ b/packages/design/src/input/index.en-US.md
@@ -27,4 +27,4 @@ demo:
 
 ### Input.Password extensions
 
-The password is rendered as a text input masked with text-security, so browsers do not treat it as a password field and no saved-password dropdown appears on focus. When `autoComplete="new-password"`, the component also attaches password-manager `data-*` hints to avoid misdetection by third-party password managers.
+Matches antd via `Input.Password` with native `type="password"` for browser autofill. When `autoComplete="new-password"`, password-manager `data-*` hints are attached to reduce misdetection by third-party password managers.

--- a/packages/design/src/input/index.md
+++ b/packages/design/src/input/index.md
@@ -27,4 +27,4 @@ demo:
 
 ### Input.Password 扩展
 
-密码框以 text 型输入 + text-security 遮蔽呈现，浏览器不会将其识别为密码框，focus 时不会弹出已保存密码下拉。`autoComplete="new-password"` 时，组件会附加密码管理器 `data-*` hint，进一步避免第三方密码管理器误识别。
+默认与 antd 一致，委托 `Input.Password` 实现，`type="password"` 支持浏览器密码自动填充。`autoComplete="new-password"` 时额外附加密码管理器 `data-*` hint，避免第三方密码管理器误识别。

--- a/packages/design/src/input/resolveInputLocale.ts
+++ b/packages/design/src/input/resolveInputLocale.ts
@@ -1,0 +1,15 @@
+import type { ConfigConsumerProps } from '../config-provider';
+import defaultLocale from '../locale/en-US';
+import type { InputLocale } from './Input';
+
+export function resolveInputLocale(
+  contextLocale: ConfigConsumerProps['locale'],
+  customLocale?: InputLocale
+): InputLocale {
+  return {
+    placeholder: contextLocale?.global?.inputPlaceholder || defaultLocale.global?.inputPlaceholder,
+    ...defaultLocale.Input,
+    ...contextLocale?.Input,
+    ...customLocale,
+  };
+}

--- a/packages/design/src/input/style/index.ts
+++ b/packages/design/src/input/style/index.ts
@@ -20,10 +20,6 @@ export const genInputStyle: GenerateStyle<InputToken> = (token: InputToken): CSS
         },
       },
     },
-    // 密码以 text 型输入呈现，借助 text-security 遮蔽文本，浏览器不将其识别为密码框
-    [`${componentCls}-text-security`]: {
-      WebkitTextSecurity: 'disc',
-    },
   };
 };
 

--- a/packages/ui/src/Password/__tests__/rememberHint.test.tsx
+++ b/packages/ui/src/Password/__tests__/rememberHint.test.tsx
@@ -21,9 +21,7 @@ describe('Password remember hint in Form.Item', () => {
 
     const passwordInput = container.querySelector('.ant-input-password input') as HTMLInputElement;
     expect(passwordInput).toBeTruthy();
-    // 密码以 text 型输入 + text-security 遮蔽呈现，浏览器不将其识别为密码框
-    expect(passwordInput.getAttribute('type')).toBe('text');
-    expect(passwordInput.classList.contains('ant-input-text-security')).toBe(true);
+    expect(passwordInput.getAttribute('type')).toBe('password');
 
     await user.type(passwordInput, VALID_PASSWORD);
     await user.tab();


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

`Input.Password` previously rendered all fields as `type="text"` with `-webkit-text-security` (#1528), so browsers did not treat login passwords as native password inputs and autofill did not work for non-`new-password` fields.

This PR delegates to antd `Input.Password` (native `type="password"`). Shared `resolveInputLocale` replaces duplicated locale assembly across Input variants.

| Before | After |
| :--- | :--- |
| All passwords: `type=text` + text-security | Non-`new-password`: antd `type=password` (autofill works) |

### 📝 Changelog

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | - Input.Password<br/>&nbsp;&nbsp;- 🐞 Fix browser password autofill for non-`new-password` fields (e.g. login). |
| 🇨🇳 Chinese | - Input.Password<br/>&nbsp;&nbsp;- 🐞 修复非 `new-password` 场景（如登录）浏览器密码无法自动填充的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed