### PR TITLE
fix(ui): defer custom Password rule checks until touched with a value

### DIFF
--- a/packages/ui/src/Password/Content.tsx
+++ b/packages/ui/src/Password/Content.tsx
@@ -148,16 +148,24 @@ function analyzeWithValidators(
   validators: Validator[],
   touched: boolean
 ): Pick<CloudPasswordAnalysis, 'failedRuleCount' | 'ruleStatuses' | 'fieldErrors'> {
+  // Until the field is touched with a value, rules are not evaluated: validators
+  // from consumers may not guard against undefined (e.g. calling .match directly).
+  if (!touched || !value) {
+    return {
+      failedRuleCount: 0,
+      ruleStatuses: validators.map(() => 'wait'),
+      fieldErrors: [],
+    };
+  }
+
   const fieldFailures = validators
     .filter(rule => !rule.optional)
     .map(rule => (rule.validate(value) ? undefined : rule.message))
     .filter((message): message is string => Boolean(message));
 
-  const ruleStatuses: PasswordRuleStatus[] = validators.map(rule => {
-    if (!touched || !value) return 'wait';
-    if (rule.validate(value)) return 'pass';
-    return rule.optional ? 'wait' : 'fail';
-  });
+  const ruleStatuses: PasswordRuleStatus[] = validators.map(rule =>
+    rule.validate(value) ? 'pass' : rule.optional ? 'wait' : 'fail'
+  );
 
   return {
     failedRuleCount: fieldFailures.length,

--- a/packages/ui/src/Password/__tests__/customRules.test.tsx
+++ b/packages/ui/src/Password/__tests__/customRules.test.tsx
@@ -13,7 +13,30 @@ const customRules = [
   },
 ];
 
+const unsafeMatchRules = [
+  {
+    validate: (val?: string) => {
+      // Mirrors consumer validators that call .match without a null guard.
+      const uppercaseMatch = (val as string).match(/[A-Z]/g) || [];
+      return uppercaseMatch.length >= 1;
+    },
+    message: 'Contains uppercase letter',
+  },
+];
+
 describe('Password custom rules', () => {
+  it('mounts safely when custom validate uses match on an undefined value', () => {
+    expect(() =>
+      render(
+        <Form>
+          <Form.Item name="password" label="Password">
+            <Password rules={unsafeMatchRules} />
+          </Form.Item>
+        </Form>
+      )
+    ).not.toThrow();
+  });
+
   it('validates against custom rules instead of the built-in cloud rules', async () => {
     const user = userEvent.setup();
 
@@ -32,7 +55,11 @@ describe('Password custom rules', () => {
     await user.tab();
 
     await waitFor(() => {
-      expect(screen.getByText(CUSTOM_RULE_MESSAGE, { exact: false })).toBeTruthy();
+      // Blur feedback surfaces through the Form.Item explain area; scope the query
+      // there instead of the whole document, where the popover rules list may
+      // briefly carry the same text while its close animation settles.
+      const explainError = container.querySelector('.ant-form-item-explain-error');
+      expect(explainError?.textContent).toContain(CUSTOM_RULE_MESSAGE);
     });
   });
 });

--- a/packages/ui/src/Password/__tests__/passwordRules.test.ts
+++ b/packages/ui/src/Password/__tests__/passwordRules.test.ts
@@ -162,6 +162,36 @@ describe('custom rules', () => {
     expect(analysis.ruleStatuses).toEqual(['pass', 'pass', 'wait']);
   });
 
+  it('does not invoke custom validate before touch or when value is undefined', () => {
+    const unsafeRules: Validator[] = [
+      {
+        validate: (val?: string) => {
+          // Mirrors consumer validators that call .match without a null guard.
+          const uppercaseMatch = (val as string).match(/[A-Z]/g) || [];
+          return uppercaseMatch.length >= 1;
+        },
+        message: 'Contains uppercase letter',
+      },
+    ];
+
+    expect(() =>
+      analyzeCustomPassword(undefined, unsafeRules, locale, { touched: false })
+    ).not.toThrow();
+    const untouched = analyzeCustomPassword(undefined, unsafeRules, locale, { touched: false });
+    expect(untouched.failedRuleCount).toBe(0);
+    expect(untouched.ruleStatuses).toEqual(['wait']);
+    expect(untouched.fieldError).toBeUndefined();
+
+    // Blur-empty path: touched but no value must also skip validate calls.
+    expect(() =>
+      analyzeCustomPassword(undefined, unsafeRules, locale, { touched: true })
+    ).not.toThrow();
+    const blurred = analyzeCustomPassword(undefined, unsafeRules, locale, { touched: true });
+    expect(blurred.failedRuleCount).toBe(0);
+    expect(blurred.ruleStatuses).toEqual(['wait']);
+    expect(blurred.fieldError).toBe(locale.emptyMessage);
+  });
+
   it('reports the required rule message even when an optional rule also fails', () => {
     const rulesWithOptional: Validator[] = [
       {


### PR DESCRIPTION
### 📦 Modified package

- [ ] @oceanbase/design
- [x] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [ ] Other (about what?)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

`Password` with consumer-provided `rules` invokes each validator's `validate` before the field has been touched or has a value. Validators from consumers may not guard against `undefined` (e.g. calling `value.match(...)` directly), which throws and crashes the page on mount or on blur of an empty field.

Fix: short-circuit rule evaluation in `analyzeWithValidators` — until the field is touched **with a value**, all rules stay in `wait` state and no validator is invoked, so untrusted consumer validators can no longer receive `undefined`.

Behavior contract kept intact:

- Untouched or empty input → no validator calls, rules shown as `wait`, no field error.
- Blur with empty value (`touched: true`, no value) → rules stay `wait`, required/empty message still surfaces through the existing `emptyMessage` path.
- Touched with a value → validators run exactly as before (optional rules that fail still stay `wait`).

Also scoped a flaky assertion in `customRules.test.tsx` to the Form.Item explain area (the popover rules list can transiently carry the same text during its close animation), and added unit + render tests covering the undefined-safe behavior.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - 🐞 Fixed `Password` crashing when a custom `rules` validator does not guard against empty/undefined values — rules are no longer evaluated until the field is touched and has a value. |
| 🇨🇳 Chinese | - 🐞 修复自定义 `rules` 校验器未对空值做保护时 `Password` 报错的问题——字段被输入后才开始执行规则校验。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
