### PR TITLE
feat(site): add 0.x entry to header More dropdown

### DIFF
--- a/.dumi/theme/slots/Header/More.tsx
+++ b/.dumi/theme/slots/Header/More.tsx
@@ -22,6 +22,14 @@ const useStyle = (rtl?: boolean) => ({
 export const getEcosystemGroup = (): MenuProps['items'] => [
   {
     label: (
+      <a href="https://oceanbase-design-v0.vercel.app/" target="_blank" rel="noopener noreferrer">
+        0.x
+      </a>
+    ),
+    key: '0.x',
+  },
+  {
+    label: (
       <a href="http://ant.design" target="_blank" rel="noopener noreferrer">
         Ant Design
       </a>


### PR DESCRIPTION
### 📦 Modified package

- [ ] @oceanbase/design
- [ ] @oceanbase/ui
- [ ] @oceanbase/icons
- [ ] @oceanbase/charts
- [ ] @oceanbase/util
- [ ] @oceanbase/codemod
- [x] Other (docs site theme `.dumi`)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

The header "More" dropdown currently only links ecosystem projects. Users still on OceanBase Design 0.x can't find the legacy docs, so this PR adds a **0.x** entry at the top of the dropdown pointing to the archived v0 docs site:

- https://oceanbase-design-v0.vercel.app/

| Before | After |
| :--- | :--- |
| More ▾ : Ant Design / Pro Components / Charts | More ▾ : **0.x** / Ant Design / Pro Components / Charts |

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - 📖 Added a `0.x` entry to the header More menu linking to the archived 0.x docs site. |
| 🇨🇳 Chinese | - 📖 顶部导航「更多」菜单新增 `0.x` 入口，指向 0.x 旧版文档站点。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests is updated/provided or not needed
- [x] Changelog is provided or not needed
