### PR TITLE
fix(design): suppress saved-password dropdown for new-password Input.Password

### DIFF
--- a/packages/design/src/input/NewPassword.tsx
+++ b/packages/design/src/input/NewPassword.tsx
@@ -1,0 +1,82 @@
+import React, { forwardRef, useContext, useLayoutEffect, useRef, useState } from 'react';
+import { Input as AntInput } from 'antd';
+import type { InputRef } from 'antd';
+import { composeRef } from 'rc-util/lib/ref';
+import type { PasswordProps } from './Password';
+import ConfigProvider from '../config-provider';
+import type { ConfigConsumerProps } from '../config-provider';
+import { showCountFormatter } from './Input';
+import { resolveInputLocale } from './resolveInputLocale';
+
+/**
+ * new-password requires type=text plus text-security; cannot fully delegate to AntInput.Password.
+ * Other behavior (visibility toggle, suffix, disabled) stays on antd; patch native input attrs after layout.
+ */
+const NewPassword = forwardRef<InputRef, PasswordProps>((props, ref) => {
+  const {
+    prefixCls: customizePrefixCls,
+    locale: customLocale,
+    showCount,
+    autoComplete,
+    visibilityToggle = true,
+    ...restProps
+  } = props;
+
+  const { getPrefixCls, locale: contextLocale } = useContext<ConfigConsumerProps>(
+    ConfigProvider.ConfigContext
+  );
+  const inputPrefixCls = getPrefixCls('input', customizePrefixCls);
+  const inputLocale = resolveInputLocale(contextLocale, customLocale);
+  const inputRef = useRef<InputRef>(null);
+
+  const visibilityControlled =
+    typeof visibilityToggle === 'object' && visibilityToggle.visible !== undefined;
+  const [internalVisible, setInternalVisible] = useState(false);
+  const visible = visibilityControlled ? (visibilityToggle.visible ?? false) : internalVisible;
+
+  useLayoutEffect(() => {
+    const input = inputRef.current?.input;
+    if (!input) {
+      return;
+    }
+    input.type = 'text';
+    input.classList.toggle(`${inputPrefixCls}-text-security`, !visible);
+  }, [visible, inputPrefixCls]);
+
+  const resolvedVisibilityToggle =
+    visibilityToggle === false
+      ? false
+      : {
+          visible,
+          onVisibleChange: (nextVisible: boolean) => {
+            if (!visibilityControlled) {
+              setInternalVisible(nextVisible);
+            }
+            if (typeof visibilityToggle === 'object') {
+              visibilityToggle.onVisibleChange?.(nextVisible);
+            }
+          },
+        };
+
+  return (
+    <AntInput.Password
+      ref={composeRef(ref, inputRef)}
+      prefixCls={customizePrefixCls}
+      placeholder={inputLocale.placeholder}
+      showCount={showCount === true ? { formatter: showCountFormatter } : showCount}
+      autoComplete={autoComplete}
+      visibilityToggle={resolvedVisibilityToggle}
+      {...restProps}
+      data-lpignore="true"
+      data-1p-ignore="true"
+      data-bwignore="true"
+      data-form-type="other"
+    />
+  );
+});
+
+if (process.env.NODE_ENV !== 'production') {
+  NewPassword.displayName = 'NewPassword';
+}
+
+export default NewPassword;

--- a/packages/design/src/input/Password.tsx
+++ b/packages/design/src/input/Password.tsx
@@ -6,6 +6,7 @@ import type { InputLocale } from './Input';
 import ConfigProvider from '../config-provider';
 import type { ConfigConsumerProps } from '../config-provider';
 import { showCountFormatter } from './Input';
+import NewPassword from './NewPassword';
 import useStyle from './style';
 import { resolveInputLocale } from './resolveInputLocale';
 
@@ -19,38 +20,38 @@ function isNewPasswordField(autoComplete?: string): boolean {
   return autoComplete === 'new-password';
 }
 
-const NEW_PASSWORD_MANAGER_ATTRS = {
-  'data-lpignore': 'true',
-  'data-1p-ignore': 'true',
-  'data-bwignore': 'true',
-  'data-form-type': 'other',
-} as const;
+const Password = forwardRef<InputRef, PasswordProps>((props, ref) => {
+  const {
+    prefixCls: customizePrefixCls,
+    locale: customLocale,
+    showCount,
+    autoComplete,
+    ...restProps
+  } = props;
 
-const Password = forwardRef<InputRef, PasswordProps>(
-  (
-    { prefixCls: customizePrefixCls, locale: customLocale, showCount, autoComplete, ...restProps },
-    ref
-  ) => {
-    const { getPrefixCls, locale: contextLocale } = useContext<ConfigConsumerProps>(
-      ConfigProvider.ConfigContext
-    );
-    const inputPrefixCls = getPrefixCls('input', customizePrefixCls);
-    const [wrapCSSVar] = useStyle(inputPrefixCls);
-    const inputLocale = resolveInputLocale(contextLocale, customLocale);
+  const { getPrefixCls, locale: contextLocale } = useContext<ConfigConsumerProps>(
+    ConfigProvider.ConfigContext
+  );
+  const inputPrefixCls = getPrefixCls('input', customizePrefixCls);
+  const [wrapCSSVar] = useStyle(inputPrefixCls);
 
-    return wrapCSSVar(
-      <AntInput.Password
-        ref={ref}
-        prefixCls={customizePrefixCls}
-        placeholder={inputLocale.placeholder}
-        showCount={showCount === true ? { formatter: showCountFormatter } : showCount}
-        autoComplete={autoComplete}
-        {...restProps}
-        {...(isNewPasswordField(autoComplete) ? NEW_PASSWORD_MANAGER_ATTRS : {})}
-      />
-    );
+  if (isNewPasswordField(autoComplete)) {
+    return wrapCSSVar(<NewPassword ref={ref} {...props} />);
   }
-);
+
+  const inputLocale = resolveInputLocale(contextLocale, customLocale);
+
+  return wrapCSSVar(
+    <AntInput.Password
+      ref={ref}
+      prefixCls={customizePrefixCls}
+      placeholder={inputLocale.placeholder}
+      showCount={showCount === true ? { formatter: showCountFormatter } : showCount}
+      autoComplete={autoComplete}
+      {...restProps}
+    />
+  );
+});
 
 if (process.env.NODE_ENV !== 'production') {
   Password.displayName = 'Password';

--- a/packages/design/src/input/__tests__/password.test.tsx
+++ b/packages/design/src/input/__tests__/password.test.tsx
@@ -28,10 +28,11 @@ describe('Input.Password', () => {
     expect(input.getAttribute('type')).toBe('password');
   });
 
-  it('renders new-password as native password input', () => {
+  it('renders new-password as text input masked by -webkit-text-security', () => {
     const { container } = render(<Input.Password autoComplete="new-password" />);
     const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
-    expect(input.getAttribute('type')).toBe('password');
+    expect(input.getAttribute('type')).toBe('text');
+    expect(input.classList.contains('ant-input-text-security')).toBe(true);
   });
 
   it('reveals plain text when visibility toggled for new-password', () => {
@@ -39,13 +40,13 @@ describe('Input.Password', () => {
       <Input.Password autoComplete="new-password" defaultValue="password" />
     );
     const input = container.querySelector('.ant-input-password input') as HTMLInputElement;
-    expect(input.getAttribute('type')).toBe('password');
+    expect(input.classList.contains('ant-input-text-security')).toBe(true);
 
     fireEvent.click(container.querySelector('.ant-input-password-icon') as HTMLElement);
-    expect(input.getAttribute('type')).toBe('text');
+    expect(input.classList.contains('ant-input-text-security')).toBe(false);
 
     fireEvent.click(container.querySelector('.ant-input-password-icon') as HTMLElement);
-    expect(input.getAttribute('type')).toBe('password');
+    expect(input.classList.contains('ant-input-text-security')).toBe(true);
   });
 
   it('keeps third-party password manager ignore attrs for new-password', () => {

--- a/packages/design/src/input/index.en-US.md
+++ b/packages/design/src/input/index.en-US.md
@@ -27,4 +27,4 @@ demo:
 
 ### Input.Password extensions
 
-Matches antd via `Input.Password` with native `type="password"` for browser autofill. When `autoComplete="new-password"`, password-manager `data-*` hints are attached to reduce misdetection by third-party password managers.
+Matches antd via `Input.Password` with native `type="password"` for browser autofill. When `autoComplete="new-password"`, the input is text masked with text-security to suppress the saved-password dropdown, with password-manager `data-*` hints.

--- a/packages/design/src/input/index.md
+++ b/packages/design/src/input/index.md
@@ -27,4 +27,4 @@ demo:
 
 ### Input.Password 扩展
 
-默认与 antd 一致，委托 `Input.Password` 实现，`type="password"` 支持浏览器密码自动填充。`autoComplete="new-password"` 时额外附加密码管理器 `data-*` hint，避免第三方密码管理器误识别。
+默认与 antd 一致，委托 `Input.Password` 实现，`type="password"`，支持浏览器密码自动填充。`autoComplete="new-password"` 时以 text 型输入 + text-security 遮蔽，避免浏览器弹出已保存密码下拉，并附加密码管理器 `data-*` hint。

--- a/packages/design/src/input/style/index.ts
+++ b/packages/design/src/input/style/index.ts
@@ -20,6 +20,10 @@ export const genInputStyle: GenerateStyle<InputToken> = (token: InputToken): CSS
         },
       },
     },
+    // new-password: text input + text-security mask to avoid browser saved-password dropdown
+    [`${componentCls}-text-security`]: {
+      WebkitTextSecurity: 'disc',
+    },
   };
 };
 

--- a/packages/ui/src/Password/__tests__/rememberHint.test.tsx
+++ b/packages/ui/src/Password/__tests__/rememberHint.test.tsx
@@ -21,7 +21,8 @@ describe('Password remember hint in Form.Item', () => {
 
     const passwordInput = container.querySelector('.ant-input-password input') as HTMLInputElement;
     expect(passwordInput).toBeTruthy();
-    expect(passwordInput.getAttribute('type')).toBe('password');
+    expect(passwordInput.getAttribute('type')).toBe('text');
+    expect(passwordInput.classList.contains('ant-input-text-security')).toBe(true);
 
     await user.type(passwordInput, VALID_PASSWORD);
     await user.tab();


### PR DESCRIPTION
### 📦 Modified package

- [x] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

After #1561 delegated all `Input.Password` to `AntInput.Password`, login autofill was restored, but `autoComplete="new-password"` fields regressed: browsers again show the saved-password dropdown on focus.

**Solution:** Route `autoComplete="new-password"` to a `NewPassword` subcomponent that still renders `AntInput.Password` (visibility toggle, suffix, locale) but patches the native input after layout: `type="text"` plus `-text-security` when hidden. Non-`new-password` paths remain fully delegated to `AntInput.Password` for autofill.

**Regression note:** `NewPassword` relies on `useLayoutEffect` to override antd's `type` after mount; re-test when upgrading antd.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Input.Password<br/>&nbsp;&nbsp;- 🐞 Suppresses browser saved-password dropdown when `autoComplete="new-password"`, while login and other non-`new-password` fields keep browser password autofill. |
| 🇨🇳 Chinese | - Input.Password<br/>&nbsp;&nbsp;- 🐞 修复 `autoComplete="new-password"` 时浏览器弹出已保存密码下拉的问题，同时保持登录等场景密码自动填充。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
