### PR TITLE
chore(docs): Add changelog for @oceanbase/design@1.4.4 and @oceanbase/ui@1.4.4

### DIFF
--- a/docs/design/design-CHANGELOG.md
+++ b/docs/design/design-CHANGELOG.md
@@ -8,6 +8,13 @@ group: General
 
 ---
 
+## 1.4.4
+
+`2026-09-04`
+
+- Input.Password
+  - 🐞 Fixed `autoComplete="new-password"` fields (e.g. create / change password) offering the browser's saved-password dropdown; such inputs are now masked in place via `text-security` instead. [#1564](https://github.com/oceanbase/oceanbase-design/pull/1564)
+
 ## 1.4.3
 
 `2026-09-02`

--- a/docs/design/design-CHANGELOG.zh-CN.md
+++ b/docs/design/design-CHANGELOG.zh-CN.md
@@ -8,6 +8,13 @@ group: 基础组件
 
 ---
 
+## 1.4.4
+
+`2026-09-04`
+
+- Input.Password
+  - 🐞 修复 `autoComplete="new-password"`（如设置/修改密码）的密码框会弹出浏览器"已保存密码"下拉的问题，此类输入框改为通过 `text-security` 遮蔽输入内容。[#1564](https://github.com/oceanbase/oceanbase-design/pull/1564)
+
 ## 1.4.3
 
 `2026-09-02`

--- a/docs/ui/ui-CHANGELOG.md
+++ b/docs/ui/ui-CHANGELOG.md
@@ -8,6 +8,15 @@ group: Biz Components
 
 ---
 
+## 1.4.4
+
+`2026-09-04`
+
+- DateRanger
+  - 🌐 Quick options, custom-range descriptions (e.g. "Nearly 30 days") and the "History records" title now follow the active locale, with Japanese (ja-JP) support added. [#1566](https://github.com/oceanbase/oceanbase-design/pull/1566)
+- Password
+  - 🐞 Custom `rules` are now evaluated only after the field is touched with a value, avoiding premature strength/error feedback on empty fields. [#1565](https://github.com/oceanbase/oceanbase-design/pull/1565)
+
 ## 1.4.0
 
 `2026-08-25`

--- a/docs/ui/ui-CHANGELOG.zh-CN.md
+++ b/docs/ui/ui-CHANGELOG.zh-CN.md
@@ -8,6 +8,15 @@ group: 业务组件
 
 ---
 
+## 1.4.4
+
+`2026-09-04`
+
+- DateRanger
+  - 🌐 快捷选项、自定义时间范围描述（如“近 30 天”）及“历史记录”标题支持跟随当前语言，并新增日语 (ja-JP) 支持。[#1566](https://github.com/oceanbase/oceanbase-design/pull/1566)
+- Password
+  - 🐞 自定义 `rules` 仅在字段被触碰且输入内容后才执行校验，避免空值时提前触发强度/错误提示。[#1565](https://github.com/oceanbase/oceanbase-design/pull/1565)
+
 ## 1.4.0
 
 `2026-08-25`


### PR DESCRIPTION
## @oceanbase/design@1.4.4

`2026-09-04`

- Input.Password
  - 🐞 Fixed `autoComplete="new-password"` fields (e.g. create / change password) offering the browser's saved-password dropdown; such inputs are now masked in place via `text-security` instead. [#1564](https://github.com/oceanbase/oceanbase-design/pull/1564)

## @oceanbase/ui@1.4.4

`2026-09-04`

- DateRanger
  - 🌐 Quick options, custom-range descriptions (e.g. "Nearly 30 days") and the "History records" title now follow the active locale, with Japanese (ja-JP) support added. [#1566](https://github.com/oceanbase/oceanbase-design/pull/1566)
- Password
  - 🐞 Custom `rules` are now evaluated only after the field is touched with a value, avoiding premature strength/error feedback on empty fields. [#1565](https://github.com/oceanbase/oceanbase-design/pull/1565)
