### PR TITLE
fix(design): fix missing bottom border for row-span Table in Card

### DIFF
--- a/packages/design/src/card/style/index.ts
+++ b/packages/design/src/card/style/index.ts
@@ -232,14 +232,17 @@ export const genCardStyle: GenerateStyle<CardToken> = (token: CardToken): CSSObj
     // no body padding bottom and bordered card
     [`${componentCls}${componentCls}-bordered${componentCls}-no-body-padding-bottom`]: {
       [`> ${componentCls}-body`]: {
-        // fix double border when Table has no pagination
-        [`> ${tableComponentCls}-wrapper${tableComponentCls}-no-pagination`]: {
-          [`${tableComponentCls}`]: {
-            [`${tableComponentCls}-tbody > tr:last-child > td`]: {
-              borderBottom: 'none',
+        // Remove last-row td bottom border when there is no pagination, to avoid double border with Card.
+        // Row/column merge tables cannot use built-in pagination (pagination breaks merge semantics), so they are always no-pagination;
+        // tr:last-child then does not include every visual bottom-edge cell — do not strip border-bottom or the bottom edge looks broken.
+        [`> ${tableComponentCls}-wrapper${tableComponentCls}-no-pagination:not(${tableComponentCls}-has-rowspan)`]:
+          {
+            [`${tableComponentCls}`]: {
+              [`${tableComponentCls}-tbody > tr:last-child > td`]: {
+                borderBottom: 'none',
+              },
             },
           },
-        },
         // fix double border when Table has no data
         [`> ${tableComponentCls}-wrapper${tableComponentCls}-has-empty`]: {
           [`${tableComponentCls}`]: {

--- a/packages/design/src/table/__tests__/index.test.tsx
+++ b/packages/design/src/table/__tests__/index.test.tsx
@@ -184,4 +184,64 @@ describe('Table', () => {
     expect(getComputedStyle(nameCell).paddingLeft).toBe('8px');
     expect(getComputedStyle(nameTh).paddingLeft).toBe('8px');
   });
+
+  it('should not set has-rowspan class without row merge', () => {
+    const { container } = render(
+      <Table columns={columns} dataSource={dataSource.slice(0, 2)} pagination={false} />
+    );
+    expect(container.querySelector('.ant-table-has-rowspan')).toBeFalsy();
+    expect(container.querySelector('.ant-table-has-rowspan-first')).toBeFalsy();
+    expect(container.querySelector('.ant-table-has-rowspan-last')).toBeFalsy();
+  });
+
+  it('should set has-rowspan class when any column has rowSpan merge', () => {
+    const rowSpanColumns = [
+      { title: 'Name', dataIndex: 'name' },
+      {
+        title: 'Tel',
+        dataIndex: 'tel',
+        onCell: (_: unknown, index?: number) => {
+          if (index === 0) {
+            return { rowSpan: 2 };
+          }
+          if (index === 1) {
+            return { rowSpan: 0 };
+          }
+          return {};
+        },
+      },
+      { title: 'Address', dataIndex: 'address' },
+    ];
+    const rowSpanData = [
+      { key: '1', name: 'A', tel: '111', address: 'Addr 1' },
+      { key: '2', name: 'B', tel: '222', address: 'Addr 2' },
+    ];
+    const { container } = render(
+      <Table columns={rowSpanColumns} dataSource={rowSpanData} pagination={false} />
+    );
+    expect(container.querySelector('.ant-table-wrapper.ant-table-has-rowspan')).toBeTruthy();
+    expect(container.querySelector('.ant-table-has-rowspan-first')).toBeFalsy();
+    expect(container.querySelector('.ant-table-has-rowspan-last')).toBeFalsy();
+  });
+
+  it('should set has-rowspan-first when first column has rowSpan merge', () => {
+    const rowSpanColumns = [
+      {
+        title: 'Name',
+        dataIndex: 'name',
+        onCell: (_: unknown, index?: number) =>
+          index === 0 ? { rowSpan: 2 } : index === 1 ? { rowSpan: 0 } : {},
+      },
+      { title: 'Age', dataIndex: 'age' },
+    ];
+    const rowSpanData = [
+      { key: '1', name: 'A', age: 1 },
+      { key: '2', name: 'B', age: 2 },
+    ];
+    const { container } = render(
+      <Table columns={rowSpanColumns} dataSource={rowSpanData} pagination={false} />
+    );
+    expect(container.querySelector('.ant-table-wrapper.ant-table-has-rowspan')).toBeTruthy();
+    expect(container.querySelector('.ant-table-has-rowspan-first')).toBeTruthy();
+  });
 });

--- a/packages/design/src/table/demo/colspan-rowspan.tsx
+++ b/packages/design/src/table/demo/colspan-rowspan.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Table } from '@oceanbase/design';
+import React, { useState } from 'react';
+import { Card, Form, Switch, Table } from '@oceanbase/design';
 import type { ColumnsType } from '@oceanbase/design/es/table';
 
 interface DataType {
@@ -113,6 +113,26 @@ const data: DataType[] = [
   },
 ];
 
-const App: React.FC = () => <Table columns={columns} dataSource={data} bordered />;
+const App: React.FC = () => {
+  const [pagination, setPagination] = useState(false);
+
+  return (
+    <>
+      <Form layout="inline" style={{ marginBottom: 16 }}>
+        <Form.Item label="Pagination">
+          <Switch size="small" checked={pagination} onChange={setPagination} />
+        </Form.Item>
+      </Form>
+      <Card bordered bodyStyle={{ padding: 0 }}>
+        <Table
+          columns={columns}
+          dataSource={data}
+          bordered
+          pagination={pagination ? { pageSize: 3 } : false}
+        />
+      </Card>
+    </>
+  );
+};
 
 export default App;

--- a/packages/design/src/table/index.en-US.md
+++ b/packages/design/src/table/index.en-US.md
@@ -35,7 +35,7 @@ markdown: |
 <code src="./demo/tree-table.tsx" title="Tree Table" description="Auto tree when data has `children`; use childrenColumnName for other field. Use indentSize for indent."></code>
 <code src="./demo/grouping-columns.tsx" title="Column Grouping" description="Nest children in columns for grouped headers."></code>
 <code src="./demo/rowspan.tsx" title="Row Span" description="Use onCell rowSpan for row merge."></code>
-<code src="./demo/colspan-rowspan.tsx" title="Row and Column Span" description="Header supports column span via column colSpan.<br>Table supports row/column span; colSpan or rowSpan 0 in render hides cell."></code>
+<code src="./demo/colspan-rowspan.tsx" title="Row and Column Span" description="Header supports column span via column colSpan.<br>Table supports row/column span; colSpan or rowSpan 0 in render hides cell.<br>Merged tables usually disable pagination; toggle Pagination to compare bottom border inside Card."></code>
 <code src="./demo/edit-row.tsx" title="Editable Row" description="Table with row edit."></code>
 <code src="./demo/virtual.tsx" title="Virtual Scroll" description="Enable via `virtual`; requires `scroll.x` and `scroll.y` as number."></code>
 <code src="./demo/dynamic-settings.tsx" title="Dynamic Table Props" description="Select different configs to see effect."></code>

--- a/packages/design/src/table/index.md
+++ b/packages/design/src/table/index.md
@@ -35,7 +35,7 @@ markdown: |
 <code src="./demo/tree-table.tsx" title="树形表格" description="当数据中有 `children` 字段时会自动展示为树形表格，如果不需要或配置为其他字段可以用 childrenColumnName 进行配置。可以通过设置 indentSize 以控制每一层的缩进宽度。"></code>
 <code src="./demo/grouping-columns.tsx" title="表头分组" description="columns 可以通过嵌套 children，实现表头分组。"></code>
 <code src="./demo/rowspan.tsx" title="行合并" description="通过 onCell 设置单元格属性 rowSpan，可以实现行合并。"></code>
-<code src="./demo/colspan-rowspan.tsx" title="行列合并" description="表头只支持列合并，使用 column 里的 colSpan 进行设置。<br>表格支持行/列合并，使用 render 里的单元格属性 colSpan 或者 rowSpan 设值为 0 时，设置的表格不会渲染。"></code>
+<code src="./demo/colspan-rowspan.tsx" title="行列合并" description="表头只支持列合并，使用 column 里的 colSpan 进行设置。<br>表格支持行/列合并，使用 render 里的单元格属性 colSpan 或者 rowSpan 设值为 0 时，设置的表格不会渲染。<br>行列合并表通常关闭分页；可切换 Pagination 对比 Card 内底边表现。"></code>
 <code src="./demo/edit-row.tsx" title="可编辑行" description="带行编辑功能的表格。"></code>
 <code src="./demo/virtual.tsx" title="虚拟滚动" description="通过 `virtual` 开启虚拟滚动，要求设置 `scroll.x` 和 `scroll.y` 且必须为 number 类型。"></code>
 <code src="./demo/dynamic-settings.tsx" title="动态控制表格属性" description="选择不同配置组合查看效果。"></code>

--- a/packages/design/src/table/index.tsx
+++ b/packages/design/src/table/index.tsx
@@ -34,53 +34,6 @@ export type TableColumnsType<T = AnyObject> = (TableColumnGroupType<T> | TableCo
 
 export * from 'antd/es/table';
 
-/** 第一个非 hidden 的叶子列（支持 column 分组） */
-function getFirstLeafColumn<T extends AnyObject>(
-  cols: ColumnsType<T> | undefined
-): AnyObject | null {
-  if (!cols) {
-    return null;
-  }
-  for (const item of cols as AnyObject[]) {
-    if (item.hidden) {
-      continue;
-    }
-    if (item.children?.length) {
-      const found = getFirstLeafColumn(item.children as ColumnsType<T>);
-      if (found) {
-        return found;
-      }
-    } else {
-      return item;
-    }
-  }
-  return null;
-}
-
-/** 最后一个非 hidden 的叶子列 */
-function getLastLeafColumn<T extends AnyObject>(
-  cols: ColumnsType<T> | undefined
-): AnyObject | null {
-  if (!cols) {
-    return null;
-  }
-  for (let i = cols.length - 1; i >= 0; i--) {
-    const item = cols[i] as AnyObject;
-    if (item.hidden) {
-      continue;
-    }
-    if (item.children?.length) {
-      const found = getLastLeafColumn(item.children as ColumnsType<T>);
-      if (found) {
-        return found;
-      }
-    } else {
-      return item;
-    }
-  }
-  return null;
-}
-
 /** 叶子列数量（与 rc-table 扁平列顺序一致：深度优先跳过 hidden） */
 function countLeafColumns<T extends AnyObject>(cols: ColumnsType<T> | undefined): number {
   if (!cols?.length) {
@@ -101,6 +54,81 @@ function countLeafColumns<T extends AnyObject>(cols: ColumnsType<T> | undefined)
   };
   walk(cols);
   return n;
+}
+
+function isRowSpanMerge(rowSpan: unknown): boolean {
+  return rowSpan === 0 || (typeof rowSpan === 'number' && rowSpan > 1);
+}
+
+interface ColumnRowSpanMeta {
+  needsColMeta: boolean;
+  hasAnyRowSpan: boolean;
+  hasFirstColumnRowSpan: boolean;
+  hasLastColumnRowSpan: boolean;
+}
+
+/** Single pass over leaf columns; aggregates rowspan-related class and data-* injection flags. */
+function analyzeColumnRowSpan<T extends AnyObject>(
+  cols: ColumnsType<T> | undefined,
+  data: readonly T[] | undefined
+): ColumnRowSpanMeta {
+  const empty: ColumnRowSpanMeta = {
+    needsColMeta: false,
+    hasAnyRowSpan: false,
+    hasFirstColumnRowSpan: false,
+    hasLastColumnRowSpan: false,
+  };
+  if (!cols?.length || !data?.length) {
+    return empty;
+  }
+
+  const tailIdx = countLeafColumns(cols) - 1;
+  let leafIndex = 0;
+  let hasAnyRowSpan = false;
+  let hasFirstColumnRowSpan = false;
+  let hasLastColumnRowSpan = false;
+
+  const walk = (items: ColumnsType<T>): void => {
+    for (const item of items as AnyObject[]) {
+      if (item.hidden) {
+        continue;
+      }
+      if (item.children?.length) {
+        walk(item.children as ColumnsType<T>);
+        continue;
+      }
+      const myIndex = leafIndex;
+      leafIndex += 1;
+      if (typeof item.onCell !== 'function') {
+        continue;
+      }
+      let colHasRowSpan = false;
+      for (let i = 0; i < data.length; i++) {
+        if (isRowSpanMerge(item.onCell(data[i], i)?.rowSpan)) {
+          colHasRowSpan = true;
+          break;
+        }
+      }
+      if (!colHasRowSpan) {
+        continue;
+      }
+      hasAnyRowSpan = true;
+      if (myIndex === 0) {
+        hasFirstColumnRowSpan = true;
+      }
+      if (myIndex === tailIdx) {
+        hasLastColumnRowSpan = true;
+      }
+    }
+  };
+  walk(cols);
+
+  return {
+    hasAnyRowSpan,
+    hasFirstColumnRowSpan,
+    hasLastColumnRowSpan,
+    needsColMeta: hasFirstColumnRowSpan || hasLastColumnRowSpan,
+  };
 }
 
 /**
@@ -219,38 +247,9 @@ function Table<T extends Record<string, any>>(props: TableProps<T>, ref: React.R
   const noPagination = pagination === false || pagination === null;
   const noData = dataSource?.length === 0;
 
-  /** 基于原始 columns 检测，避免依赖注入后的 onCell；needsColMeta 为真时才注入 data-* */
-  const { needsColMeta, hasFirstColumnRowSpan, hasLastColumnRowSpan } = React.useMemo(() => {
-    const empty = {
-      needsColMeta: false,
-      hasFirstColumnRowSpan: false,
-      hasLastColumnRowSpan: false,
-    };
-    if (!columns?.length || !dataSource?.length) {
-      return empty;
-    }
-    const firstCol = getFirstLeafColumn(columns);
-    const lastCol = getLastLeafColumn(columns);
-    const leafHasRowSpan = (col: AnyObject | null) => {
-      if (typeof col?.onCell !== 'function') {
-        return false;
-      }
-      for (let i = 0; i < dataSource.length; i++) {
-        const rs = col.onCell(dataSource[i], i)?.rowSpan;
-        if (rs === 0 || (typeof rs === 'number' && rs > 1)) {
-          return true;
-        }
-      }
-      return false;
-    };
-    const first = leafHasRowSpan(firstCol);
-    const last = firstCol === lastCol ? first : leafHasRowSpan(lastCol);
-    return {
-      needsColMeta: first || last,
-      hasFirstColumnRowSpan: first,
-      hasLastColumnRowSpan: last,
-    };
-  }, [columns, dataSource]);
+  /** Detect from raw columns before injected onCell wrappers are applied */
+  const { needsColMeta, hasAnyRowSpan, hasFirstColumnRowSpan, hasLastColumnRowSpan } =
+    React.useMemo(() => analyzeColumnRowSpan(columns, dataSource), [columns, dataSource]);
 
   const columnsWithCellMeta = React.useMemo(
     () => (needsColMeta ? injectUserColumnCellMeta(columns) : columns),
@@ -283,6 +282,7 @@ function Table<T extends Record<string, any>>(props: TableProps<T>, ref: React.R
       [`${prefixCls}-expandable`]: !isEmpty(expandable),
       [`${prefixCls}-selectable`]: !!rowSelection,
       [`${prefixCls}-has-footer`]: !!footer,
+      [`${prefixCls}-has-rowspan`]: hasAnyRowSpan,
       ...(rowspanSuffix ? { [`${prefixCls}-has-rowspan-${rowspanSuffix}`]: true } : {}),
       [`${prefixCls}-thead-multiple-rows`]: hasMultipleTheadRows,
       [`${prefixCls}-inner-bordered`]: innerBordered,


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

When a bordered Table with row/column merge sits inside a bordered Card with zero body bottom padding and no pagination, Card styles removed `border-bottom` from `tr:last-child > td` to avoid a double border with the Card edge. With row span, the last DOM row does not include every visual bottom-edge cell, so some columns lost their bottom border.

**Fix:**
- Table adds `ant-table-has-rowspan` when any leaf column uses row span merge (single `analyzeColumnRowSpan` pass).
- Card skips the last-row `border-bottom: none` rule when that class is present.
- Colspan-rowspan demo gains a Pagination switch inside Card for regression comparison.
- Unit tests cover `has-rowspan` class detection.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Table<br/>&nbsp;&nbsp;- 🐞 Fixed incomplete bottom border when a row-span merged Table without pagination is placed in a bordered Card with zero body bottom padding. |
| 🇨🇳 Chinese | - Table<br/>&nbsp;&nbsp;- 🐞 修复行列合并 Table 在无边距 Card 内且无分页时末行底边不完整的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed


Made with [Cursor](https://cursor.com)